### PR TITLE
Lmp server fixes

### DIFF
--- a/Server/MainServer.cs
+++ b/Server/MainServer.cs
@@ -38,6 +38,8 @@ namespace Server
 
         public static readonly CancellationTokenSource CancellationTokenSrc = new CancellationTokenSource();
 
+        private static bool IsRestart = false;
+
         public static void Main()
         {
             try
@@ -129,6 +131,14 @@ namespace Server
                 LmpPluginHandler.FireOnServerStop();
 
                 LunaLog.Normal("So long and thanks for all the fish!");
+
+                if (IsRestart)
+                {
+                    //Start new server
+                    var serverExePath = Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location) + "\\Server.exe";
+                    var newProcLmpServer = new ProcessStartInfo { FileName = serverExePath };
+                    Process.Start(newProcLmpServer);
+                }
             }
             catch (Exception e)
             {
@@ -194,12 +204,10 @@ namespace Server
             CancellationTokenSrc.Cancel();
 
             Task.WaitAll(TaskContainer.ToArray());
-            QuitEvent.Set();
 
-            //Start new server
-            var serverExePath = Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location) + "\\Server.exe";
-            var newProcLmpServer = new ProcessStartInfo { FileName = serverExePath };
-            Process.Start(newProcLmpServer);
+            IsRestart = true;
+
+            QuitEvent.Set();
         }
     }
 }

--- a/Server/System/FlagSystem.cs
+++ b/Server/System/FlagSystem.cs
@@ -48,11 +48,15 @@ namespace Server.System
 
                 var flagOwner = Path.GetDirectoryName(serverFlag);
                 if (flagOwner == null) continue;
+
+                var flagData = File.ReadAllBytes(serverFlag);
+
                 flagList.Add(flagName, new FlagInfo
                 {
                     Owner = flagOwner,
-                    FlagData = File.ReadAllBytes(serverFlag),
-                    FlagName = flagName
+                    FlagData = flagData,
+                    FlagName = flagName,
+                    NumBytes = flagData.Length
                 });
             }
 


### PR DESCRIPTION
##### Thank you for contributing to LMP!

### Fixes included in this PR:

I have fixed two server bugs here:
- Custom flags did not display in-game
- Server would occasionally close and not restart when rebooted from the admin panel in the LMP menu window

Custom flags:
After some analysing it seemed that the client was expecting the field “NumBytes”. However, the server seems to not include this when sending the flag details. I have added the field and now custom flags seem to work again (tested with multiple players and several custom flags).

Server reboot by admin panel:
I have noticed several times that when the server is rebooted using the admin panel, it will have a small % chance of not rebooting and instead closing the console.
This seems to occur due to the fact that “QuitEvent.Set();” allows the “Main()” method to continue, occasionally reaching the end before “//Start new server” is reached, resulting in the application closing.
I have moved the restart logic to the Main() method, this ensures that it is always reached. I have also added a Boolean “IsRestart” that is used to indicate a restart by the “Restart()” method.


### Changes proposed in this PR:
