### PR TITLE
Added exception handling during init

### DIFF
--- a/Client/ModuleStore/FieldModuleStore.cs
+++ b/Client/ModuleStore/FieldModuleStore.cs
@@ -57,18 +57,25 @@ namespace LunaClient.ModuleStore
         {
             foreach (var assembly in AppDomain.CurrentDomain.GetAssemblies())
             {
-                var partModules = assembly.GetTypes().Where(myType => myType.IsClass && myType.IsSubclassOf(typeof(PartModule)));
-                foreach (var partModule in partModules)
+                try
                 {
-                    var persistentFields = partModule.GetFields(BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.DeclaredOnly)
-                        .Where(f => f.GetCustomAttributes(typeof(KSPField), true).Any(attr => ((KSPField)attr).isPersistant)).ToArray();
-                    
-                    if (persistentFields.Any())
+                    var partModules = assembly.GetTypes().Where(myType => myType.IsClass && myType.IsSubclassOf(typeof(PartModule)));
+                    foreach (var partModule in partModules)
                     {
-                        ModuleFieldsDictionary.Add(partModule.Name, new FieldModuleDefinition(partModule, persistentFields));
-                    }
+                        var persistentFields = partModule.GetFields(BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.DeclaredOnly)
+                            .Where(f => f.GetCustomAttributes(typeof(KSPField), true).Any(attr => ((KSPField)attr).isPersistant)).ToArray();
 
-                    InheritanceTypeChain.Add(partModule.Name, GetInheritChain(partModule));
+                        if (persistentFields.Any())
+                        {
+                            ModuleFieldsDictionary.Add(partModule.Name, new FieldModuleDefinition(partModule, persistentFields));
+                        }
+
+                        InheritanceTypeChain.Add(partModule.Name, GetInheritChain(partModule));
+                    }
+                }
+                catch (Exception ex)
+                {
+                    LunaLog.LogError(string.Format("Exception loading types from assembly {0}: {1}", assembly.FullName, ex.Message));
                 }
             }
 

--- a/Client/Systems/SystemsHandler.cs
+++ b/Client/Systems/SystemsHandler.cs
@@ -25,11 +25,18 @@ namespace LunaClient.Systems
             var systemsList = new List<ISystem>();
             foreach (var assembly in AppDomain.CurrentDomain.GetAssemblies())
             {
-                var systems = assembly.GetTypes().Where(t => t.IsClass && typeof(ISystem).IsAssignableFrom(t) && !t.IsAbstract).ToArray();
-                foreach (var sys in systems)
+                try
                 {
-                    if (sys.GetProperty("Singleton", BindingFlags.Public | BindingFlags.Static | BindingFlags.FlattenHierarchy)?.GetValue(null, null) is ISystem systemImplementation)
-                        systemsList.Add(systemImplementation);
+                    var systems = assembly.GetTypes().Where(t => t.IsClass && typeof(ISystem).IsAssignableFrom(t) && !t.IsAbstract).ToArray();
+                    foreach (var sys in systems)
+                    {
+                        if (sys.GetProperty("Singleton", BindingFlags.Public | BindingFlags.Static | BindingFlags.FlattenHierarchy)?.GetValue(null, null) is ISystem systemImplementation)
+                            systemsList.Add(systemImplementation);
+                    }
+                }
+                catch (Exception ex)
+                {
+                    LunaLog.LogError(string.Format("Exception loading types from assembly {0}: {1}", assembly.FullName, ex.Message));
                 }
             }
 

--- a/Client/Windows/WindowsHandler.cs
+++ b/Client/Windows/WindowsHandler.cs
@@ -22,11 +22,18 @@ namespace LunaClient.Windows
             var windowsList = new List<IWindow>();
             foreach (var assembly in AppDomain.CurrentDomain.GetAssemblies())
             {
-                var systems = assembly.GetTypes().Where(t => t.IsClass && typeof(IWindow).IsAssignableFrom(t) && !t.IsAbstract).ToArray();
-                foreach (var sys in systems)
+                try
                 {
-                    if (sys.GetProperty("Singleton", BindingFlags.Public | BindingFlags.Static | BindingFlags.FlattenHierarchy)?.GetValue(null, null) is IWindow windowImplementation)
-                        windowsList.Add(windowImplementation);
+                    var systems = assembly.GetTypes().Where(t => t.IsClass && typeof(IWindow).IsAssignableFrom(t) && !t.IsAbstract).ToArray();
+                    foreach (var sys in systems)
+                    {
+                        if (sys.GetProperty("Singleton", BindingFlags.Public | BindingFlags.Static | BindingFlags.FlattenHierarchy)?.GetValue(null, null) is IWindow windowImplementation)
+                            windowsList.Add(windowImplementation);
+                    }
+                }
+                catch (Exception ex)
+                {
+                    LunaLog.LogError(string.Format("Exception loading types from assembly {0}: {1}", assembly.FullName, ex.Message));
                 }
             }
 


### PR DESCRIPTION
This addresses an issue I ran into where LMP failed to init because another assembly loaded into the AppDomain (PlanetShine) threw an exception when assembly.GetTypes() was called.  These changes will log the exception and continue scanning (in my case ignoring the irrelevant exception).
