### PR TITLE
Add MemBytesUsed property to CurrentState

### DIFF
--- a/Server/Web/Structures/CurrentState.cs
+++ b/Server/Web/Structures/CurrentState.cs
@@ -12,6 +12,7 @@ namespace Server.Web.Structures
         public List<string> CurrentPlayers { get; } = new List<string>();
         public List<VesselInfo> CurrentVessels { get; } = new List<VesselInfo>();
         public List<Subspace> Subspaces { get; } = new List<Subspace>();
+        public int MemBytesUsed { get; }
 
         public void Refresh()
         {
@@ -22,6 +23,9 @@ namespace Server.Web.Structures
             CurrentPlayers.AddRange(ServerContext.Clients.Values.Select(v => v.PlayerName));
             CurrentVessels.AddRange(VesselStoreSystem.CurrentVessels.Values.Select(v => new VesselInfo(v)));
             Subspaces.AddRange(WarpContext.Subspaces.Values);
+            BytesUsed = Environment.WorkingSet;
         }
+        
+        
     }
 }


### PR DESCRIPTION
**Fixes included in this PR**: None

**Changes proposed in this PR**:
1. Add `MemBytesUsed` to `CurrentState` class.
    - That property contains the number of bytes allocated/used (I'm not really sure because the [docs](https://docs.microsoft.com/en-us/dotnet/api/system.environment.workingset?view=net-5.0#System_Environment_WorkingSet) are worded weird)