### PR TITLE
bugfix: Remove experimental parts after contract is completed

### DIFF
--- a/Server/System/Scenario/ScenarioPartPurchaseDataUpdater.cs
+++ b/Server/System/Scenario/ScenarioPartPurchaseDataUpdater.cs
@@ -1,5 +1,6 @@
 ﻿using LmpCommon.Message.Data.ShareProgress;
 using LunaConfigNode.CfgNode;
+using Server.Log;
 using System.Globalization;
 using System.Threading.Tasks;
 
@@ -36,13 +37,18 @@ namespace Server.System.Scenario
                     else
                     {
                         if (experimentalPartMsg.Count == 0)
-                            expPartNode.Value.RemoveValue(specificExpPart.Value);
+                        {
+                            expPartNode?.Value.RemoveValue(experimentalPartMsg.PartName);
+                            LunaLog.Debug($"Removing experimental part: {experimentalPartMsg.PartName}");
+                        }
                         else
                             specificExpPart.Value = experimentalPartMsg.Count.ToString(CultureInfo.InvariantCulture);
                     }
 
                     if (expPartNode?.Value.GetAllValues().Count == 0)
-                        scenario.RemoveNode(expPartNode.Value);
+                        expPartNode.Value.CreateValue(new CfgNodeValue<string, string>("dummyPart", "0"));
+                        // Create a dummy part - LMP treats empty expPartsNode as null, which causes creating a new one
+                    ScenarioStoreSystem.BackupScenarios();
                 }
             });
         }


### PR DESCRIPTION
<!-- Thank you for contributing to LMP!

If you are adding a dedicated server, please read https://github.com/LunaMultiplayer/LunaMultiplayer/wiki/Dedicated-server first,
especially:
* Your server doesn't need to be listed as "dedicated server" to show up in the server browser.
* Dedicated servers should have either a static IP address or working DynDNS
* Port forwarding should be set up statically, or at least UPnP needs to work reliably
* Dedicated servers should not be password protected
* Dedicated servers need to be available 24/7

Please confirm that you have read and verified all of the above.
-->
### Fixes included in this PR:

Experimental parts being present indefinitely after contract is finished.

### Changes proposed in this PR:

- Remove experimental parts when contract is complete.
- Fix issue with `expPartsNode` duplicating when no experimental parts are inside