### PR TITLE
Fix game parameter syncing to not overwrite unrelated existing game parameters

### DIFF
--- a/LmpClient/MainSystem.cs
+++ b/LmpClient/MainSystem.cs
@@ -363,8 +363,8 @@ namespace LmpClient
             //Set the game mode
             HighLogic.CurrentGame.Mode = ConvertGameMode(SettingsSystem.ServerSettings.GameMode);
 
-            //Set difficulty
-            HighLogic.CurrentGame.Parameters = SettingsSystem.ServerSettings.ServerParameters;
+            //Set game parameters without overwriting extra ones
+            SetParams(HighLogic.CurrentGame);
             SetAdvancedParams(HighLogic.CurrentGame);
             SetCommNetParams(HighLogic.CurrentGame);
 
@@ -386,6 +386,16 @@ namespace LmpClient
             GamePersistence.SaveGame(HighLogic.CurrentGame, "persistent", HighLogic.SaveFolder, SaveMode.OVERWRITE);
             HighLogic.CurrentGame.Start();
             LunaLog.Log("[LMP]: Started!");
+        }
+
+        public void SetParams(Game currentGame)
+        {
+            currentGame.Parameters.Flight = SettingsSystem.ServerSettings.ServerParameters.Flight;
+            currentGame.Parameters.Editor = SettingsSystem.ServerSettings.ServerParameters.Editor;
+            currentGame.Parameters.TrackingStation = SettingsSystem.ServerSettings.ServerParameters.TrackingStation;
+            currentGame.Parameters.SpaceCenter = SettingsSystem.ServerSettings.ServerParameters.SpaceCenter;
+            currentGame.Parameters.Difficulty = SettingsSystem.ServerSettings.ServerParameters.Difficulty;
+            currentGame.Parameters.Career = SettingsSystem.ServerSettings.ServerParameters.Career;
         }
 
         public void SetAdvancedParams(Game currentGame)


### PR DESCRIPTION
<!-- Thank you for contributing to LMP!

If you are adding a dedicated server, please read https://github.com/LunaMultiplayer/LunaMultiplayer/wiki/Dedicated-server first,
especially:
* Your server doesn't need to be listed as "dedicated server" to show up in the server browser.
* Dedicated servers should have either a static IP address or working DynDNS
* Port forwarding should be set up statically, or at least UPnP needs to work reliably
* Dedicated servers should not be password protected
* Dedicated servers need to be available 24/7

Please confirm that you have read and verified all of the above.
-->
### Fixes included in this PR:
Fixes the constant resetting of parameters set by mods like CTB (Click-Through-Blocker) every time you connect to a server.
Probably solves the issue encountered in #587.

### Changes proposed in this PR:
- Overwrite only predefined sections of parameters instead of the entire block.