### PR TITLE
Add Per-Player Kerbals

### DIFF
--- a/Server/Context/ServerContext.cs
+++ b/Server/Context/ServerContext.cs
@@ -28,6 +28,7 @@ namespace Server.Context
         public static string ModFilePath = Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "LMPModControl.xml");
         public static string UniverseDirectory = Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "Universe");
         public static string ConfigDirectory = Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "Config");
+        public static string PlayerDataPath = Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "Universe", "PlayerData");
 
         // Configuration object
         public static NetPeerConfiguration Config { get; } = new NetPeerConfiguration("LMP")

--- a/Server/Context/Universe.cs
+++ b/Server/Context/Universe.cs
@@ -35,6 +35,9 @@ namespace Server.Context
             if (!FileHandler.FolderExists(ServerContext.UniverseDirectory))
                 FileHandler.FolderCreate(ServerContext.UniverseDirectory);
 
+            if (!FileHandler.FolderExists(ServerContext.PlayerDataPath))
+                FileHandler.FolderCreate(ServerContext.PlayerDataPath);
+
             if (!FileHandler.FolderExists(CraftLibrarySystem.CraftPath))
                 FileHandler.FolderCreate(CraftLibrarySystem.CraftPath);
             if (!FileHandler.FolderExists(FlagSystem.FlagPath))

--- a/Server/Settings/Definition/GameplaySettingsDefinition.cs
+++ b/Server/Settings/Definition/GameplaySettingsDefinition.cs
@@ -32,6 +32,9 @@ namespace Server.Settings.Definition
         [XmlComment(Value = "Allow Other launchsites")]
         public bool AllowOtherLaunchSites { get; set; }
 
+        [XmlComment(Value = "Allow per Player Kerbals")]
+        public bool AllowPerPlayerKerbals { get; set; }
+
         //Game systems
 
         [XmlComment(Value = "Re-Entry Heating")]

--- a/Server/System/LockSystem.cs
+++ b/Server/System/LockSystem.cs
@@ -1,6 +1,7 @@
 ﻿using LmpCommon.Locks;
 using Server.Client;
 using System.Linq;
+using Server.Settings.Structures;
 
 namespace Server.System
 {
@@ -13,8 +14,14 @@ namespace Server.System
         {
             repeatedAcquire = false;
 
+            // Change name to allow per-player kerbals Changing the kerbal name to KerbalName+PlayerName will result in
+            // per-player kerbal locks, while other players will still have control over their own kerbals.
+            var kerbalName = lockDef.KerbalName;
+            if (lockDef.Type == LockType.Kerbal && GameplaySettings.SettingsStore.AllowPerPlayerKerbals)
+                kerbalName = lockDef.KerbalName + lockDef.PlayerName;
+
             //Player tried to acquire a lock that he already owns
-            if (LockQuery.LockBelongsToPlayer(lockDef.Type, lockDef.VesselId, lockDef.KerbalName, lockDef.PlayerName))
+            if (LockQuery.LockBelongsToPlayer(lockDef.Type, lockDef.VesselId, kerbalName, lockDef.PlayerName))
             {
                 repeatedAcquire = true;
                 return true;
@@ -39,7 +46,11 @@ namespace Server.System
 
         public static bool ReleaseLock(LockDefinition lockDef)
         {
-            if (LockQuery.LockBelongsToPlayer(lockDef.Type, lockDef.VesselId, lockDef.KerbalName, lockDef.PlayerName))
+            var kerbalName = lockDef.KerbalName;
+            if (lockDef.Type == LockType.Kerbal && GameplaySettings.SettingsStore.AllowPerPlayerKerbals)
+                kerbalName = lockDef.KerbalName + lockDef.PlayerName;
+
+            if (LockQuery.LockBelongsToPlayer(lockDef.Type, lockDef.VesselId, kerbalName, lockDef.PlayerName))
             {
                 LockStore.RemoveLock(lockDef);
                 return true;


### PR DESCRIPTION
##### Thank you for contributing to LMP!

### Fixes included in this PR:
No fixes included.

### Changes proposed in this PR:
Allows Players to have their own Kerbals and thus, removes the need to wait for locks (if a Player want to use the same Kerbal). This may fix some issues with the syncing (e.g. #328 ).

This creates a directory using Player's UID (might be changed to just PlayerName), Universe/PlayerData/PLAYER_UID/
Where player's Kerbal data is stored. This could be extended to allow more per-player data, and probably will be required to implement groups/companies etc.