### PR TITLE
Expand IPv6 support; Attempt IPv6 connections via server list

### DIFF
--- a/LmpClient/Localization/Structures/ServerListFiltersText.cs
+++ b/LmpClient/Localization/Structures/ServerListFiltersText.cs
@@ -4,7 +4,8 @@
     {
         public string Title { get; set; } = "Server list";
         public string NoServers { get; set; } = "No servers!";
-        public string Ping { get; set; } = "Ping";
+        public string Ping { get; set; } = "IPv4 Ping";
+        public string Ping6 { get; set; } = "IPv6 Ping";
         public string Players { get; set; } = "Players";
         public string MaxPlayers { get; set; } = "Max players";
         public string Mode { get; set; } = "Mode";

--- a/LmpClient/Network/NetworkReceiver.cs
+++ b/LmpClient/Network/NetworkReceiver.cs
@@ -60,10 +60,16 @@ namespace LmpClient.Network
         /// </summary>
         public static void ReceiveMain()
         {
+            LunaLog.Log("[LMP]: Receive thread started");
             try
             {
                 while (!NetworkConnection.ResetRequested)
                 {
+                    while (NetworkMain.ClientConnection.Status == NetPeerStatus.NotRunning)
+                    {
+                        Thread.Sleep(50);
+                    }
+
                     if (NetworkMain.ClientConnection.ReadMessage(out var msg))
                     {
                         switch (msg.MessageType)
@@ -73,6 +79,9 @@ namespace LmpClient.Network
                                 break;
                             case NetIncomingMessageType.VerboseDebugMessage:
                                 LunaLog.Log($"[Lidgren VERBOSE] {msg.ReadString()}");
+                                break;
+                            case NetIncomingMessageType.WarningMessage:
+                                LunaLog.Log($"[Lidgren WARNING] {msg.ReadString()}");
                                 break;
                             case NetIncomingMessageType.NatIntroductionSuccess:
                                 NetworkServerList.HandleNatIntroduction(msg);
@@ -120,9 +129,10 @@ namespace LmpClient.Network
             }
             catch (Exception e)
             {
-                LunaLog.LogError($"[LMP]: Receive message thread error: {e}");
+                LunaLog.LogError($"[LMP]: Receive thread error: {e}");
                 NetworkMain.HandleDisconnectException(e);
             }
+            LunaLog.Log("[LMP]: Receive thread exited");
         }
 
         /// <summary>

--- a/LmpClient/Network/NetworkServerList.cs
+++ b/LmpClient/Network/NetworkServerList.cs
@@ -6,7 +6,9 @@ using LmpCommon.Message.MasterServer;
 using LmpCommon.Time;
 using System;
 using System.Collections.Concurrent;
+using System.Collections.Generic;
 using System.Net;
+using System.Net.Sockets;
 
 namespace LmpClient.Network
 {
@@ -16,7 +18,7 @@ namespace LmpClient.Network
         public static ConcurrentDictionary<long, ServerInfo> Servers { get; } = new ConcurrentDictionary<long, ServerInfo>();
 
         /// <summary>
-        /// Sends a request servers to the master servers
+        /// Sends a request for the server list to the master servers
         /// </summary>
         public static void RequestServers()
         {
@@ -35,7 +37,7 @@ namespace LmpClient.Network
             {
                 var msgDeserialized = NetworkMain.MstSrvMsgFactory.Deserialize(msg, LunaNetworkTime.UtcNow.Ticks);
 
-                //Sometimes we receive other type of unconnected messages. 
+                //Sometimes we receive other type of unconnected messages.
                 //Therefore we assert that the received message data is of MsReplyServersMsgData
                 if (msgDeserialized.Data is MsReplyServersMsgData data)
                 {
@@ -43,37 +45,35 @@ namespace LmpClient.Network
                     if (!LmpVersioning.IsCompatible(data.ServerVersion))
                         return;
 
-                    if (!Servers.ContainsKey(data.Id))
+                    var server = new ServerInfo
                     {
-                        var server = new ServerInfo
-                        {
-                            Id = data.Id,
-                            InternalEndpoint = data.InternalEndpoint,
-                            ExternalEndpoint = data.ExternalEndpoint,
-                            Description = data.Description,
-                            Country = data.Country,
-                            Website = data.Website,
-                            WebsiteText = data.WebsiteText,
-                            Password = data.Password,
-                            Cheats = data.Cheats,
-                            ServerName = data.ServerName,
-                            MaxPlayers = data.MaxPlayers,
-                            WarpMode = data.WarpMode,
-                            TerrainQuality = data.TerrainQuality,
-                            PlayerCount = data.PlayerCount,
-                            GameMode = data.GameMode,
-                            ModControl = data.ModControl,
-                            DedicatedServer = data.DedicatedServer,
-                            RainbowEffect = data.RainbowEffect,
-                            VesselUpdatesSendMsInterval = data.VesselUpdatesSendMsInterval,
-                            ServerVersion = data.ServerVersion
-                        };
+                        Id = data.Id,
+                        InternalEndpoint = data.InternalEndpoint,
+                        InternalEndpoint6 = data.InternalEndpoint6,
+                        ExternalEndpoint = data.ExternalEndpoint,
+                        Description = data.Description,
+                        Country = data.Country,
+                        Website = data.Website,
+                        WebsiteText = data.WebsiteText,
+                        Password = data.Password,
+                        Cheats = data.Cheats,
+                        ServerName = data.ServerName,
+                        MaxPlayers = data.MaxPlayers,
+                        WarpMode = data.WarpMode,
+                        TerrainQuality = data.TerrainQuality,
+                        PlayerCount = data.PlayerCount,
+                        GameMode = data.GameMode,
+                        ModControl = data.ModControl,
+                        DedicatedServer = data.DedicatedServer,
+                        RainbowEffect = data.RainbowEffect,
+                        VesselUpdatesSendMsInterval = data.VesselUpdatesSendMsInterval,
+                        ServerVersion = data.ServerVersion
+                    };
 
-                        Array.Copy(data.Color, server.Color, 3);
+                    Array.Copy(data.Color, server.Color, 3);
 
-                        if (Servers.TryAdd(data.Id, server))
-                            PingSystem.QueuePing(data.Id);
-                    }
+                    Servers.AddOrUpdate(data.Id, server, (l, info) =>  server);
+                    PingSystem.QueuePing(data.Id);
                 }
             }
             catch (Exception e)
@@ -89,10 +89,15 @@ namespace LmpClient.Network
         {
             if (Servers.TryGetValue(serverId, out var serverInfo))
             {
-                if (ServerIsInLocalLan(serverInfo.ExternalEndpoint))
+                if (ServerIsInLocalLan(serverInfo.ExternalEndpoint) || ServerIsInLocalLan(serverInfo.InternalEndpoint6))
                 {
                     LunaLog.Log("Server is in LAN. Skipping NAT punch");
-                    NetworkConnection.ConnectToServer(serverInfo.InternalEndpoint, Password);
+                    var endpoints = new List<IPEndPoint>();
+                    if (!serverInfo.InternalEndpoint6.Address.Equals(IPAddress.IPv6Loopback))
+                        endpoints.Add(serverInfo.InternalEndpoint6);
+                    if (!serverInfo.InternalEndpoint.Address.Equals(IPAddress.Loopback))
+                        endpoints.Add(serverInfo.InternalEndpoint);
+                    NetworkConnection.ConnectToServer(endpoints.ToArray(), Password);
                 }
                 else
                 {
@@ -101,12 +106,13 @@ namespace LmpClient.Network
                         var msgData = NetworkMain.CliMsgFactory.CreateNewMessageData<MsIntroductionMsgData>();
                         msgData.Id = serverId;
                         msgData.Token = MainSystem.UniqueIdentifier;
-                        msgData.InternalEndpoint = new IPEndPoint(LunaNetUtils.GetOwnInternalIpAddress(), NetworkMain.Config.Port);
+                        msgData.InternalEndpoint = new IPEndPoint(LunaNetUtils.GetOwnInternalIPv4Address(), NetworkMain.ClientConnection.Port);
+                        msgData.InternalEndpoint6 = new IPEndPoint(LunaNetUtils.GetOwnInternalIPv6Address(), NetworkMain.ClientConnection.Port);
 
                         var introduceMsg = NetworkMain.MstSrvMsgFactory.CreateNew<MainMstSrvMsg>(msgData);
 
                         MainSystem.Singleton.Status = string.Empty;
-                        LunaLog.Log($"[LMP]: Sending NAT introduction to server. Token: {MainSystem.UniqueIdentifier}");
+                        LunaLog.Log($"[LMP]: Sending NAT introduction to master servers. Token: {MainSystem.UniqueIdentifier}");
                         NetworkSender.QueueOutgoingMessage(introduceMsg);
                     }
                     catch (Exception e)
@@ -122,6 +128,24 @@ namespace LmpClient.Network
         /// </summary>
         private static bool ServerIsInLocalLan(IPEndPoint serverEndPoint)
         {
+            var ownNetwork = LunaNetUtils.GetOwnInternalIPv6Network();
+            if (ownNetwork != null && serverEndPoint.AddressFamily == AddressFamily.InterNetworkV6)
+            {
+                // For IPv6, we strip both addresses down to the subnet portion (likely the first 64 bits) and compare them.
+                // Because we only receive Global Unique Addresses from GetOwnInternalIPv6Network() (which are globally
+                // unique, as the name suggests and the RFCs define), those being equal should mean both are on the same network.
+                var ownBytes = ownNetwork.Address.GetAddressBytes();
+                var serverBytes = serverEndPoint.Address.GetAddressBytes();
+                // TODO IPv6: We currently assume an on-link prefix length of 64 bits, which is the most common case
+                // and standardized as per the RFCs. UnicastIPAddressInformation.PrefixLength is not implemented yet,
+                // and also wouldn't be reliable (hosts often assign their address as /128). A possible solution could be
+                // checking whether serverEndPoint matches any configured on-link/no-gateway route.
+                Array.Resize(ref ownBytes, 8);
+                Array.Resize(ref serverBytes, 8);
+                if (ownBytes == serverBytes)
+                    return true;
+            }
+
             return Equals(LunaNetUtils.GetOwnExternalIpAddress(), serverEndPoint.Address);
         }
 
@@ -133,7 +157,7 @@ namespace LmpClient.Network
             if (MainSystem.UniqueIdentifier == msg.ReadString())
             {
                 LunaLog.Log($"[LMP]: Nat introduction success against {msg.SenderEndPoint}. Token: {MainSystem.UniqueIdentifier}");
-                NetworkConnection.ConnectToServer(msg.SenderEndPoint, Password);
+                NetworkConnection.ConnectToServer(new []{ msg.SenderEndPoint }, Password);
             }
             else
             {

--- a/LmpClient/Systems/SettingsSys/SettingsStructures.cs
+++ b/LmpClient/Systems/SettingsSys/SettingsStructures.cs
@@ -30,8 +30,10 @@ namespace LmpClient.Systems.SettingsSys
         public float TimeoutSeconds { get; set; } = 15;
         public ServerFilters ServerFilters { get; set; } = new ServerFilters();
 
+        public string CustomMasterServer { get; set; } = "";
+
         /*
-         * You can use this debug switches for testing purposes. 
+         * You can use this debug switches for testing purposes.
          * For example do one part or the code or another in case the debugX is on/off
          * NEVER upload the code with those switches in use as some other developer might need them!!!!!
          */

--- a/LmpClient/Windows/ServerList/ServerListDrawer.cs
+++ b/LmpClient/Windows/ServerList/ServerListDrawer.cs
@@ -9,7 +9,7 @@ namespace LmpClient.Windows.ServerList
 {
     public partial class ServerListWindow
     {
-        private static readonly float[] HeaderGridSize = new float[14];
+        private static readonly float[] HeaderGridSize = new float[15];
 
         #region Servers grid
 
@@ -79,7 +79,7 @@ namespace LmpClient.Windows.ServerList
             if (Event.current.type == EventType.Repaint) HeaderGridSize[3] = GUILayoutUtility.GetLastRect().width;
             GUILayout.EndHorizontal();
 
-            GUILayout.BeginHorizontal(GUILayout.MinWidth(50));
+            GUILayout.BeginHorizontal(GUILayout.MinWidth(65));
             if (GUILayout.Button(LocalizationContainer.ServerListWindowText.Ping))
             {
                 _orderBy = "Ping";
@@ -87,12 +87,20 @@ namespace LmpClient.Windows.ServerList
             if (Event.current.type == EventType.Repaint) HeaderGridSize[4] = GUILayoutUtility.GetLastRect().width;
             GUILayout.EndHorizontal();
 
+            GUILayout.BeginHorizontal(GUILayout.MinWidth(65));
+            if (GUILayout.Button(LocalizationContainer.ServerListWindowText.Ping6))
+            {
+                _orderBy = "Ping6";
+            }
+            if (Event.current.type == EventType.Repaint) HeaderGridSize[5] = GUILayoutUtility.GetLastRect().width;
+            GUILayout.EndHorizontal();
+
             GUILayout.BeginHorizontal(GUILayout.MinWidth(50));
             if (GUILayout.Button(LocalizationContainer.ServerListWindowText.Players))
             {
                 _orderBy = "PlayerCount";
             }
-            if (Event.current.type == EventType.Repaint) HeaderGridSize[5] = GUILayoutUtility.GetLastRect().width;
+            if (Event.current.type == EventType.Repaint) HeaderGridSize[6] = GUILayoutUtility.GetLastRect().width;
             GUILayout.EndHorizontal();
 
             GUILayout.BeginHorizontal(GUILayout.MinWidth(85));
@@ -100,7 +108,7 @@ namespace LmpClient.Windows.ServerList
             {
                 _orderBy = "MaxPlayers";
             }
-            if (Event.current.type == EventType.Repaint) HeaderGridSize[6] = GUILayoutUtility.GetLastRect().width;
+            if (Event.current.type == EventType.Repaint) HeaderGridSize[7] = GUILayoutUtility.GetLastRect().width;
             GUILayout.EndHorizontal();
 
             GUILayout.BeginHorizontal(GUILayout.MinWidth(85));
@@ -108,7 +116,7 @@ namespace LmpClient.Windows.ServerList
             {
                 _orderBy = "GameMode";
             }
-            if (Event.current.type == EventType.Repaint) HeaderGridSize[7] = GUILayoutUtility.GetLastRect().width;
+            if (Event.current.type == EventType.Repaint) HeaderGridSize[8] = GUILayoutUtility.GetLastRect().width;
             GUILayout.EndHorizontal();
 
             GUILayout.BeginHorizontal(GUILayout.MinWidth(75));
@@ -116,7 +124,7 @@ namespace LmpClient.Windows.ServerList
             {
                 _orderBy = "WarpMode";
             }
-            if (Event.current.type == EventType.Repaint) HeaderGridSize[8] = GUILayoutUtility.GetLastRect().width;
+            if (Event.current.type == EventType.Repaint) HeaderGridSize[9] = GUILayoutUtility.GetLastRect().width;
             GUILayout.EndHorizontal();
 
             GUILayout.BeginHorizontal(GUILayout.MinWidth(50));
@@ -124,7 +132,7 @@ namespace LmpClient.Windows.ServerList
             {
                 _orderBy = "TerrainQuality";
             }
-            if (Event.current.type == EventType.Repaint) HeaderGridSize[9] = GUILayoutUtility.GetLastRect().width;
+            if (Event.current.type == EventType.Repaint) HeaderGridSize[10] = GUILayoutUtility.GetLastRect().width;
             GUILayout.EndHorizontal();
 
             GUILayout.BeginHorizontal(GUILayout.MinWidth(50));
@@ -132,7 +140,7 @@ namespace LmpClient.Windows.ServerList
             {
                 _orderBy = "Cheats";
             }
-            if (Event.current.type == EventType.Repaint) HeaderGridSize[10] = GUILayoutUtility.GetLastRect().width;
+            if (Event.current.type == EventType.Repaint) HeaderGridSize[11] = GUILayoutUtility.GetLastRect().width;
             GUILayout.EndHorizontal();
 
             GUILayout.BeginHorizontal(GUILayout.MinWidth(220));
@@ -140,7 +148,7 @@ namespace LmpClient.Windows.ServerList
             {
                 _orderBy = "ServerName";
             }
-            if (Event.current.type == EventType.Repaint) HeaderGridSize[11] = GUILayoutUtility.GetLastRect().width > 220 ? GUILayoutUtility.GetLastRect().width : 220;
+            if (Event.current.type == EventType.Repaint) HeaderGridSize[12] = GUILayoutUtility.GetLastRect().width > 220 ? GUILayoutUtility.GetLastRect().width : 220;
             GUILayout.EndHorizontal();
 
             GUILayout.BeginHorizontal(GUILayout.MinWidth(150));
@@ -148,7 +156,7 @@ namespace LmpClient.Windows.ServerList
             {
                 _orderBy = "WebsiteText";
             }
-            if (Event.current.type == EventType.Repaint) HeaderGridSize[12] = GUILayoutUtility.GetLastRect().width;
+            if (Event.current.type == EventType.Repaint) HeaderGridSize[13] = GUILayoutUtility.GetLastRect().width;
             GUILayout.EndHorizontal();
 
             GUILayout.BeginHorizontal(GUILayout.MinWidth(600));
@@ -156,7 +164,7 @@ namespace LmpClient.Windows.ServerList
             {
                 _orderBy = "Description";
             }
-            if (Event.current.type == EventType.Repaint) HeaderGridSize[13] = GUILayoutUtility.GetLastRect().width > 600 ? GUILayoutUtility.GetLastRect().width : 600;
+            if (Event.current.type == EventType.Repaint) HeaderGridSize[14] = GUILayoutUtility.GetLastRect().width > 600 ? GUILayoutUtility.GetLastRect().width : 600;
             GUILayout.EndHorizontal();
 
             GUILayout.EndHorizontal();
@@ -234,45 +242,49 @@ namespace LmpClient.Windows.ServerList
             GUILayout.EndHorizontal();
 
             GUILayout.BeginHorizontal(GUILayout.MinWidth(HeaderGridSize[5]));
-            GUILayout.Label(new GUIContent($"{currentEntry.PlayerCount}"), GetCorrectLabelStyle(currentEntry), GUILayout.MinWidth(HeaderGridSize[5]));
+            GUILayout.Label(new GUIContent($"{currentEntry.DisplayedPing6}"), GetCorrectLabelStyle(currentEntry), GUILayout.MinWidth(HeaderGridSize[5]));
             GUILayout.EndHorizontal();
 
             GUILayout.BeginHorizontal(GUILayout.MinWidth(HeaderGridSize[6]));
-            GUILayout.Label(new GUIContent($"{currentEntry.MaxPlayers}"), GetCorrectLabelStyle(currentEntry), GUILayout.MinWidth(HeaderGridSize[6]));
+            GUILayout.Label(new GUIContent($"{currentEntry.PlayerCount}"), GetCorrectLabelStyle(currentEntry), GUILayout.MinWidth(HeaderGridSize[6]));
             GUILayout.EndHorizontal();
 
             GUILayout.BeginHorizontal(GUILayout.MinWidth(HeaderGridSize[7]));
-            GUILayout.Label(new GUIContent($"{(GameMode)currentEntry.GameMode}"), GetCorrectLabelStyle(currentEntry), GUILayout.MinWidth(HeaderGridSize[7]));
+            GUILayout.Label(new GUIContent($"{currentEntry.MaxPlayers}"), GetCorrectLabelStyle(currentEntry), GUILayout.MinWidth(HeaderGridSize[7]));
             GUILayout.EndHorizontal();
 
             GUILayout.BeginHorizontal(GUILayout.MinWidth(HeaderGridSize[8]));
-            GUILayout.Label(new GUIContent($"{(WarpMode)currentEntry.WarpMode}"), GetCorrectLabelStyle(currentEntry), GUILayout.MinWidth(HeaderGridSize[8]));
+            GUILayout.Label(new GUIContent($"{(GameMode)currentEntry.GameMode}"), GetCorrectLabelStyle(currentEntry), GUILayout.MinWidth(HeaderGridSize[8]));
             GUILayout.EndHorizontal();
 
             GUILayout.BeginHorizontal(GUILayout.MinWidth(HeaderGridSize[9]));
-            GUILayout.Label(new GUIContent($"{(TerrainQuality)currentEntry.TerrainQuality}"), GetCorrectLabelStyle(currentEntry), GUILayout.MinWidth(HeaderGridSize[9]));
+            GUILayout.Label(new GUIContent($"{(WarpMode)currentEntry.WarpMode}"), GetCorrectLabelStyle(currentEntry), GUILayout.MinWidth(HeaderGridSize[9]));
             GUILayout.EndHorizontal();
 
             GUILayout.BeginHorizontal(GUILayout.MinWidth(HeaderGridSize[10]));
-            GUILayout.Label(new GUIContent($"{currentEntry.Cheats}"), GetCorrectLabelStyle(currentEntry), GUILayout.MinWidth(HeaderGridSize[10]));
+            GUILayout.Label(new GUIContent($"{(TerrainQuality)currentEntry.TerrainQuality}"), GetCorrectLabelStyle(currentEntry), GUILayout.MinWidth(HeaderGridSize[10]));
             GUILayout.EndHorizontal();
 
             GUILayout.BeginHorizontal(GUILayout.MinWidth(HeaderGridSize[11]));
-            GUILayout.Label(new GUIContent($"{currentEntry.ServerName}"), GetCorrectLabelStyle(currentEntry), GUILayout.MinWidth(HeaderGridSize[11]));
+            GUILayout.Label(new GUIContent($"{currentEntry.Cheats}"), GetCorrectLabelStyle(currentEntry), GUILayout.MinWidth(HeaderGridSize[11]));
             GUILayout.EndHorizontal();
 
             GUILayout.BeginHorizontal(GUILayout.MinWidth(HeaderGridSize[12]));
+            GUILayout.Label(new GUIContent($"{currentEntry.ServerName}"), GetCorrectLabelStyle(currentEntry), GUILayout.MinWidth(HeaderGridSize[12]));
+            GUILayout.EndHorizontal();
+
+            GUILayout.BeginHorizontal(GUILayout.MinWidth(HeaderGridSize[13]));
             if (!string.IsNullOrEmpty(currentEntry.Website))
             {
-                if (GUILayout.Button(new GUIContent(currentEntry.WebsiteText), GetCorrectHyperlinkLabelStyle(currentEntry), GUILayout.MinWidth(HeaderGridSize[12])))
+                if (GUILayout.Button(new GUIContent(currentEntry.WebsiteText), GetCorrectHyperlinkLabelStyle(currentEntry), GUILayout.MinWidth(HeaderGridSize[13])))
                 {
                     Application.OpenURL(currentEntry.Website);
                 }
             }
             GUILayout.EndHorizontal();
 
-            GUILayout.BeginHorizontal(GUILayout.MinWidth(HeaderGridSize[13]));
-            GUILayout.Label(new GUIContent($"{currentEntry.Description}"), GetCorrectLabelStyle(currentEntry), GUILayout.MinWidth(HeaderGridSize[13]));
+            GUILayout.BeginHorizontal(GUILayout.MinWidth(HeaderGridSize[14]));
+            GUILayout.Label(new GUIContent($"{currentEntry.Description}"), GetCorrectLabelStyle(currentEntry), GUILayout.MinWidth(HeaderGridSize[14]));
             GUILayout.EndHorizontal();
 
             ColorEffect.StopPaintingServer();

--- a/LmpCommon/Message/Data/MasterServer/MsIntroductionMsgData.cs
+++ b/LmpCommon/Message/Data/MasterServer/MsIntroductionMsgData.cs
@@ -13,6 +13,7 @@ namespace LmpCommon.Message.Data.MasterServer
 
         public long Id;
         public IPEndPoint InternalEndpoint;
+        public IPEndPoint InternalEndpoint6;
         public string Token;
 
         public override string ClassName { get; } = nameof(MsIntroductionMsgData);
@@ -23,6 +24,7 @@ namespace LmpCommon.Message.Data.MasterServer
 
             lidgrenMsg.Write(Id);
             lidgrenMsg.Write(InternalEndpoint);
+            lidgrenMsg.Write(InternalEndpoint6);
             lidgrenMsg.Write(Token);
         }
 
@@ -32,12 +34,15 @@ namespace LmpCommon.Message.Data.MasterServer
 
             Id = lidgrenMsg.ReadInt64();
             InternalEndpoint = lidgrenMsg.ReadIPEndPoint();
+            // ReadIPEndPoint supports IPv6 addresses despite saying otherwise in the code doc.
+            InternalEndpoint6 = lidgrenMsg.ReadIPEndPoint();
             Token = lidgrenMsg.ReadString();
         }
 
         internal override int InternalGetMessageSize()
         {
-            return base.InternalGetMessageSize() + sizeof(long) + InternalEndpoint.GetByteCount() + Token.GetByteCount();
+            return base.InternalGetMessageSize() + sizeof(long) + InternalEndpoint.GetByteCount() +
+                   InternalEndpoint6.GetByteCount() + Token.GetByteCount();
         }
     }
 }

--- a/LmpCommon/Message/Data/MasterServer/MsRegisterServerMsgData.cs
+++ b/LmpCommon/Message/Data/MasterServer/MsRegisterServerMsgData.cs
@@ -14,6 +14,7 @@ namespace LmpCommon.Message.Data.MasterServer
         public long Id;
         public string ServerVersion;
         public IPEndPoint InternalEndpoint;
+        public IPEndPoint InternalEndpoint6;
         public bool Password;
         public bool Cheats;
         public bool ModControl;
@@ -41,6 +42,7 @@ namespace LmpCommon.Message.Data.MasterServer
             lidgrenMsg.Write(Id);
             lidgrenMsg.Write(ServerVersion);
             lidgrenMsg.Write(InternalEndpoint);
+            lidgrenMsg.Write(InternalEndpoint6);
 
             lidgrenMsg.Write(Password);
             lidgrenMsg.Write(Cheats);
@@ -72,6 +74,8 @@ namespace LmpCommon.Message.Data.MasterServer
             Id = lidgrenMsg.ReadInt64();
             ServerVersion = lidgrenMsg.ReadString();
             InternalEndpoint = lidgrenMsg.ReadIPEndPoint();
+            // ReadIPEndPoint supports IPv6 addresses despite saying otherwise in the code doc.
+            InternalEndpoint6 = lidgrenMsg.ReadIPEndPoint();
 
             Password = lidgrenMsg.ReadBoolean();
             Cheats = lidgrenMsg.ReadBoolean();
@@ -99,9 +103,10 @@ namespace LmpCommon.Message.Data.MasterServer
         internal override int InternalGetMessageSize()
         {
             //We use sizeof(byte) instead of sizeof(bool) because we use the WritePadBits()
-            return base.InternalGetMessageSize() + sizeof(long) + ServerVersion.GetByteCount() + InternalEndpoint.GetByteCount() + sizeof(byte) +
-                sizeof(int) * 7 + ServerName.GetByteCount() + Description.GetByteCount() + CountryCode.GetByteCount() + Website.GetByteCount() +
-                   WebsiteText.GetByteCount() + sizeof(bool) * 3;
+            return base.InternalGetMessageSize() + sizeof(long) + ServerVersion.GetByteCount() +
+                   InternalEndpoint.GetByteCount() + InternalEndpoint6.GetByteCount() + sizeof(byte) +
+                   sizeof(int) * 7 + ServerName.GetByteCount() + Description.GetByteCount() +
+                   CountryCode.GetByteCount() + Website.GetByteCount() + WebsiteText.GetByteCount() + sizeof(bool) * 3;
         }
     }
 }

--- a/LmpCommon/Message/Data/MasterServer/MsReplyServersMsgData.cs
+++ b/LmpCommon/Message/Data/MasterServer/MsReplyServersMsgData.cs
@@ -14,6 +14,7 @@ namespace LmpCommon.Message.Data.MasterServer
         public long Id;
         public string ServerVersion;
         public IPEndPoint InternalEndpoint;
+        public IPEndPoint InternalEndpoint6;
         public IPEndPoint ExternalEndpoint;
         public bool Password;
         public bool Cheats;
@@ -42,6 +43,7 @@ namespace LmpCommon.Message.Data.MasterServer
             lidgrenMsg.Write(Id);
             lidgrenMsg.Write(ServerVersion);
             lidgrenMsg.Write(InternalEndpoint);
+            lidgrenMsg.Write(InternalEndpoint6);
             lidgrenMsg.Write(ExternalEndpoint);
             lidgrenMsg.Write(Password);
             lidgrenMsg.Write(Cheats);
@@ -70,6 +72,8 @@ namespace LmpCommon.Message.Data.MasterServer
             Id = lidgrenMsg.ReadInt64();
             ServerVersion = lidgrenMsg.ReadString();
             InternalEndpoint = lidgrenMsg.ReadIPEndPoint();
+            // ReadIPEndPoint supports IPv6 addresses despite saying otherwise in the code doc.
+            InternalEndpoint6 = lidgrenMsg.ReadIPEndPoint();
             ExternalEndpoint = lidgrenMsg.ReadIPEndPoint();
             Password = lidgrenMsg.ReadBoolean();
             Cheats = lidgrenMsg.ReadBoolean();
@@ -93,10 +97,11 @@ namespace LmpCommon.Message.Data.MasterServer
 
         internal override int InternalGetMessageSize()
         {
-            return base.InternalGetMessageSize() +
-                sizeof(long) + ServerVersion.GetByteCount() + InternalEndpoint.GetByteCount() +
-                ExternalEndpoint.GetByteCount() + ServerName.GetByteCount() + Description.GetByteCount() + Country.GetByteCount() + Website.GetByteCount() + WebsiteText.GetByteCount() +
-                sizeof(bool) * 5 + sizeof(int) * 6 + sizeof(byte) * 3;
+            return base.InternalGetMessageSize() + sizeof(long) + ServerVersion.GetByteCount() +
+                   InternalEndpoint.GetByteCount() + InternalEndpoint6.GetByteCount() +
+                   ExternalEndpoint.GetByteCount() + ServerName.GetByteCount() + Description.GetByteCount() +
+                   Country.GetByteCount() + Website.GetByteCount() + WebsiteText.GetByteCount() +
+                   sizeof(bool) * 5 + sizeof(int) * 6 + sizeof(byte) * 3;
         }
     }
 }

--- a/LmpCommon/RepoRetrievers/MasterServerRetriever.cs
+++ b/LmpCommon/RepoRetrievers/MasterServerRetriever.cs
@@ -66,7 +66,7 @@ namespace LmpCommon.RepoRetrievers
                             }
                             catch (Exception)
                             {
-                                //Ignore the bad server   
+                                //Ignore the bad server
                             }
                         }
                     }

