### PR TITLE
Fix master server auto-update with /nightly flag

### DIFF
--- a/LmpUpdater/Appveyor/AppveyorUpdateChecker.cs
+++ b/LmpUpdater/Appveyor/AppveyorUpdateChecker.cs
@@ -19,7 +19,7 @@ namespace LmpUpdater.Appveyor
                     {
                         wc.Headers.Add("user-agent", "Mozilla/4.0 (compatible; MSIE 6.0; Windows NT 5.2; .NET CLR 1.0.3705;)");
 
-                        var json = wc.DownloadString(RepoConstants.ApiLatestGithubReleaseUrl);
+                        var json = wc.DownloadString(RepoConstants.AppveyorUrl);
                         return JsonConvert.DeserializeObject<RootObject>(JObject.Parse(json).ToString());
                     }
                 }


### PR DESCRIPTION
(A version number is assumed to be in the form of MAJOR.MINOR.PATCH.BUILD in the following text, with BUILD being optional in most cases)

## Problems
The master server auto-update functionality for nightly releases is currently broken.
- It tries to reach the AppVeyor API using `RepoConstants.ApiLatestGithubReleaseUrl`, which should be `RepoConstants.AppveyorUrl` instead (nightly releases aren't published to GitHub)
- Even with the URL fixed, it'll only ever run the update when either MAJOR, MINOR or PATCH are bumped. This doesn't seem to happen very often. For nightly builds, only the BUILD number is incremented.

As an example, none of the "nightly" master servers seems to have picked up my IPv6 changes yet (which is easy to spot with the missing "IPv6 address" column in the HTTP UI).

### Fixes included in this PR:
- The API URL is fixed
- The auto-update logic also compares the BUILD parts of the DLL and the latest nightly build, basically making the nightly master servers update themselves after every commit to master (with a delay, of course).
- Local builds don't have a BUILD number in the assembly version, which we now use as indicator _not_ to run any updates (so it doesn't mess with debugging).
  This also prevents e.g. master servers running in Docker containers from doing auto-updates, but _usually_ this is desired. We could think about a `/force-update` flag or similar if there's demand to keep auto-updates in containers or other self-compiled deployments. Not sure how master server owners are running them, input welcome.
  
A manual update is required for these changes to reach already deployed master servers and have an effect.