### PR TITLE
Added/removed KerbCat Dedicated Servers

### DIFF
--- a/MasterServersList/DedicatedServersList.txt
+++ b/MasterServersList/DedicatedServersList.txt
@@ -17,8 +17,9 @@ nonameships.pw:8800
 176.31.101.45:8800
 176.31.101.45:8801
 #KerbCat
-47.104.88.9:8800
-66.70.181.218:8800
+chengdu.211.network:8800
+beijing.211.network:8800
+qingdao.211.network:8800
 #SLUGSoc.co.uk
 143.167.132.10:27028
 #Tayaut Engineering


### PR DESCRIPTION
##### Thank you for contributing to LMP!

### Fixes included in this PR:

### Changes proposed in this PR:
KerbCat 211Server domain changed from 211server.net to 211.network.
Removed 211Server IP addresses.