### PR TITLE
Add a new server

### DIFF
--- a/MasterServersList/DedicatedServersList.txt
+++ b/MasterServersList/DedicatedServersList.txt
@@ -39,3 +39,5 @@ zandstra.duckdns.org:8800
 ksp.delabonifier.com:33790
 ksp.delabonifier.com:33792
 ksp.delabonifier.com:33793
+#Sprout Software
+ksp.sprout.software:503


### PR DESCRIPTION
- Adds ksp.sprout.software port 503, which is hosted 24/7 on a spare VM i have.

<!-- Thank you for contributing to LMP!

If you are adding a dedicated server, please read https://github.com/LunaMultiplayer/LunaMultiplayer/wiki/Dedicated-server first,
especially:
* Your server doesn't need to be listed as "dedicated server" to show up in the server browser.
* Dedicated servers should have either a static IP address or working DynDNS
* Port forwarding should be set up statically, or at least UPnP needs to work reliably
* Dedicated servers should not be password protected
* Dedicated servers need to be available 24/7

Please confirm that you have read and verified all of the above.
-->
### Fixes included in this PR:

### Changes proposed in this PR:
