### PR TITLE
Fixed sometimes showing up wrong name for player controlled vessel in…

### DIFF
--- a/Client/Windows/Status/StatusTexts.cs
+++ b/Client/Windows/Status/StatusTexts.cs
@@ -29,7 +29,7 @@ namespace LunaClient.Windows.Status
         private static string _lastPlayerText = string.Empty;
         public static string GetPlayerText(PlayerStatus playerStatus)
         {
-            if (!_lastPlayerText.Contains(playerStatus.VesselText))
+            if (_lastPlayerText != playerStatus.VesselText)
                 _lastPlayerText = $"Pilot: {playerStatus.VesselText}";
 
             return _lastPlayerText;


### PR DESCRIPTION
… LMP window

For Example: Let your vessels name be "Aeris".
If you crash that plane after reverting,
when focused a debris of it,
after that crash the name of your new vessel will be
"Aeris Debris".