### PR TITLE
Add initial IPv6 support to server and client

### DIFF
--- a/LmpClient/Network/NetworkMain.cs
+++ b/LmpClient/Network/NetworkMain.cs
@@ -6,6 +6,7 @@ using LmpCommon.Message;
 using LmpCommon.Message.Interface;
 using System;
 using System.Collections.Concurrent;
+using System.Net;
 using System.Threading;
 using System.Threading.Tasks;
 #if DEBUG
@@ -33,7 +34,9 @@ namespace LmpClient.Network
             PingInterval = (float)TimeSpan.FromMilliseconds(SettingsSystem.CurrentSettings.HearbeatMsInterval).TotalSeconds,
             ConnectionTimeout = SettingsSystem.CurrentSettings.TimeoutSeconds,
             MaximumTransmissionUnit = SettingsSystem.CurrentSettings.Mtu,
-            AutoExpandMTU = SettingsSystem.CurrentSettings.AutoExpandMtu
+            AutoExpandMTU = SettingsSystem.CurrentSettings.AutoExpandMtu,
+            LocalAddress = IPAddress.IPv6Any,
+            DualStack = true
         };
 
         public static NetClient ClientConnection { get; private set; }

--- a/Server/MainServer.cs
+++ b/Server/MainServer.cs
@@ -73,7 +73,7 @@ namespace Server
                 //Set day for log change
                 ServerContext.Day = LunaNetworkTime.Now.Day;
 
-                LunaLog.Normal($"Luna Server version: {LmpVersioning.CurrentVersion} ({Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location)})");
+                LunaLog.Normal($"Luna Server version: {LmpVersioning.CurrentVersion} ({AppContext.BaseDirectory})");
 
                 Universe.CheckUniverse();
                 LoadSettingsAndGroups();
@@ -84,7 +84,7 @@ namespace Server
                 WarpSystem.Reset();
                 TimeSystem.Reset();
 
-                LunaLog.Normal($"Starting '{GeneralSettings.SettingsStore.ServerName}' on Port {ConnectionSettings.SettingsStore.Port}... ");
+                LunaLog.Normal($"Starting '{GeneralSettings.SettingsStore.ServerName}' on Address {ConnectionSettings.SettingsStore.ListenAddress} Port {ConnectionSettings.SettingsStore.Port}... ");
 
                 LidgrenServer.SetupLidgrenServer();
                 LmpPortMapper.OpenLmpPort().Wait();

--- a/Server/Server/LidgrenServer.cs
+++ b/Server/Server/LidgrenServer.cs
@@ -9,6 +9,8 @@ using Server.Log;
 using Server.Settings.Structures;
 using Server.Utilities;
 using System;
+using System.Net;
+using System.Net.Sockets;
 using System.Threading.Tasks;
 
 namespace Server.Server
