### PR TITLE
Add KSP-AVC version file for CKAN

### DIFF
--- a/LunaMultiplayer.version
+++ b/LunaMultiplayer.version
@@ -1,0 +1,18 @@
+{
+    "NAME":     "Luna Multiplayer",
+    "URL":      "https://github.com/LunaMultiplayer/LunaMultiplayer/raw/master/LunaMultiplayer.version",
+    "DOWNLOAD": "https://github.com/LunaMultiplayer/LunaMultiplayer/releases",
+    "GITHUB": {
+        "USERNAME":   "LunaMultiplayer",
+        "REPOSITORY": "LunaMultiplayer"
+    },
+    "VERSION": {
+        "MAJOR": 0,
+        "MINOR": 25,
+        "PATCH": 0
+    },
+    "KSP_VERSION": {
+        "MAJOR": 1,
+        "MINOR": 9
+    }
+}

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -59,6 +59,7 @@ after_build:
  - ps: mkdir "$env:appveyor_build_folder\FinalFiles\$env:configuration\LMPClient\GameData\LunaMultiplayer\Icons"
  - ps: mkdir "$env:appveyor_build_folder\FinalFiles\$env:configuration\LMPClient\GameData\LunaMultiplayer\Flags"
  - ps: copy "$env:appveyor_build_folder\LMP Readme.txt" "$env:appveyor_build_folder\FinalFiles\$env:configuration\LMP Readme.txt"
+ - ps: copy "$env:appveyor_build_folder\LunaMultiplayer.version" "$env:appveyor_build_folder\FinalFiles\$env:configuration\LMPClient\GameData\LunaMultiplayer\LunaMultiplayer.version"
  - ps: xcopy /y "$env:appveyor_build_folder\LmpClient\Resources\*.*" "$env:appveyor_build_folder\FinalFiles\$env:configuration\LMPClient\GameData\LunaMultiplayer\Button"
  - ps: xcopy /y "$env:appveyor_build_folder\LmpClient\bin\$env:configuration\*.*" "$env:appveyor_build_folder\FinalFiles\$env:configuration\LMPClient\GameData\LunaMultiplayer\Plugins"
  - ps: xcopy /y /s "$env:appveyor_build_folder\LmpClient\Localization\XML\*.*" "$env:appveyor_build_folder\FinalFiles\$env:configuration\LMPClient\GameData\LunaMultiplayer\Localization"


### PR DESCRIPTION
### Changes proposed in this PR:
This PR adds a version file according to the KSP-AVC schema:
https://github.com/linuxgurugamer/KSPAddonVersionChecker/blob/master/KSP-AVC.schema.json

It allows users to track available updates and KSP version compatibility of LMP if they have the _Addon Version Checker_ mod installed.

It also allows this mod to be added to the [CKAN](https://github.com/KSP-CKAN/CKAN), with the NetKAN bot being able to parse the KSP compatibility data from this file.


The file should be included in the client folder of future releases. The AppVeyor script has been adjusted accordingly, I hope I got everything right there, if not, please let me know.
It also needs to be updated for new releases. That means, the `VERSION` and `KSP_VERSION` parts need to be updated _before_ a new release is made.
(I think you are already familiar with the process from Tilt 'Em)

To finish the indexing, a new release should be made which includes the version file.
Then https://github.com/KSP-CKAN/NetKAN/pull/7880 can be merged, and users will be able to install LMP via CKAN.