### PR TITLE
Fix DirectoryNotFoundException for new LMPModControl.xml path on first start

### DIFF
--- a/Server/Context/Universe.cs
+++ b/Server/Context/Universe.cs
@@ -30,10 +30,16 @@ namespace Server.Context
         {
             LunaLog.Debug($"Loading universe... {GetUniverseSize()}{ByteSize.KiloByteSymbol}");
 
-            if (FileHandler.FileExists(ServerContext.OldModFilePath))
-                FileHandler.MoveFile(ServerContext.OldModFilePath, ServerContext.ModFilePath);
+            if (!FileHandler.FolderExists(ServerContext.ConfigDirectory))
+                FileHandler.FolderCreate(ServerContext.ConfigDirectory);
             if (!FileHandler.FileExists(ServerContext.ModFilePath))
-                ModFileSystem.GenerateNewModFile();
+                if (FileHandler.FileExists(ServerContext.OldModFilePath))
+                    FileHandler.MoveFile(ServerContext.OldModFilePath, ServerContext.ModFilePath);
+                else
+                    ModFileSystem.GenerateNewModFile();
+            else
+                // Cleanup
+                FileHandler.FileDelete(ServerContext.OldModFilePath);
             if (!FileHandler.FolderExists(ServerContext.UniverseDirectory))
                 FileHandler.FolderCreate(ServerContext.UniverseDirectory);
 

--- a/Server/System/FileHandler.cs
+++ b/Server/System/FileHandler.cs
@@ -239,7 +239,7 @@ namespace Server.System
         }
 
         /// <summary>
-        /// Thread safe file deleting method
+        /// Thread safe file deleting method, checks for existence before removing the file
         /// </summary>
         /// <param name="path">Path of the file to remove</param>
         public static void FileDelete(string path)


### PR DESCRIPTION
## Problem
Caused by #465, the server throws an exception on completely fresh instances because we try to create `LMPModControl.xml` before the `Config` directory:
```
Exception: System.IO.DirectoryNotFoundException: Could not find a part of the path 'LMPServer-IOREx/Config/LMPModControl.xml'.
at Interop.ThrowExceptionForIoErrno(ErrorInfo errorInfo, String path, Boolean isDirectory, Func`2 errorRewriter)
at Microsoft.Win32.SafeHandles.SafeFileHandle.Open(String path, OpenFlags flags, Int32 mode)
at System.IO.FileStream.OpenHandle(FileMode mode, FileShare share, FileOptions options)
at System.IO.FileStream..ctor(String path, FileMode mode, FileAccess access, FileShare share, Int32 bufferSize, FileOptions options)
at System.IO.FileStream..ctor(String path, FileMode mode, FileAccess access)
at Server.System.FileHandler.WriteToFile(String path, Byte[] data, Int32 numBytes) in LunaMultiplayer/Server/System/FileHandler.cs:line 61
at Server.System.FileHandler.WriteToFile(String path, String text) in LunaMultiplayer/Server/System/FileHandler.cs:line 76
at Server.System.ModFileSystem.GenerateNewModFile() in LunaMultiplayer/Server/System/ModFileSystem.cs:line 19
at Server.Context.Universe.CheckUniverse() in LunaMultiplayer/Server/Context/Universe.cs:line 36
at Server.MainServer.Main() in LunaMultiplayer/Server/MainServer.cs:line 78
```

## Changes
Now we create the `Config` folder as first step in `CheckUniverse()`.
Additionally, the code is now a bit smarter and doesn#t try to move the file form the old location to the new location if it already exists in the new location (shouldn't happen in normal circumstances, but it helps if people play with the files).
And it cleans up the old location if it still exists despite the file also being present in the new location already.