### PR TITLE
Killing contracts is not enough

### DIFF
--- a/LmpClient/Systems/ShareContracts/ShareContractsEvents.cs
+++ b/LmpClient/Systems/ShareContracts/ShareContractsEvents.cs
@@ -111,6 +111,7 @@ namespace LmpClient.Systems.ShareContracts
             if (contract.GetType() == typeof(RecoverAsset))
             {
                 //We don't support rescue contracts. See: https://github.com/LunaMultiplayer/LunaMultiplayer/issues/226#issuecomment-431831526
+                contract.Withdraw();
                 contract.Kill();
                 return;
             }


### PR DESCRIPTION
I have encountered countless rescue missions even they should be disabled, so I did some digging.
It seems calling `Kill()` on a contract does not force the game to instantly remove it (documentation uses the word [prepares](https://kerbalspaceprogram.com/api/class_contracts_1_1_contract.html#a423e9e110fc485183a48865a926c7665
)) `Withdraw()` seems to correctly prevent the contracts from appearing.

Withdrawing contracts in the `!LockSystem.LockQuery.ContractLockBelongsToPlayer(SettingsSystem.CurrentSettings.PlayerName)` block makes available contracts invisible for all other players except the one holding the contract lock. Although this seems to be the intention of the code, it would be a regression, as all players can currently see and accept the same available contracts. What should be done about this?