### PR TITLE
Feature: Prometheus Metrics Framework

### DIFF
--- a/Server/Client/ClientConnectionHandler.cs
+++ b/Server/Client/ClientConnectionHandler.cs
@@ -47,6 +47,9 @@ namespace Server.Client
                     MessageQueuer.RelayMessage<PlayerConnectionSrvMsg>(client, msgData);
                     LockSystem.ReleasePlayerLocks(client);
                     WarpSystem.RemoveSubspace(client.Subspace);
+
+                    // Remove the player from the metrics.
+                    Metrics.Player.RemovePlayer(client.PlayerName);
                 }
 
                 try

--- a/Server/Server.csproj
+++ b/Server/Server.csproj
@@ -19,6 +19,7 @@
     <PackageReference Include="LunaConfigNode" Version="1.8.1" />
     <PackageReference Include="Microsoft.VisualStudio.Threading" Version="16.10.56" />
     <PackageReference Include="open.nat.core" Version="2.1.0.5" />
+    <PackageReference Include="prometheus-net" Version="8.0.0" />
     <PackageReference Include="System.Drawing.Common" Version="6.0.0" />
   </ItemGroup>
 

--- a/Server/Server/Metrics/Player.cs
+++ b/Server/Server/Metrics/Player.cs
@@ -8,10 +8,10 @@ namespace Server.Metrics {
             new Prometheus.GaugeConfiguration{}
         );
 
