### PR TITLE
Updated ABrit's Server on DedicatedServersList.txt

### DIFF
--- a/MasterServersList/DedicatedServersList.txt
+++ b/MasterServersList/DedicatedServersList.txt
@@ -35,7 +35,7 @@ zeus.styxnet.xyz:2100
 #Ship For Brains Server
 176.58.102.60
 #ABrit'sServer
-abrit.ddns.net:8800
+abritin.space:8800
 #Tserver
 ksp.trickys.gg:8800
 #Esbjerg Space Center


### PR DESCRIPTION
##### Thank you for contributing to LMP!

### Fixes included in this PR:

### Changes proposed in this PR: 
Changed from former address (abrit.ddns.net, no longer working) to functioning address (abritin.space) for ABrit's Server.
