### PR TITLE
move LMPModControl.xml to Config directory

### DIFF
--- a/Server/Context/ServerContext.cs
+++ b/Server/Context/ServerContext.cs
@@ -25,9 +25,9 @@ namespace Server.Context
         public static bool UsePassword => !string.IsNullOrEmpty(GeneralSettings.SettingsStore.Password);
 
         public static Stopwatch ServerClock = new Stopwatch();
-        public static string ModFilePath = Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "LMPModControl.xml");
         public static string UniverseDirectory = Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "Universe");
         public static string ConfigDirectory = Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "Config");
+        public static string ModFilePath = Path.Combine(ConfigDirectory, "LMPModControl.xml");
 
         // Configuration object
         public static NetPeerConfiguration Config { get; } = new NetPeerConfiguration("LMP")

--- a/Server/Context/ServerContext.cs
+++ b/Server/Context/ServerContext.cs
@@ -28,6 +28,7 @@ namespace Server.Context
         public static string UniverseDirectory = Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "Universe");
         public static string ConfigDirectory = Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "Config");
         public static string ModFilePath = Path.Combine(ConfigDirectory, "LMPModControl.xml");
+        public static string OldModFilePath = Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "LMPModControl.xml");
 
         // Configuration object
         public static NetPeerConfiguration Config { get; } = new NetPeerConfiguration("LMP")

--- a/Server/Context/Universe.cs
+++ b/Server/Context/Universe.cs
@@ -30,6 +30,8 @@ namespace Server.Context
         {
             LunaLog.Debug($"Loading universe... {GetUniverseSize()}{ByteSize.KiloByteSymbol}");
 
+            if (FileHandler.FileExists(ServerContext.OldModFilePath))
+                FileHandler.MoveFile(ServerContext.OldModFilePath, ServerContext.ModFilePath);
             if (!FileHandler.FileExists(ServerContext.ModFilePath))
                 ModFileSystem.GenerateNewModFile();
             if (!FileHandler.FolderExists(ServerContext.UniverseDirectory))


### PR DESCRIPTION
### Changes proposed in this PR:
Moving the LMPModControl.xml to the Config folder. It makes more sense to have it there, and it makes deploying docker containers easier since you won't have to make a volume just for the file if you are playing with mods.

This resolves #463 (it was a more simple change than I thought)