@@ -20,6 +22,17 @@ namespace Server.Server
 
         public static void SetupLidgrenServer()
         {
+            if (!IPAddress.TryParse(ConnectionSettings.SettingsStore.ListenAddress, out var listenAddress))
+            {
+                LunaLog.Warning("Could not parse ListenAddress, falling back to 0.0.0.0");
+                listenAddress = IPAddress.Any;
+            };
+            ServerContext.Config.LocalAddress = listenAddress;
+            // Listen on dual-stack for the unspecified address in IPv6 format ([::]).
+            if (ServerContext.Config.LocalAddress.Equals(IPAddress.IPv6Any))
+            {
+                ServerContext.Config.DualStack = true;
+            }
             ServerContext.Config.Port = ConnectionSettings.SettingsStore.Port;
             ServerContext.Config.AutoExpandMTU = ConnectionSettings.SettingsStore.AutoExpandMtu;
             ServerContext.Config.MaximumTransmissionUnit = ConnectionSettings.SettingsStore.MaximumTransmissionUnit;

--- a/Server/Settings/Definition/ConnectionSettingsDefinition.cs
+++ b/Server/Settings/Definition/ConnectionSettingsDefinition.cs
@@ -1,12 +1,16 @@
 ﻿using Lidgren.Network;
 using LmpCommon.Xml;
 using System;
+using System.Net;
 
 namespace Server.Settings.Definition
 {
     [Serializable]
     public class ConnectionSettingsDefinition
     {
+        [XmlComment(Value = "The address the server listens on. If set to the unspecified IPv6 address [::], the server listens for both IPv6 and IPv4")]
+        public string ListenAddress { get; set; } = IPAddress.Any.ToString();
+
         [XmlComment(Value = "The UDP port the server listens on. You don't need to open it on your router if RegisterWithMasterServer = true. " +
                             "If you want that players can connect against your server MANUALLY you will need to open it on your router")]
         public int Port { get; set; } = 8800;


### PR DESCRIPTION
### Motivation
IMHO IPv6 support is crucial for anything online multiplayer related, especially with a P2P system. Some benefits:
- You can run multiple servers at the same time on the well-known port, giving each its own IPv6 address (you have plenty available).
- Thanks to the lack of NAT, P2P connection setup with UDP firewall punchthrough is still possible even if one user is behind symmetric NAT on IPv4.
- Configuring allow-rules in a firewall is easier than configuring port-forwarding, at least theoretically speaking, depends on the specifics of router UI.
- The server address is the same for everyone who wants to connect – be it the user who hosts the server on the same PC, a friend on the LAN, or some random user from the internet. So everyone can use the server list, no need to manually enter `locahost`/`127.0.0.1` or a LAN IPv4 address. Works out of the box, no NAT reflection or similar needed.

### Changes proposed in this PR:
This PR adds the ability to listen on IPv6 addresses to the server, and the ability to connect to IPv6 addresses to the client.
It does so in the most undisruptive behavior possible:
- The server still listens on `IPAddress.Any` (`0.0.0.0`) by default. To make it listen on IPv6, one needs to change the new `ListenAddress` option in `ConnectionSettings.xml`, e.g. to `[::]` or `::`, which is the IPv6 equivalent of `0.0.0.0`.
- When you configure the `IPAddress.IPv6Any` (`[::]`) as `ListenAddress`, the `DualStack` option for the socket is enabled, which makes the socket effectively listen on `0.0.0.0` as well at the same time. This is supported by pretty much every major OS: Linux, FreeBSD and other BSDs, macOS, Windows. The `DualStack` option only works for the `IPAddress.IPv6Any` address though, that's why we only enable it for this one.
- If the configured `ListenAddress` can't be parsed, it falls back to `IPAddress.Any` (`0.0.0.0`).

- Similarly, the client is also configured to "listen" on `IPAddress.IPv6Any` (instead of the implicit default of `IPAddress.Any`), with the `DualStack` option turned on so it can also connect to IPv4 servers.

&nbsp;

This does not touch master servers at all yet, and everything should continue to work as is right now. This only allows you to connect to IPv6 servers via their address or hostname using the "direct connection" feature.

Before changing master servers to hand out IPv6 addresses of servers to clients, some more things need to be changed:
- The master server should know both the public IPv4 and public IPv6 address of the servers, so it can hand out both to clients. This means the master servers _definitely_ need to listen on IPv4, and servers _definitely_ need to connect to master servers via IPv4.
  For IPv6, we could either rely on the server knowing its own public address (the common case, NPTv6 is rare but exists, many-to-one IPv6 NAT is even rarer but exists too) and put it in the message along the IPv4 `InternalEndpoint`; or we make it connect via IPv6 as well, so the master server can get it from `netMsg.SenderEndPoint`. The second option needs quite a bunch of changes.
  One could start with the first option and make the server not send any IPv6 address if there are only ULAs and link-locals available (hoping nobody's behind many-to-ony IPv6 NAT with a GUA assigned), and implement the second one later-on.
- Clients should gain a fallback logic, so if a connection doesn't come up via the advertised IPv6 address of a server, it retries via IPv4. Maybe one could even do [Happy Eyeballs](https://en.wikipedia.org/wiki/Happy_Eyeballs), so the faster one wins.
  This doesn't seem very easy with Lidgren, from what I can see.

---

And one more unrelated change:
- Instead of `Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location)`, the server prints `AppContext.BaseDirectory` at start now. The first one is not guaranteed to be set, e.g. if you compile to a single file `-p:PublishSingleFile=true` where the DLL no longer exists. The second one seems to be the advertised alternative.

