### PR TITLE
Port changes for DeltaServers in DedicatedServersList.txt

### DIFF
--- a/MasterServersList/DedicatedServersList.txt
+++ b/MasterServersList/DedicatedServersList.txt
@@ -36,6 +36,6 @@ server.emlynlj.co.uk:2185
 #Zandstraal Server
 zandstra.duckdns.org:8800
 #Delta Servers
-ksp.delabonifier.com:8800
-ksp.delabonifier.com:8820
-ksp.delabonifier.com:8830
+ksp.delabonifier.com:33790
+ksp.delabonifier.com:33792
+ksp.delabonifier.com:33793


### PR DESCRIPTION
### Changes proposed in this PR:

Due to an upcoming network infrastructure change, the ports on which these servers run needs to change.
I have not yet changed the ports on the servers, so they stay marked as dedicated until this PR is merged.