--- a/LmpCommon/ServerInfo.cs
+++ b/LmpCommon/ServerInfo.cs
@@ -7,10 +7,13 @@ namespace LmpCommon
         public long Id { get; set; }
         public string Country { get; set; }
         public IPEndPoint InternalEndpoint { get; set; }
+        public IPEndPoint InternalEndpoint6 { get; set; }
         public IPEndPoint ExternalEndpoint { get; set; }
         public string ServerVersion { get; set; }
         public string DisplayedPing { get; set; } = "?";
+        public string DisplayedPing6 { get; set; } = "?";
         public int Ping { get; set; } = int.MaxValue;
+        public int Ping6 { get; set; } = int.MaxValue;
         public bool Password { get; set; }
         public bool Cheats { get; set; }
         public int GameMode { get; set; }

--- a/LmpCommon/Time/LunaNetworkTime.cs
+++ b/LmpCommon/Time/LunaNetworkTime.cs
@@ -25,7 +25,7 @@ namespace LmpCommon.Time
         private const int TimeSyncIntervalMs = 30 * 1000;
 
         /// <summary>
-        /// Static constructor where we create the time that syncs time with the time providers every 10 seconds
+        /// Static constructor where we create the timer that syncs time with the time providers every 10 seconds
         /// </summary>
         static LunaNetworkTime() => Timer = new Timer(_ => RefreshTimeDifference(), null, 0, TimeSyncIntervalMs);
 

--- a/LmpCommonTest/LmpCommonTest.csproj
+++ b/LmpCommonTest/LmpCommonTest.csproj
@@ -92,10 +92,6 @@
   <Import Project="..\LmpGlobal\LmpGlobal.projitems" Label="Shared" />
   <Import Project="$(VSToolsPath)\TeamTest\Microsoft.TestTools.targets" Condition="Exists('$(VSToolsPath)\TeamTest\Microsoft.TestTools.targets')" />
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
-  <PropertyGroup>
-    <PostBuildEvent>
-    </PostBuildEvent>
-  </PropertyGroup>
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>

--- a/LmpMasterServer/Http/Handlers/ServerListHandler.cs
+++ b/LmpMasterServer/Http/Handlers/ServerListHandler.cs
@@ -108,7 +108,8 @@ namespace LmpMasterServer.Http.Handlers
 
             writer.RenderBeginTag("thead");
             writer.RenderBeginTag(HtmlTextWriterTag.Tr);
-            writer.RenderBeginTag(HtmlTextWriterTag.Th); writer.Write("Address"); writer.RenderEndTag();
+            writer.RenderBeginTag(HtmlTextWriterTag.Th); writer.Write("IPv4 Address"); writer.RenderEndTag();
+            writer.RenderBeginTag(HtmlTextWriterTag.Th); writer.Write("IPv6 Address"); writer.RenderEndTag();
             writer.RenderBeginTag(HtmlTextWriterTag.Th); writer.Write("Country"); writer.RenderEndTag();
             writer.RenderBeginTag(HtmlTextWriterTag.Th); writer.Write("Password"); writer.RenderEndTag();
             writer.RenderBeginTag(HtmlTextWriterTag.Th); writer.Write("Name"); writer.RenderEndTag();
@@ -131,6 +132,7 @@ namespace LmpMasterServer.Http.Handlers
                 {
                     writer.RenderBeginTag(HtmlTextWriterTag.Tr);
                     writer.RenderBeginTag(HtmlTextWriterTag.Td); writer.Write(HttpUtility.HtmlEncode(server.ExternalEndpoint)); writer.RenderEndTag();
+                    writer.RenderBeginTag(HtmlTextWriterTag.Td); writer.Write(HttpUtility.HtmlEncode(server.InternalEndpoint6)); writer.RenderEndTag();
                     writer.RenderBeginTag(HtmlTextWriterTag.Td); writer.Write(HttpUtility.HtmlEncode(server.Country)); writer.RenderEndTag();
                     writer.RenderBeginTag(HtmlTextWriterTag.Td); writer.Write(HttpUtility.HtmlEncode(server.Password)); writer.RenderEndTag();
                     writer.RenderBeginTag(HtmlTextWriterTag.Td); writer.Write(HttpUtility.HtmlEncode(server.ServerName)); writer.RenderEndTag();

--- a/LmpMasterServer/LmpMasterServer.csproj
+++ b/LmpMasterServer/LmpMasterServer.csproj
@@ -154,11 +154,8 @@
   <Import Project="..\LmpCommon\LmpCommon.projitems" Label="Shared" />
   <Import Project="..\LmpGlobal\LmpGlobal.projitems" Label="Shared" />
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
-  <PropertyGroup Condition="'$(OS)' != 'Unix'">
-    <PostBuildEvent>xcopy /y /s "$(TargetDir)*.*" "$(SolutionDir)MasterServer\bin\$(ConfigurationName)"</PostBuildEvent>
-  </PropertyGroup>
   <PropertyGroup>
-    <PostBuildEvent />
+    <PostBuildEvent Condition="'$(OS)' != 'Unix'">xcopy /y /s "$(TargetDir)*.*" "$(SolutionDir)MasterServer\bin\$(ConfigurationName)"</PostBuildEvent>
   </PropertyGroup>
   <Import Project="..\External\Nuget\Microsoft.VisualStudio.Threading.Analyzers.16.10.56\build\Microsoft.VisualStudio.Threading.Analyzers.targets" Condition="Exists('..\External\Nuget\Microsoft.VisualStudio.Threading.Analyzers.16.10.56\build\Microsoft.VisualStudio.Threading.Analyzers.targets')" />
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">

--- a/LmpMasterServer/Structure/Server.cs
+++ b/LmpMasterServer/Structure/Server.cs
@@ -34,6 +34,7 @@ namespace LmpMasterServer.Structure
         public void Update(MsRegisterServerMsgData msg)
         {
             InternalEndpoint = msg.InternalEndpoint;
+            InternalEndpoint6 = msg.InternalEndpoint6;
             LastRegisterTime = LunaNetworkTime.UtcNow.Ticks;
             Cheats = msg.Cheats;
             Password = msg.Password;

--- a/MasterServer/MasterServer.csproj
+++ b/MasterServer/MasterServer.csproj
@@ -47,28 +47,28 @@
     <StartupObject />
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Microsoft.Bcl.AsyncInterfaces, Version=1.0.0.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
-      <HintPath>..\External\Nuget\Microsoft.Bcl.AsyncInterfaces.1.1.1\lib\net461\Microsoft.Bcl.AsyncInterfaces.dll</HintPath>
+    <Reference Include="Microsoft.Bcl.AsyncInterfaces, Version=5.0.0.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\External\Nuget\Microsoft.Bcl.AsyncInterfaces.5.0.0\lib\net461\Microsoft.Bcl.AsyncInterfaces.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.VisualStudio.Threading, Version=16.8.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\External\Nuget\Microsoft.VisualStudio.Threading.16.8.55\lib\net472\Microsoft.VisualStudio.Threading.dll</HintPath>
+    <Reference Include="Microsoft.VisualStudio.Threading, Version=16.10.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\External\Nuget\Microsoft.VisualStudio.Threading.16.10.56\lib\net472\Microsoft.VisualStudio.Threading.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.VisualStudio.Validation, Version=16.8.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\External\Nuget\Microsoft.VisualStudio.Validation.16.8.33\lib\netstandard2.0\Microsoft.VisualStudio.Validation.dll</HintPath>
+    <Reference Include="Microsoft.VisualStudio.Validation, Version=16.9.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\External\Nuget\Microsoft.VisualStudio.Validation.16.9.32\lib\netstandard2.0\Microsoft.VisualStudio.Validation.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.Win32.Registry, Version=4.1.3.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\External\Nuget\Microsoft.Win32.Registry.4.7.0\lib\net461\Microsoft.Win32.Registry.dll</HintPath>
+    <Reference Include="Microsoft.Win32.Registry, Version=5.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\External\Nuget\Microsoft.Win32.Registry.5.0.0\lib\net461\Microsoft.Win32.Registry.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="System.Runtime.CompilerServices.Unsafe, Version=4.0.4.1, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>..\External\Nuget\System.Runtime.CompilerServices.Unsafe.4.5.3\lib\net461\System.Runtime.CompilerServices.Unsafe.dll</HintPath>
     </Reference>
-    <Reference Include="System.Security.AccessControl, Version=4.1.3.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\External\Nuget\System.Security.AccessControl.4.7.0\lib\net461\System.Security.AccessControl.dll</HintPath>
+    <Reference Include="System.Security.AccessControl, Version=5.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\External\Nuget\System.Security.AccessControl.5.0.0\lib\net461\System.Security.AccessControl.dll</HintPath>
     </Reference>
-    <Reference Include="System.Security.Principal.Windows, Version=4.1.3.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\External\Nuget\System.Security.Principal.Windows.4.7.0\lib\net461\System.Security.Principal.Windows.dll</HintPath>
+    <Reference Include="System.Security.Principal.Windows, Version=5.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\External\Nuget\System.Security.Principal.Windows.5.0.0\lib\net461\System.Security.Principal.Windows.dll</HintPath>
     </Reference>
     <Reference Include="System.Threading.Tasks.Extensions, Version=4.2.0.1, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
       <HintPath>..\External\Nuget\System.Threading.Tasks.Extensions.4.5.4\lib\net461\System.Threading.Tasks.Extensions.dll</HintPath>

--- a/MasterServer/MasterServer.csproj
+++ b/MasterServer/MasterServer.csproj
@@ -119,9 +119,9 @@
     </PreBuildEvent>
   </PropertyGroup>
   <PropertyGroup>
-    <PostBuildEvent>xcopy /y /s  "$(SolutionDir)LmpMasterServer\bin\$(ConfigurationName)\*.*" "$(TargetDir)"</PostBuildEvent>
+    <PostBuildEvent Condition="'$(OS)' != 'Unix'">xcopy /y /s  "$(SolutionDir)LmpMasterServer\bin\$(ConfigurationName)\*.*" "$(TargetDir)"</PostBuildEvent>
   </PropertyGroup>
-  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
+  <!-- To modify your build process, add your task inside one of the targets below and uncomment it.
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">
   </Target>

--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@
 - [x] [Interpolation](http://www.gabrielgambetta.com/entity-interpolation.html) so the vessels won't jump when there are bad network conditions.
 - [x] Multilanguage.
 - [x] [Nat-punchtrough](../../wiki/Master-server) feature so a server doesn't need to open ports on it's router.
+- [x] [IPv6](https://en.wikipedia.org/wiki/IPv6) support for client<->server connections, allowing connection setup even behind symmetric IPv4 NAT
 - [x] Servers displayed within the mod.
 - [x] Settings saved as XML.
 - [x] [UPnP](https://en.wikipedia.org/wiki/Universal_Plug_and_Play) support for servers and [master servers](../../wiki/Master-server)

--- a/Server/Command/CommandHandler.cs
+++ b/Server/Command/CommandHandler.cs
@@ -45,20 +45,24 @@ namespace Server.Command
                 while (ServerContext.ServerRunning)
                 {
                     var input = Console.ReadLine();
-                    if (string.IsNullOrEmpty(input))
+                    if (input == null)
                     {
-                        continue;
+                        LunaLog.Normal("End of stdin, stopping command listener");
+                        break;
                     }
-                    LunaLog.Normal($"Command input: {input}");
                     if (!string.IsNullOrEmpty(input))
                     {
-                        if (input.StartsWith("/"))
+                        LunaLog.Normal($"Command input: {input}");
+                        if (!string.IsNullOrEmpty(input))
                         {
-                            HandleServerInput(input.Substring(1));
-                        }
-                        else
-                        {
-                            Commands["say"].Func(input);
+                            if (input.StartsWith("/"))
+                            {
+                                HandleServerInput(input.Substring(1));
+                            }
+                            else
+                            {
+                                Commands["say"].Func(input);
+                            }
                         }
                     }
 

--- a/Server/Server/LidgrenMasterServer.cs
+++ b/Server/Server/LidgrenMasterServer.cs
@@ -8,6 +8,7 @@ using Server.Log;
 using Server.Settings.Structures;
 using System;
 using System.Net;
+using System.Net.Sockets;
 using System.Threading.Tasks;
 
 namespace Server.Server
@@ -23,10 +24,25 @@ namespace Server.Server
 
             LunaLog.Normal("Registering with master servers...");
 
-            var adr = LunaNetUtils.GetOwnInternalIpAddress();
-            if (adr == null) return;
+            var adr4 = LunaNetUtils.GetOwnInternalIPv4Address();
+            // As of right now the internal endpoint for IPv4 is mandatory, because if there is none, there is no
+            // IPv4 connectivity at all, which is required to connect to the master servers (so they can determine
+            // the public IPv4 address).
+            if (adr4 == null) return;
+            var endpoint4 = new IPEndPoint(adr4, ServerContext.Config.Port);
+            // Only send IPv6 address if actually listening on IPv6, otherwise send loopback with means "none".
+            IPAddress adr6;
+            IPEndPoint endpoint6;
+            if (LidgrenServer.Server.Socket.AddressFamily == AddressFamily.InterNetworkV6)
+            {
+                adr6 = LunaNetUtils.GetOwnInternalIPv6Address();
+                endpoint6 = new IPEndPoint(adr6, ServerContext.Config.Port);
+            }
+            else
+            {
+                endpoint6 = new IPEndPoint(IPAddress.IPv6Loopback, ServerContext.Config.Port);
+            }
 
-            var endpoint = new IPEndPoint(adr, ServerContext.Config.Port);
             while (ServerContext.ServerRunning)
             {
                 var msgData = ServerContext.ServerMessageFactory.CreateNewMessageData<MsRegisterServerMsgData>();
@@ -40,7 +56,8 @@ namespace Server.Server
                 msgData.RainbowEffect = DedicatedServerSettings.SettingsStore.UseRainbowEffect;
                 msgData.Color = new[] { DedicatedServerSettings.SettingsStore.Red, DedicatedServerSettings.SettingsStore.Green, DedicatedServerSettings.SettingsStore.Blue };
                 msgData.GameMode = (int)GeneralSettings.SettingsStore.GameMode;
-                msgData.InternalEndpoint = endpoint;
+                msgData.InternalEndpoint = endpoint4;
+                msgData.InternalEndpoint6 = endpoint6;
                 msgData.MaxPlayers = GeneralSettings.SettingsStore.MaxPlayers;
                 msgData.ModControl = GeneralSettings.SettingsStore.ModControl;
                 msgData.PlayerCount = ServerContext.Clients.Count;
@@ -57,7 +74,18 @@ namespace Server.Server
                 msgData.WebsiteText = msgData.WebsiteText.Length > 15 ? msgData.WebsiteText.Substring(0, 15) : msgData.WebsiteText;
                 msgData.ServerName = msgData.ServerName.Length > 30 ? msgData.ServerName.Substring(0, 30) : msgData.ServerName;
 
-                foreach (var masterServer in MasterServerRetriever.MasterServers.GetValues)
+                IPEndPoint[] masterServers;
+                if (string.IsNullOrEmpty(DebugSettings.SettingsStore.CustomMasterServer))
+                    masterServers = MasterServerRetriever.MasterServers.GetValues;
+                else
+                {
+                    masterServers = new[]
+                    {
+                        LunaNetUtils.CreateEndpointFromString(DebugSettings.SettingsStore.CustomMasterServer)
+                    };
+
+                }
+                foreach (var masterServer in masterServers)
                 {
                     RegisterWithMasterServer(msgData, masterServer);
                 }

--- a/Server/Settings/Definition/DebugSettingsDefinition.cs
+++ b/Server/Settings/Definition/DebugSettingsDefinition.cs
@@ -17,5 +17,8 @@ namespace Server.Settings.Definition
 
         [XmlComment(Value = "Minimum latency that a packet will have")]
         public int MinSimulatedLatencyMs { get; set; } = 0;
+
+        [XmlComment(Value = "Custom master server to register with for debugging purposes")]
+        public string CustomMasterServer { get; set; } = "";
     }
 }

--- a/Server/Settings/Definition/WebsiteSettingsDefinition.cs
+++ b/Server/Settings/Definition/WebsiteSettingsDefinition.cs
@@ -9,6 +9,9 @@ namespace Server.Settings.Definition
         [XmlComment(Value = "Enable the website system that allows to retrieve server information in JSON format. You can get the data at http://YourIP:Port")]
         public bool EnableWebsite { get; set; } = true;
 
+        [XmlComment(Value = "The address that the web server listens on. Falls back to ConnectionSettings.ListenAddress if unset, which defaults to 0.0.0.0")]
+        public string ListenAddress { get; set; } = "";
+
         [XmlComment(Value = "TCP port. You will need to open this port on your router if you want to display the data from outside your local network")]
         public int Port { get; set; } = 8900;
 


### PR DESCRIPTION
Follow-up to #445, this basically "completes" IPv6 support.
This PR extends the IPv6 support to server-list connections as well, with firewall punchthrough support.
It touches a lot of code, it changes a lot of the core networking logic. Please review carefully.

This PR also includes changes to the wire format of some messages. I.e. master servers / servers / clients receiving from older or newer master servers / servers / clients will probably throw some NullReferenceExceptions and have other unexpected behavior. Do we need to bump some version number for this, or is this just the danger of running nightlies?

## Testing

This has been tested
- with IPv4-only server & master server running on localhost
- with dual-stack server & master server running on localhost
- with IPv4-only server running on remote machine A and master server running on remote machine B:
  - with "static port mapping" NAT & firewall between client <-> server/master server and firewall between server <-> master server
  - with "symmetric" IPv4 & firewall between client <-> server/master server and firewall between server <-> master server
- with dual-stack server running on remote machine A and master server running on remote machine B

It has not been tested with an "IPv4-only" client yet, as I need to start a VM for that, since I rely on IPv6 on my main machine.

I have some Docker images on Docker Hub, if it helps with testing: [Master server](https://hub.docker.com/r/dasskelett/lmpmasterserver) | [Server](https://hub.docker.com/r/dasskelett/lmpserver).
However they can be changed at any time, and do not necessarily match the code currently pushed to this branch.
For example, they don't support UPnP, as that code fails to compile on my machine (something with the Visual Studio DLLs) and is commented out in my working directory.

I have a master server and a server using the above Docker images running on a VPS, whose addresses I can share for testing if you are interested.

## Changes
### Client
- Initiate single global ClientConnection at startup, don't replace after disconnect
- Make socket IPv4-only if OS doesn't support IPv6
- Implement IPv6->IPv4 fallback logic in ConnectToServer for direct connections
- The manual retries in `ConnectToServer()` have been removed and replaced by Lidgren's builtin retry logic configured via `Config.MaximumHandshakeAttempts` and `Config.ResendHandshakeInterval`
- `SendNetworkMessage()` starts the `NetClient` when sending unconnected messages to the master servers if necessary, usually when retrieving the server list.
- Servers in the server list are now updated when receiving new data (especially useful for debugging, but might benefit other situations as well) 
- Communicate IPv6 addresses with master servers when asking for NAT introduction
- `ServerIsInLocalLan()` compares the prefix for IPv6 addresses (thanks to the global uniqueness of GlobalUnicastAddresses this is fairly reliable)
- Add debug option to overwrite the master server list
- Show IPv6 RTT in server list

### Server
- Communicate IPv6 addresses with master servers
- Add debug setting to overwrite master server list
- Allow specifying a separate `ListenAddress` for the web server, with fallback to the game server `ListenAddress` if left unspecified.

### Master server
- Support IPv6 addresses for servers, send to clients
- Send another NAT introduction for IPv6, if both client and server have IPv6 enabled:
  - The first NAT introduction message triggers hole punching for both the public IPv4 addresses and the IPv6 addresses. This is unavoidable, since we need to send the trigger message to the public IPv4 addresses of the client and server.
    This one is likely to succeed in the most common case (as long as both client and server have working IPv6, or the IPv4 NAT in between allows hole punching).
  - The second NAT introduction message triggers hole punching for both the public IPv4 addresses again and the internal IPv4 addresses. It is sent after a delay of 50 ms, to allow some cooldown after the first round (even though my testing showed there's no problem with sending dozens of NAT punch-through messages, the connection setup after a punch-through succeeded is race-free).
  - Since we have this delay of 50ms, the whole operation now happens in a background thread, as to not block receiving and processing other messages in the meantime.
- Fail softly if it can't get its own external IPv4 address, e.g. if networking of the container is broken \*ahem\*
- Show IPv6 address in HTTP interface table
- Add debug option to overwrite the master server list

### Common
- `CreateAddressFromString()`  now supports parsing IPv6 addresses, however it does still filter out AAAA records of hostnames. This is not a problem, because it is only used to read the master and dedicated server lists, both of which must run on IPv4 (or dual-stack) as of now. At some point it should be refactored to return an array of addresses, including IPv6.
- `CreateEndpointFromString()` returns all addresses for a hostname, instead of the first. This fixes the direct connection feature if a hostname has an AAAA record but the server (or client) are not IPv6-enabled.  This was already broken before #445.
- A new `GetOwnInternalIPv6Address()` can return any available GUA address, it filters out link-locals and ULAs, first of which are non-routable and the second indicating that the machine is behind IPv6 NAT (ULA's are roughly equivalent to IPv4's RFC1918 subnets, 10.0.0.0/8 etc.).

### Build
- Some of the `PostBuildEvent` statements have been fixed to not run on *nix systems, they don't have `xcopy`.
- The DLL references in `MasterServer.csproj` are updated to match the ones in `LmpMasterServer.csproj`, so they are copied to the output directory, and it doesn't crash at startup trying to import the DLL.

## Future enhancements
- Look into port opening for IPv6 using [PCP](https://en.wikipedia.org/wiki/Port_Control_Protocol). It's not as heavily needed for the server, as firewall punch-through is much more likely to succeed via IPv6 due to the lack of NAT. And for the master server you should set up manual port forwardings/openings anyway for stability.
- Look into better ways to determine whether a server is on the same network as the client for IPv6 addresses. Maybe by checking whether the route has a gateway or is on-link?
- Make servers listen on IPv6 by default after thorough testing, so even casual users who don't look too deep into config files experience the benefits of IPv6.
- Support IPv6-only servers, make master servers listen on IPv6 as well. There is probably not much demand for this, and it is a little trickier to do, but maybe it's useful for some people.