-        public static readonly Prometheus.Counter Online = Prometheus.Metrics.CreateCounter(
+        public static readonly Prometheus.Gauge Online = Prometheus.Metrics.CreateGauge(
             "lmp_player_online",
             "Whether or not the player is currently online.",
-            new Prometheus.CounterConfiguration{LabelNames = new[] {"name"}}
+            new Prometheus.GaugeConfiguration{LabelNames = new[] {"name"}}
         );
 
         public static void AddPlayer(string name) {

--- a/Server/Server/Metrics/Player.cs
+++ b/Server/Server/Metrics/Player.cs
@@ -17,7 +17,7 @@ namespace Server.Metrics {
         public static void AddPlayer(string name) {
             Total.Inc(1);
 
-            if (MetricsSettings.SettingsStore.DetailedPlayerMetrics) {
+            if (MetricsSettings.SettingsStore.EnablePlayerDetailedMetrics) {
                 Online.WithLabels(name).IncTo(1);
             }
         }
@@ -25,7 +25,7 @@ namespace Server.Metrics {
         public static void RemovePlayer(string name) {
             Total.Inc(-1);
 
-            if (MetricsSettings.SettingsStore.DetailedPlayerMetrics) {
+            if (MetricsSettings.SettingsStore.EnablePlayerDetailedMetrics) {
                 Online.RemoveLabelled(name);
             }
         }

--- a/Server/Server/Metrics/Player.cs
+++ b/Server/Server/Metrics/Player.cs
@@ -1,0 +1,13 @@
+namespace Server.Metrics {
+    public class Player {
+        public static readonly Prometheus.Counter Count = Prometheus.Metrics.CreateCounter(
+            "lmp_player_online",
+            "Whether or not the player is currently online.",
+            new Prometheus.CounterConfiguration{LabelNames = new[] {"name"}}
+        );
+
+        public static void RemovePlayer(string name) {
+            Count.RemoveLabelled(name);
+        }
+    }
+}

--- a/Server/Server/Metrics/Player.cs
+++ b/Server/Server/Metrics/Player.cs
@@ -2,10 +2,10 @@ using Server.Settings.Structures;
 
 namespace Server.Metrics {
     public class Player {
-        public static readonly Prometheus.Counter Total = Prometheus.Metrics.CreateCounter(
+        public static readonly Prometheus.Gauge Total = Prometheus.Metrics.CreateGauge(
             "lmp_player_online_total",
             "The total count of unique players online.",
-            new Prometheus.CounterConfiguration{}
+            new Prometheus.GaugeConfiguration{}
         );
 
         public static readonly Prometheus.Counter Online = Prometheus.Metrics.CreateCounter(
@@ -15,7 +15,7 @@ namespace Server.Metrics {
         );
 
         public static void AddPlayer(string name) {
-            Total.Inc(1);
+            Total.Inc();
 
             if (MetricsSettings.SettingsStore.EnablePlayerDetailedMetrics) {
                 Online.WithLabels(name).IncTo(1);
@@ -23,7 +23,7 @@ namespace Server.Metrics {
         }
 
         public static void RemovePlayer(string name) {
-            Total.Inc(-1);
+            Total.Dec();
 
             if (MetricsSettings.SettingsStore.EnablePlayerDetailedMetrics) {
                 Online.RemoveLabelled(name);

--- a/Server/Server/Metrics/Player.cs
+++ b/Server/Server/Metrics/Player.cs
@@ -1,13 +1,33 @@
+using Server.Settings.Structures;
+
 namespace Server.Metrics {
     public class Player {
-        public static readonly Prometheus.Counter Count = Prometheus.Metrics.CreateCounter(
+        public static readonly Prometheus.Counter Total = Prometheus.Metrics.CreateCounter(
+            "lmp_player_online_total",
+            "The total count of unique players online.",
+            new Prometheus.CounterConfiguration{}
+        );
+
+        public static readonly Prometheus.Counter Online = Prometheus.Metrics.CreateCounter(
             "lmp_player_online",
             "Whether or not the player is currently online.",
             new Prometheus.CounterConfiguration{LabelNames = new[] {"name"}}
         );
 
+        public static void AddPlayer(string name) {
+            Total.Inc(1);
+
+            if (MetricsSettings.SettingsStore.DetailedPlayerMetrics) {
+                Online.WithLabels(name).IncTo(1);
+            }
+        }
+
         public static void RemovePlayer(string name) {
-            Count.RemoveLabelled(name);
+            Total.Inc(-1);
+
+            if (MetricsSettings.SettingsStore.DetailedPlayerMetrics) {
+                Online.RemoveLabelled(name);
+            }
         }
     }
 }

--- a/Server/Settings/Definition/MetricsSettingsDefinition.cs
+++ b/Server/Settings/Definition/MetricsSettingsDefinition.cs
@@ -1,0 +1,18 @@
+using LmpCommon.Enums;
+using LmpCommon.Xml;
+using System;
+
+namespace Server.Settings.Definition
+{
+    [Serializable]
+    public class MetricsSettingsDefinition
+    {
+        [XmlComment(Value = "Whether or not to enable the Prometheus metrics endpoint.")]
+        public bool Enabled { get; set; } = false;
+
+        [XmlComment(Value = "The endpoint to serve the Prometheus metrics on.")]
+        public string Endpoint { get; set; } = "metrics";
+
+        // TODO: toggle-able detailed metrics
+    }
+}

--- a/Server/Settings/Definition/MetricsSettingsDefinition.cs
+++ b/Server/Settings/Definition/MetricsSettingsDefinition.cs
@@ -13,10 +13,10 @@ namespace Server.Settings.Definition
         [XmlComment(Value = "Whether or not to include the default Prometheus metrics.")]
         public bool EnableDefaultMetrics { get; set; } = false;
 
+        [XmlComment(Value = "Whether or not to include detailed per-player metrics.")]
+        public bool EnablePlayerDetailedMetrics { get; set; } = true;
+
         [XmlComment(Value = "The endpoint to serve the Prometheus metrics on.")]
         public string Endpoint { get; set; } = "metrics";
-
-        [XmlComment(Value = "Whether or not to include detailed per-player metrics.")]
-        public bool DetailedPlayerMetrics { get; set; } = false;
     }
 }

--- a/Server/Settings/Definition/MetricsSettingsDefinition.cs
+++ b/Server/Settings/Definition/MetricsSettingsDefinition.cs
@@ -8,7 +8,10 @@ namespace Server.Settings.Definition
     public class MetricsSettingsDefinition
     {
         [XmlComment(Value = "Whether or not to enable the Prometheus metrics endpoint.")]
-        public bool Enabled { get; set; } = false;
+        public bool Enabled { get; set; } = true;
+
+        [XmlComment(Value = "Whether or not to include the default Prometheus metrics.")]
+        public bool EnableDefaultMetrics { get; set; } = false;
 
         [XmlComment(Value = "The endpoint to serve the Prometheus metrics on.")]
         public string Endpoint { get; set; } = "metrics";

--- a/Server/Settings/Definition/MetricsSettingsDefinition.cs
+++ b/Server/Settings/Definition/MetricsSettingsDefinition.cs
@@ -14,7 +14,7 @@ namespace Server.Settings.Definition
         public bool EnableDefaultMetrics { get; set; } = false;
 
         [XmlComment(Value = "Whether or not to include detailed per-player metrics.")]
-        public bool EnablePlayerDetailedMetrics { get; set; } = true;
+        public bool EnablePlayerDetailedMetrics { get; set; } = false;
 
         [XmlComment(Value = "The endpoint to serve the Prometheus metrics on.")]
         public string Endpoint { get; set; } = "metrics";

--- a/Server/Settings/Definition/MetricsSettingsDefinition.cs
+++ b/Server/Settings/Definition/MetricsSettingsDefinition.cs
@@ -13,6 +13,7 @@ namespace Server.Settings.Definition
         [XmlComment(Value = "The endpoint to serve the Prometheus metrics on.")]
         public string Endpoint { get; set; } = "metrics";
 
-        // TODO: toggle-able detailed metrics
+        [XmlComment(Value = "Whether or not to include detailed per-player metrics.")]
+        public bool DetailedPlayerMetrics { get; set; } = false;
     }
 }

--- a/Server/Settings/Structures/MetricsSettings.cs
+++ b/Server/Settings/Structures/MetricsSettings.cs
@@ -1,0 +1,10 @@
+using Server.Settings.Base;
+using Server.Settings.Definition;
+
+namespace Server.Settings.Structures
+{
+    public class MetricsSettings : SettingsBase<MetricsSettingsDefinition>
+    {
+        protected override string Filename => "MetricsSettings.xml";
+    }
+}

--- a/Server/System/HandshakeSystem.cs
+++ b/Server/System/HandshakeSystem.cs
@@ -46,7 +46,7 @@ namespace Server.System
                 MessageQueuer.RelayMessage<PlayerConnectionSrvMsg>(client, msgData);
 
                 // Update the player metrics.
-                Metrics.Player.Count.WithLabels(client.PlayerName).IncTo(1);
+                Metrics.Player.AddPlayer(client.PlayerName);
 
                 LunaLog.Debug($"Online Players: {ServerContext.PlayerCount}, connected: {ClientRetriever.GetClients().Length}");
             }

--- a/Server/System/HandshakeSystem.cs
+++ b/Server/System/HandshakeSystem.cs
@@ -45,6 +45,9 @@ namespace Server.System
                 msgData.PlayerName = client.PlayerName;
                 MessageQueuer.RelayMessage<PlayerConnectionSrvMsg>(client, msgData);
 
+                // Update the player metrics.
+                Metrics.Player.Count.WithLabels(client.PlayerName).IncTo(1);
+
                 LunaLog.Debug($"Online Players: {ServerContext.PlayerCount}, connected: {ClientRetriever.GetClients().Length}");
             }
         }

--- a/Server/Web/Handlers/MetricsHandler.cs
+++ b/Server/Web/Handlers/MetricsHandler.cs
@@ -3,6 +3,8 @@ using System;
 using System.Threading.Tasks;
 using System.IO;
 using uhttpsharp;
+using Server.Settings.Structures;
+using Server.Log;
 
 namespace Server.Web.Handlers {
   public class MetricsHandler : IHttpRequestHandler {
@@ -14,9 +16,12 @@ namespace Server.Web.Handlers {
     );
 
     public MetricsHandler() {
+      if (!MetricsSettings.SettingsStore.EnableDefaultMetrics) {
+        LunaLog.Info("Disabling default Prometheus metrics.");
+
       // Suppress the default metrics that come from the Prometheus client library.
-      // TODO: make this configurable?
       Prometheus.Metrics.SuppressDefaultMetrics();
+      }
 
       // Populate the build info metric.
       BuildInfo.WithLabels(LmpVersioning.CurrentVersion.ToString()).Set(1);

--- a/Server/Web/Handlers/MetricsHandler.cs
+++ b/Server/Web/Handlers/MetricsHandler.cs
@@ -19,8 +19,8 @@ namespace Server.Web.Handlers {
       if (!MetricsSettings.SettingsStore.EnableDefaultMetrics) {
         LunaLog.Info("Disabling default Prometheus metrics.");
 
-      // Suppress the default metrics that come from the Prometheus client library.
-      Prometheus.Metrics.SuppressDefaultMetrics();
+        // Suppress the default metrics that come from the Prometheus client library.
+        Prometheus.Metrics.SuppressDefaultMetrics();
       }
 
       // Populate the build info metric.

--- a/Server/Web/Handlers/MetricsHandler.cs
+++ b/Server/Web/Handlers/MetricsHandler.cs
@@ -5,6 +5,8 @@ using System.IO;
 using uhttpsharp;
 using Server.Settings.Structures;
 using Server.Log;
+using Server.Metrics;
+
 
 namespace Server.Web.Handlers {
   public class MetricsHandler : IHttpRequestHandler {
@@ -25,6 +27,9 @@ namespace Server.Web.Handlers {
 
       // Populate the build info metric.
       BuildInfo.WithLabels(LmpVersioning.CurrentVersion.ToString()).Set(1);
+
+      // Populate default metrics.
+      Player.Total.Set(0);
     }
 
     public Task Handle(IHttpContext context, Func<Task> next) {

--- a/Server/Web/Handlers/MetricsHandler.cs
+++ b/Server/Web/Handlers/MetricsHandler.cs
@@ -1,0 +1,33 @@
+using LmpCommon;
+using System;
+using System.Threading.Tasks;
+using System.IO;
+using uhttpsharp;
+
+namespace Server.Web.Handlers {
+  public class MetricsHandler : IHttpRequestHandler {
+
+    public static readonly Prometheus.Gauge BuildInfo = Prometheus.Metrics.CreateGauge(
+      "lmp_build_info",
+      "The build information of the Luna multiplayer server.",
+      new Prometheus.GaugeConfiguration{LabelNames = new[] {"version"}}
+    );
+
+    public MetricsHandler() {
+      // Suppress the default metrics that come from the Prometheus client library.
+      // TODO: make this configurable?
+      Prometheus.Metrics.SuppressDefaultMetrics();
+
+      // Populate the build info metric.
+      BuildInfo.WithLabels(LmpVersioning.CurrentVersion.ToString()).Set(1);
+    }
+
+    public Task Handle(IHttpContext context, Func<Task> next) {
+      // Write out the Prometheus metrics to the response.
+      var stream = new MemoryStream();
+      Prometheus.Metrics.DefaultRegistry.CollectAndExportAsTextAsync(stream);
+      context.Response = new HttpResponse("text/plain; version=0.0.4", stream, false);
+      return Task.Factory.GetCompleted();
+    }
+  }
+}

--- a/Server/Web/Handlers/MetricsHandler.cs
+++ b/Server/Web/Handlers/MetricsHandler.cs
@@ -27,12 +27,12 @@ namespace Server.Web.Handlers {
       BuildInfo.WithLabels(LmpVersioning.CurrentVersion.ToString()).Set(1);
     }
 
-    public Task Handle(IHttpContext context, Func<Task> next) {
+    public async Task Handle(IHttpContext context, Func<Task> next) {
       // Write out the Prometheus metrics to the response.
       var stream = new MemoryStream();
-      Prometheus.Metrics.DefaultRegistry.CollectAndExportAsTextAsync(stream);
+      await Prometheus.Metrics.DefaultRegistry.CollectAndExportAsTextAsync(stream);
       context.Response = new HttpResponse("text/plain; version=0.0.4", stream, false);
-      return Task.Factory.GetCompleted();
+      await Task.Factory.GetCompleted();
     }
   }
 }

--- a/Server/Web/Handlers/MetricsHandler.cs
+++ b/Server/Web/Handlers/MetricsHandler.cs
@@ -27,12 +27,12 @@ namespace Server.Web.Handlers {
       BuildInfo.WithLabels(LmpVersioning.CurrentVersion.ToString()).Set(1);
     }
 
-    public async Task Handle(IHttpContext context, Func<Task> next) {
+    public Task Handle(IHttpContext context, Func<Task> next) {
       // Write out the Prometheus metrics to the response.
       var stream = new MemoryStream();
-      await Prometheus.Metrics.DefaultRegistry.CollectAndExportAsTextAsync(stream);
+      _ = Prometheus.Metrics.DefaultRegistry.CollectAndExportAsTextAsync(stream);
       context.Response = new HttpResponse("text/plain; version=0.0.4", stream, false);
-      await Task.Factory.GetCompleted();
+      return Task.Factory.GetCompleted();
     }
   }
 }

--- a/Server/Web/WebServer.cs
+++ b/Server/Web/WebServer.cs
@@ -1,4 +1,4 @@
-﻿using LmpCommon;
+using LmpCommon;
 using Server.Context;
 using Server.Events;
 using Server.Log;
@@ -68,7 +68,7 @@ namespace Server.Web
 
                         // If the Prometheus endpoint is enabled, build and add the HttpRouter to handle it to the server.
                         if (MetricsSettings.SettingsStore.Enabled) {
-                            LunaLog.Info("enabling Prometheus endpoint");
+                            LunaLog.Info("Enabling Prometheus endpoint");
                             Server.Use(
                                 new HttpRouter().With(
                                     MetricsSettings.SettingsStore.Endpoint,

--- a/Server/Web/WebServer.cs
+++ b/Server/Web/WebServer.cs
@@ -65,6 +65,18 @@ namespace Server.Web
                         Server.Use(new ExceptionHandler());
                         Server.Use(new CompressionHandler(DeflateCompressor.Default, GZipCompressor.Default));
                         Server.Use(new HttpRouter().With(string.Empty, new RestHandler<ServerInformation>(new ServerInformationRestController(), JsonResponseProvider.Default)));
+
+                        // If the Prometheus endpoint is enabled, build and add the HttpRouter to handle it to the server.
+                        if (MetricsSettings.SettingsStore.Enabled) {
+                            LunaLog.Info("enabling Prometheus endpoint");
+                            Server.Use(
+                                new HttpRouter().With(
+                                    MetricsSettings.SettingsStore.Endpoint,
+                                    new MetricsHandler()
+                                )
+                            );
+                        }
+
                         Server.Start();
                     }
                     else

--- a/Server/Web/WebServer.cs
+++ b/Server/Web/WebServer.cs
@@ -64,18 +64,19 @@ namespace Server.Web
                         Server.Use(new TcpListenerAdapter(listener));
                         Server.Use(new ExceptionHandler());
                         Server.Use(new CompressionHandler(DeflateCompressor.Default, GZipCompressor.Default));
-                        Server.Use(new HttpRouter().With(string.Empty, new RestHandler<ServerInformation>(new ServerInformationRestController(), JsonResponseProvider.Default)));
 
-                        // If the Prometheus endpoint is enabled, build and add the HttpRouter to handle it to the server.
+                        var httpRouter = new HttpRouter();
+                        httpRouter.With(string.Empty, new RestHandler<ServerInformation>(new ServerInformationRestController(), JsonResponseProvider.Default));
+
+                        // If the Prometheus endpoint is enabled, add it to the HttpRouter.
                         if (MetricsSettings.SettingsStore.Enabled) {
                             LunaLog.Info("Enabling Prometheus endpoint");
-                            Server.Use(
-                                new HttpRouter().With(
-                                    MetricsSettings.SettingsStore.Endpoint,
-                                    new MetricsHandler()
-                                )
+                            httpRouter.With(
+                                MetricsSettings.SettingsStore.Endpoint,
+                                new MetricsHandler()
                             );
                         }
+                        Server.Use(httpRouter);
 
                         Server.Start();
                     }


### PR DESCRIPTION
<!-- Thank you for contributing to LMP!

If you are adding a dedicated server, please read https://github.com/LunaMultiplayer/LunaMultiplayer/wiki/Dedicated-server first,
especially:
* Your server doesn't need to be listed as "dedicated server" to show up in the server browser.
* Dedicated servers should have either a static IP address or working DynDNS
* Port forwarding should be set up statically, or at least UPnP needs to work reliably
* Dedicated servers should not be password protected
* Dedicated servers need to be available 24/7

Please confirm that you have read and verified all of the above.
-->
### Changes proposed in this PR:
This is a revamp of an old PR (#479) of mine. I'm getting back into KSP and would like a server that can export metrics in a way that Prometheus can scrape and capture them, allowing me to easily view trends over time in something like Grafana.

I decided to create a new branch and a new PR to avoid cleaning up the old one and to refresh my own memory as to how this works.

This initial PR just establishes a basic endpoint for Prometheus metrics and only exposes two metrics: one for total online player count as well as one for online status of individual players (if detailed player metrics are enabled).

If this is accepted I will create PRs to add individual groups of metrics to the server.
Looking at what I've done in the past for an old server of mine this would/could include:
- Space Program Metrics
  - Funds
  - Science
  - Reputation
- Vessel Metrics
  - Position
  - Orbital Elements
  - Staging
  - Resource Levels
- Facility Metrics
  - Levels
  - maybe damage?
- Contract Metrics
  - State of available contracts (i.e. rewards, accepted/offered)
- Technology Metrics
  - Science cost
  - Number of parts
- Subspace Metrics
  - Time difference of each subspace from server
- Kerbal Metrics
  - Attributes (bravery, dumb, etc.)
  - Flight Counts
  - Deaths
  - Recoveries
