### PR TITLE
Remove tourism contracts

### DIFF
--- a/LmpClient/Systems/ShareContracts/ShareContractsEvents.cs
+++ b/LmpClient/Systems/ShareContracts/ShareContractsEvents.cs
@@ -110,9 +110,17 @@ namespace LmpClient.Systems.ShareContracts
                 return;
             }
 
-            if (contract.GetType() == typeof(RecoverAsset))
+            if (contract.GetType().Name == "RecoverAsset")
             {
                 //We don't support rescue contracts. See: https://github.com/LunaMultiplayer/LunaMultiplayer/issues/226#issuecomment-431831526
+                contract.Withdraw();
+                contract.Kill();
+                return;
+            }
+
+            if (contract.GetType().Name == "TourismContract")
+            {
+                //We don't support tourism contracts.
                 contract.Withdraw();
                 contract.Kill();
                 return;


### PR DESCRIPTION
### Fixes included in this PR:

Removed tourism contracts, as per [wiki](https://github.com/LunaMultiplayer/LunaMultiplayer/wiki/Limitations#tourist-contracts).

These types of contracts are impossible to complete and tourists stay among crew indefinitely. It's the best to remove them altogether, like rescue contracts.

### Changes proposed in this PR:

- Added tourism contracts to exclusion list
- Changed contract type gathering by their `.Name` property, as current approach was not working with all types of contracts.

Fixes #457 