### PR TITLE
Add flag to disable update checking for masterservers

### DIFF
--- a/LmpMasterServer/EntryPoint.cs
+++ b/LmpMasterServer/EntryPoint.cs
@@ -94,6 +94,7 @@ namespace LmpMasterServer
             Console.WriteLine("/p:<port>                ... Start with the specified port (default port is 8700)");
             Console.WriteLine("/g:<port>                ... Reply to get petitions on the specified port (default is 8701)");
             Console.WriteLine("/nightly                 ... Keep this master server updated with last nightly version");
+            Console.WriteLine("/noupdatecheck           ... Disable automatic updates");
             Console.WriteLine("/noupnp                  ... Disable upnp port forwarding");
             Console.WriteLine("");
         }

--- a/MasterServer/Program.cs
+++ b/MasterServer/Program.cs
@@ -11,11 +11,10 @@ using System.Threading.Tasks;
 namespace MasterServer
 {
     /// <summary>
-    /// This program is the one who does the punchtrough between a nat client and a nat server. 
+    /// This program is the one who does the punchtrough between a nat client and a nat server.
     /// You should only run if you agree in the forum to do so and your server ip is listed in:
     /// https://raw.githubusercontent.com/LunaMultiplayer/LunaMultiplayer/master/MasterServersList
     /// </summary>
-    /// 
     internal class Program
     {
         #region Fields & properties
@@ -38,7 +37,11 @@ namespace MasterServer
                 var dllVersion = FileVersionInfo.GetVersionInfo(DllPath).FileVersion;
                 var versionComponents = dllVersion.Split('.');
 
-                return new Version(int.Parse(versionComponents[0]), int.Parse(versionComponents[1]), int.Parse(versionComponents[2]));
+                return new Version(
+                    int.Parse(versionComponents[0]),
+                    int.Parse(versionComponents[1]),
+                    int.Parse(versionComponents[2])
+                    );
             }
         }
 
@@ -49,9 +52,9 @@ namespace MasterServer
 
         private static void Main(string[] args)
         {
-            //Uncomment this to properly debug the code
-            //LmpMasterServer.EntryPoint.MainEntryPoint(new string[0]);
-            //while (true) { Thread.Sleep(100); }
+            // Uncomment this to properly debug the code
+            // LmpMasterServer.EntryPoint.MainEntryPoint(args);
+            // while (true) { Thread.Sleep(100); }
 
             if (!File.Exists(DllPath))
             {
@@ -68,7 +71,10 @@ namespace MasterServer
                 eArgs.Cancel = true;
             };
 
-            CheckNewVersion(args.Any(a => a.Contains("nightly")));
+            if (!args.Any(a => a.Contains("noupdatecheck")))
+                CheckNewVersion(args.Any(a => a.Contains("nightly")));
+            else
+                Console.WriteLine("Automatic update checking disabled, please monitor for updates on your own.");
             StartMasterServerDll();
             QuitEvent.WaitOne();
         }


### PR DESCRIPTION
## Problem
When deploying through Docker images often there are other means to keep a container up to date.
And generally it's against the Docker philosophy to have software inside a container updating itself.
Also running a few masterservers side by side can quickly burn through GitHub's meager unauthenticated API request limit of 60 per hour.

~~And a issue I found running the unit tests:
`new UdpClient()` always creates an IPv4 socket, however if the NTP domain has an AAAA record the first address (`_serverAddress`) is an IPv6 address.
As a result `socket.Connect()` always throws an error about mismatching address families.~~
(cherry-picked to master)

## Changes
Thus I've added a `/noupdatecheck` flag, which disables the automatic update checking completely. As masterservers should always stay up to date with LMP, it prints a note reminding the user to keep an eye open for updates.
@gavazquez, what do you think about this?

~~Additionally this contains a fix for the NTP synchronization for IPv6-capable system. Now the address family of the NTP server address is passed to `new UdpClient()`, so the socket matches it.~~
(cherry-picked to master)