### PR TITLE
Docker Changes - Local Image Name & Use Official Image

### DIFF
--- a/Dockerfile_Server
+++ b/Dockerfile_Server
@@ -11,15 +11,10 @@
 #Start a container with: docker start lmpsrv
 #Remove a container with: docker container rm lmpsrv
 
-FROM alpine:edge as builder
-
-RUN apk add icu-libs krb5-libs libgcc libintl libssl1.1 libstdc++ zlib wget bash && \
-    wget https://dot.net/v1/dotnet-install.sh && \
-    chmod +x ./dotnet-install.sh && ./dotnet-install.sh -c 5.0
+FROM mcr.microsoft.com/dotnet/sdk:5.0-alpine as builder
 
 COPY . /LunaMultiplayer
 RUN cd LunaMultiplayer/Server && \
-    export PATH=$PATH:/root/.dotnet && \
     dotnet publish -r linux-musl-x64 -o Publish
 
 FROM alpine:edge

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,6 +6,7 @@
 version: '3.3'
 services:
     lunamultiplayer:
+        image: lunamultiplayer:local
         build:
           context: ./
           dockerfile: Dockerfile_Server


### PR DESCRIPTION
### Fixes included in this PR:

#### - Update Docker Image (`mcr.microsoft.com/dotnet/sdk:5.0-alpine`)

I had an issue building the included docker image:  
![image](https://user-images.githubusercontent.com/293107/124451687-39e59400-ddb8-11eb-8b59-55206b157e6a.png)

I have fixed this by using the official [Microsoft Container Registry ](https://hub.docker.com/_/microsoft-dotnet-sdk) .NEW SDK Alpine Image

> Note: I also removed some of the lines that I don't think were required, or at least, the server seems to work without. Let me know if I removed something that's required!

### Changes proposed in this PR:

#### - Add `image` tag to the Docker-Compose File

Set to `lunamultiplayer:local` so people can find and delete the correct images

From the [Docker-Compose Refernce](https://docs.docker.com/compose/compose-file/compose-file-v3/#build):  
> If you specify `image` as well as `build`, then Compose names the built image with the `webapp` and optional `tag` specified in image
