### PR TITLE
Fix of #302 issue (Sync after renaming vessels in Tracking Station)

### DIFF
--- a/LmpClient/Systems/KscScene/KscSceneEvents.cs
+++ b/LmpClient/Systems/KscScene/KscSceneEvents.cs
@@ -1,6 +1,7 @@
 ﻿using Harmony;
 using KSP.UI.Screens;
 using LmpClient.Base;
+using LmpClient.Systems.VesselUpdateSys;
 using LmpCommon.Locks;
 using System.Reflection;
 using UnityEngine;
@@ -50,6 +51,20 @@ namespace LmpClient.Systems.KscScene
         {
             System.RefreshTrackingStationVessels();
             RefreshMarkers();
+        }
+
+        public void OnVesselRename(GameEvents.HostedFromToAction<Vessel, string> pair)
+        {
+            /**
+             * Use this only in GameScenes.TRACKSTATION, because in FLIGHT working VesselUpdateSystem
+             */
+            if (HighLogic.LoadedScene == GameScenes.TRACKSTATION)
+            {
+                pair.host.name = pair.to;
+
+                var vesselUpdateMessageSender = new VesselUpdateMessageSender();
+                vesselUpdateMessageSender.SendVesselUpdate(pair.host);
+            }
         }
 
         public void VesselInitialized(Vessel vessel, bool fromShipAssembly)

--- a/LmpClient/Systems/KscScene/KscSceneSystem.cs
+++ b/LmpClient/Systems/KscScene/KscSceneSystem.cs
@@ -28,6 +28,7 @@ namespace LmpClient.Systems.KscScene
             GameEvents.onLevelWasLoadedGUIReady.Add(KscSceneEvents.LevelLoaded);
             GameEvents.onVesselCreate.Add(KscSceneEvents.OnVesselCreated);
             VesselInitializeEvent.onVesselInitialized.Add(KscSceneEvents.VesselInitialized);
+            GameEvents.onVesselRename.Add(KscSceneEvents.OnVesselRename);
 
             SetupRoutine(new RoutineDefinition(0, RoutineExecution.FixedUpdate, IncreaseTimeWhileInEditor));
         }
@@ -40,6 +41,7 @@ namespace LmpClient.Systems.KscScene
             GameEvents.onLevelWasLoadedGUIReady.Remove(KscSceneEvents.LevelLoaded);
             GameEvents.onVesselCreate.Remove(KscSceneEvents.OnVesselCreated);
             VesselInitializeEvent.onVesselInitialized.Remove(KscSceneEvents.VesselInitialized);
+            GameEvents.onVesselRename.Remove(KscSceneEvents.OnVesselRename);
         }
 
         #endregion


### PR DESCRIPTION
##### Thank you for contributing to LMP!

### Fixes included in this PR:
Like name of topic, you can renaming vessels now in Tracking Station and it will be sync (When other player controls vessel, you can't rename that one)

### Changes proposed in this PR:
