### PR TITLE
Add debug stage to server Dockerfile, rework master server Dockerfile

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,7 @@
+**/bin/
+**/obj/
+.git/
+/Documentation/
+
+/Dockerfile*
+/External/KSPLibraries/KSPLibraries.7z

--- a/Dockerfile_MasterServer
+++ b/Dockerfile_MasterServer
@@ -11,13 +11,37 @@
 #Start a container with: docker start lmpms
 #Remove a container with: docker container rm lmpms
 
-FROM alpine:3.9
-RUN apk add --no-cache mono --repository http://dl-cdn.alpinelinux.org/alpine/edge/testing
-RUN apk add libgdiplus-dev --update-cache --repository http://dl-3.alpinelinux.org/alpine/edge/testing/ --allow-untrusted
-#RUN cd /usr/lib && sudo ln -s libgdiplus.so gdiplus.dll
+FROM mono:latest as builder
 
-ENV LMP_URL https://luna-masterserver-endpoint.glitch.me/latest
-ENV PORT 8700
-ENV HTTP_PORT 8701
-	
-CMD rm -f latest 2> /dev/null && wget $LMP_URL && unzip -o latest && cd LMPMasterServer && mono MasterServer.exe -p $PORT -g $HTTP_PORT
+RUN  curl -sSL https://dotnet.microsoft.com/download/dotnet/scripts/v1/dotnet-install.sh | bash /dev/stdin --channel 5.0
+ENV PATH="/root/.dotnet/:${PATH}"
+
+COPY LunaMultiPlayer.sln                    /LunaMultiplayer/LunaMultiPlayer.sln
+COPY Lidgren.Core/Lidgren.Core.csproj       /LunaMultiplayer/Lidgren.Core/Lidgren.Core.csproj
+COPY Lidgren.Net/Lidgren.Net.csproj         /LunaMultiplayer/Lidgren.Net/Lidgren.Net.csproj
+COPY Lidgren.Network/Lidgren.Network.csproj /LunaMultiplayer/Lidgren.Network/Lidgren.Network.csproj
+COPY uhttpsharp/uhttpsharp2.csproj          /LunaMultiplayer/uhttpsharp/uhttpsharp2.csproj
+COPY uhttpsharp/uhttpsharp.csproj           /LunaMultiplayer/uhttpsharp/uhttpsharp.csproj
+COPY LmpCommonTest/LmpCommonTest.csproj     /LunaMultiplayer/LmpCommonTest/LmpCommonTest.csproj
+COPY LmpUpdater/LmpUpdater.csproj           /LunaMultiplayer/LmpUpdater/LmpUpdater.csproj
+COPY LmpMasterServer/LmpMasterServer.csproj /LunaMultiplayer/LmpMasterServer/LmpMasterServer.csproj
+COPY MasterServer/MasterServer.csproj       /LunaMultiplayer/MasterServer/MasterServer.csproj
+COPY LmpUpdater/packages.config             /LunaMultiplayer/LmpUpdater/packages.config
+COPY uhttpsharp/packages.config             /LunaMultiplayer/uhttpsharp/packages.config
+COPY LmpMasterServer/packages.config        /LunaMultiplayer/LmpMasterServer/packages.config
+
+RUN cd LunaMultiplayer && \
+    nuget restore && \
+    cd MasterServer && \
+    dotnet restore
+
+COPY . /LunaMultiplayer
+WORKDIR /LunaMultiplayer/MasterServer
+RUN msbuild -p:Configuration=Release
+
+FROM mono:latest
+COPY --from=builder /LunaMultiplayer/MasterServer/bin/Release/ /LmpMasterServer/
+EXPOSE 8700/udp 8701/tcp
+STOPSIGNAL sigint
+WORKDIR /LmpMasterServer
+CMD [ "mono", "./MasterServer.exe" ]

--- a/Dockerfile_Server
+++ b/Dockerfile_Server
@@ -11,13 +11,45 @@
 #Start a container with: docker start lmpsrv
 #Remove a container with: docker container rm lmpsrv
 
-FROM mcr.microsoft.com/dotnet/sdk:5.0-alpine as builder
+ARG OS_BASE=alpine
+ARG OS_VERSION=3.14
+ARG OS_ARCH=x64
+
+FROM mcr.microsoft.com/dotnet/sdk:5.0-${OS_BASE}${OS_VERSION} as base
+ARG OS_BASE
+ARG OS_VERSION
+ARG OS_ARCH
+
+COPY LmpCommon/LmpCommon.shproj             /LunaMultiplayer/LmpCommon/LmpCommon.shproj
+COPY Lidgren/Lidgren.shproj                 /LunaMultiplayer/Lidgren/Lidgren.shproj
+COPY LmpGlobal/LmpGlobal.shproj             /LunaMultiplayer/LmpGlobal/LmpGlobal.shproj
+COPY Lidgren.Core/Lidgren.Core.csproj       /LunaMultiplayer/Lidgren.Core/Lidgren.Core.csproj
+COPY Lidgren.Net/Lidgren.Net.csproj         /LunaMultiplayer/Lidgren.Net/Lidgren.Net.csproj
+COPY Lidgren.Network/Lidgren.Network.csproj /LunaMultiplayer/Lidgren.Network/Lidgren.Network.csproj
+COPY uhttpsharp/uhttpsharp2.csproj          /LunaMultiplayer/uhttpsharp/uhttpsharp2.csproj
+COPY uhttpsharp/uhttpsharp.csproj           /LunaMultiplayer/uhttpsharp/uhttpsharp.csproj
+COPY LmpUpdater/LmpUpdater.csproj           /LunaMultiplayer/LmpUpdater/LmpUpdater.csproj
+COPY Server/Server.csproj                   /LunaMultiplayer/Server/Server.csproj
+
+RUN cd /LunaMultiplayer/Server && \
+    dotnet restore -r ${OS_BASE}.${OS_VERSION}-${OS_ARCH}
 
 COPY . /LunaMultiplayer
-RUN cd LunaMultiplayer/Server && \
-    dotnet publish -r linux-musl-x64 -o Publish
 
-FROM alpine:edge
+FROM base as debug
+WORKDIR /LunaMultiplayer/Server
+ENV DOTNET_PerfMapEnabled=1
+ENV COMPlus_PerfMapEnabled=1
+CMD [ "/bin/ash" ]
+
+FROM base as builder
+ARG OS_BASE
+ARG OS_VERSION
+ARG OS_ARCH
+WORKDIR /LunaMultiplayer/Server
+RUN dotnet publish -c Release -r ${OS_BASE}.${OS_VERSION}-${OS_ARCH} -o Publish
+
+FROM ${OS_BASE}:${OS_VERSION}
 RUN apk add icu-libs libstdc++ libgcc
 COPY --from=builder /LunaMultiplayer/Server/Publish/ /LMPServer/
 EXPOSE 8800/udp 8900/tcp

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,5 @@
 # You also need the Dockerfile_Server file, put it in the same directory as this file.
-# Build and create a container with: docker-compose up -d --build 
+# Build and create a container with: docker-compose up -d --build
 # You may set the version of the server when an update is released, see "args"
 #
 # Attach to the container with: docker-compose exec lunamultiplayer /bin/ash
@@ -10,15 +10,12 @@ services:
         build:
           context: ./
           dockerfile: Dockerfile_Server
-          args:
-             # set to desired version, available versions: https://github.com/LunaMultiplayer/LunaMultiplayer/releases    
-             - LMP_VERSION=0.25.0
         container_name: lunamultiplayer
         environment:
             - TZ=CET
         ports:
             - '8800:8800/udp'
-            # uncomment to enabler website
+            # uncomment to enable website
             # - '8900:8900'
         volumes:
             - '/opt/LMPServer/Config:/LMPServer/Config'


### PR DESCRIPTION
This reworks both Dockerfiles. The master server Dockerfile didn't actually built the project from source, but tried to download a build artifact from AppVeyor (which is broken).

## Changes
* Actually build master server from source
* Split into multiple stages and steps to better make use of build caching/layering
* Add debug stage to server Dockerfile, which sets some env vars to enhance dotnet debugging, and has `/bin/ash` as CMD so one can attach to the container and start the server using `dotnet run`

The images aren't exactly minimal, especially the master server one (~700MB). But mono:slim isn't enough to run the server, unfortunately. And mono's `mkbundle` to generate a self-contained executable is not very usable.

Based on this one could set up CI to automatically build and push the images to a Docker Registry of ones choice, e.g. [ghcr.io](https://github.com/features/packages).

I've had this sitting in a branch for a long long time, but now that I'm running my own master servers I think it's worth sharing and preserving the files here.
