### PR TITLE
Fix CI with .NET 10

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -3,7 +3,7 @@
 {
 	"name": "C# (.NET)",
 	// Or use a Dockerfile or Docker Compose file. More info: https://containers.dev/guide/dockerfile
-	"image": "mcr.microsoft.com/devcontainers/dotnet:1-10.0",
+	"image": "mcr.microsoft.com/devcontainers/dotnet:2-10.0",
 	"features": {
 		"ghcr.io/devcontainers/features/docker-in-docker:2": {
 			"moby": true,

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -58,10 +58,19 @@ before_build:
   - ps: mkdir "$env:appveyor_build_folder\FinalFiles\$env:configuration\LMPClient\GameData\LunaMultiplayer\"
    #Copy harmony dependency
   - ps: xcopy /y /s "$env:appveyor_build_folder\External\Dependencies\Harmony" "$env:appveyor_build_folder\FinalFiles\$env:configuration\LMPClient\GameData"
-  - nuget restore
-build:
-  parallel: true
-  verbosity: minimal
+  - dotnet restore
+build_script:
+ # Client build commands
+ # Use more up to date MSBuild included in manual dotnet installation
+ - ps: dotnet msbuild -m -verbosity:minimal
+ # Master server build commands
+ - ps: dotnet publish "$env:appveyor_build_folder\MasterServer\MasterServer.csproj" --configuration $env:CONFIGURATION --output "$env:appveyor_build_folder\FinalFiles\$env:configuration\LMPMasterServer" --os linux --self-contained false -p:PublishSingleFile=false
+ # Server build commands
+ - ps: dotnet publish "$env:appveyor_build_folder\Server\Server.csproj" --configuration $env:CONFIGURATION --output "$env:appveyor_build_folder\FinalFiles\win-x64-$env:configuration\LMPServer" --os win --self-contained true -p:PublishSingleFile=false -p:PublishTrimmed=true
+ - ps: dotnet publish "$env:appveyor_build_folder\Server\Server.csproj" --configuration $env:CONFIGURATION --output "$env:appveyor_build_folder\FinalFiles\linux-x64-$env:configuration\LMPServer" --os linux --self-contained true -p:PublishSingleFile=false -p:PublishTrimmed=true
+ - ps: dotnet publish "$env:appveyor_build_folder\Server\Server.csproj" --configuration $env:CONFIGURATION --output "$env:appveyor_build_folder\FinalFiles\linux-arm64-$env:configuration\LMPServer" --os linux --arch arm64 --self-contained true -p:PublishSingleFile=false -p:PublishTrimmed=true
+ - ps: dotnet publish "$env:appveyor_build_folder\Server\Server.csproj" --configuration $env:CONFIGURATION --output "$env:appveyor_build_folder\FinalFiles\linux-arm-$env:configuration\LMPServer" --os linux --arch arm --self-contained true -p:PublishSingleFile=false -p:PublishTrimmed=true
+ - ps: dotnet publish "$env:appveyor_build_folder\Server\Server.csproj" --configuration $env:CONFIGURATION --output "$env:appveyor_build_folder\FinalFiles\any-$env:configuration\LMPServer" --self-contained false -p:PublishSingleFile=false
 after_build:
  #Client post build commands
  - ps: mkdir "$env:appveyor_build_folder\FinalFiles\$env:configuration\LMPClient\GameData\LunaMultiplayer\Button"
@@ -78,14 +87,6 @@ after_build:
  - ps: xcopy /y /s "$env:appveyor_build_folder\LmpClient\ModuleStore\XML\*.*" "$env:appveyor_build_folder\FinalFiles\$env:configuration\LMPClient\GameData\LunaMultiplayer\PartSync"
  - ps: xcopy /y "$env:appveyor_build_folder\LmpClient\Resources\Icons\*.*" "$env:appveyor_build_folder\FinalFiles\$env:configuration\LMPClient\GameData\LunaMultiplayer\Icons"
  - ps: xcopy /y "$env:appveyor_build_folder\LmpClient\Resources\Flags\*.*" "$env:appveyor_build_folder\FinalFiles\$env:configuration\LMPClient\GameData\LunaMultiplayer\Flags"
- #Master server post build commands
- - ps: dotnet publish "$env:appveyor_build_folder\MasterServer\MasterServer.csproj" --configuration $env:CONFIGURATION --output "$env:appveyor_build_folder\FinalFiles\$env:configuration\LMPMasterServer" --os linux --self-contained false -p:PublishSingleFile=false
- #Server post build commands
- - ps: dotnet publish "$env:appveyor_build_folder\Server\Server.csproj" --configuration $env:CONFIGURATION --output "$env:appveyor_build_folder\FinalFiles\win-x64-$env:configuration\LMPServer" --os win --self-contained true -p:PublishSingleFile=false -p:PublishTrimmed=true
- - ps: dotnet publish "$env:appveyor_build_folder\Server\Server.csproj" --configuration $env:CONFIGURATION --output "$env:appveyor_build_folder\FinalFiles\linux-x64-$env:configuration\LMPServer" --os linux --self-contained true -p:PublishSingleFile=false -p:PublishTrimmed=true
- - ps: dotnet publish "$env:appveyor_build_folder\Server\Server.csproj" --configuration $env:CONFIGURATION --output "$env:appveyor_build_folder\FinalFiles\linux-arm64-$env:configuration\LMPServer" --os linux --arch arm64 --self-contained true -p:PublishSingleFile=false -p:PublishTrimmed=true
- - ps: dotnet publish "$env:appveyor_build_folder\Server\Server.csproj" --configuration $env:CONFIGURATION --output "$env:appveyor_build_folder\FinalFiles\linux-arm-$env:configuration\LMPServer" --os linux --arch arm --self-contained true -p:PublishSingleFile=false -p:PublishTrimmed=true
- - ps: dotnet publish "$env:appveyor_build_folder\Server\Server.csproj" --configuration $env:CONFIGURATION --output "$env:appveyor_build_folder\FinalFiles\any-$env:configuration\LMPServer" --self-contained false -p:PublishSingleFile=false
  #7zip everything
  - ps: 7z a "$env:appveyor_build_folder\LunaMultiplayer-Client-$env:configuration.zip" "$env:appveyor_build_folder\FinalFiles\$env:configuration\LMP Readme.txt" "$env:appveyor_build_folder\FinalFiles\$env:configuration\LMPClient\GameData"
  - ps: 7z a "$env:appveyor_build_folder\LunaMultiplayer-Server-win-x64-$env:configuration.zip" "$env:appveyor_build_folder\FinalFiles\$env:configuration\LMP Readme.txt" "$env:appveyor_build_folder\FinalFiles\win-x64-$env:configuration\LMPServer"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -66,10 +66,10 @@ build_script:
  # Master server build commands
  - ps: dotnet publish "$env:appveyor_build_folder\MasterServer\MasterServer.csproj" --configuration $env:CONFIGURATION --output "$env:appveyor_build_folder\FinalFiles\$env:configuration\LMPMasterServer" --os linux --self-contained false -p:PublishSingleFile=false
  # Server build commands
- - ps: dotnet publish "$env:appveyor_build_folder\Server\Server.csproj" --configuration $env:CONFIGURATION --output "$env:appveyor_build_folder\FinalFiles\win-x64-$env:configuration\LMPServer" --os win --self-contained true -p:PublishSingleFile=false -p:PublishTrimmed=true
- - ps: dotnet publish "$env:appveyor_build_folder\Server\Server.csproj" --configuration $env:CONFIGURATION --output "$env:appveyor_build_folder\FinalFiles\linux-x64-$env:configuration\LMPServer" --os linux --self-contained true -p:PublishSingleFile=false -p:PublishTrimmed=true
- - ps: dotnet publish "$env:appveyor_build_folder\Server\Server.csproj" --configuration $env:CONFIGURATION --output "$env:appveyor_build_folder\FinalFiles\linux-arm64-$env:configuration\LMPServer" --os linux --arch arm64 --self-contained true -p:PublishSingleFile=false -p:PublishTrimmed=true
- - ps: dotnet publish "$env:appveyor_build_folder\Server\Server.csproj" --configuration $env:CONFIGURATION --output "$env:appveyor_build_folder\FinalFiles\linux-arm-$env:configuration\LMPServer" --os linux --arch arm --self-contained true -p:PublishSingleFile=false -p:PublishTrimmed=true
+ - ps: dotnet publish "$env:appveyor_build_folder\Server\Server.csproj" --configuration $env:CONFIGURATION --output "$env:appveyor_build_folder\FinalFiles\win-x64-$env:configuration\LMPServer" --os win --self-contained true -p:PublishSingleFile=false -p:PublishTrimmed=false
+ - ps: dotnet publish "$env:appveyor_build_folder\Server\Server.csproj" --configuration $env:CONFIGURATION --output "$env:appveyor_build_folder\FinalFiles\linux-x64-$env:configuration\LMPServer" --os linux --self-contained true -p:PublishSingleFile=false -p:PublishTrimmed=false
+ - ps: dotnet publish "$env:appveyor_build_folder\Server\Server.csproj" --configuration $env:CONFIGURATION --output "$env:appveyor_build_folder\FinalFiles\linux-arm64-$env:configuration\LMPServer" --os linux --arch arm64 --self-contained true -p:PublishSingleFile=false -p:PublishTrimmed=false
+ - ps: dotnet publish "$env:appveyor_build_folder\Server\Server.csproj" --configuration $env:CONFIGURATION --output "$env:appveyor_build_folder\FinalFiles\linux-arm-$env:configuration\LMPServer" --os linux --arch arm --self-contained true -p:PublishSingleFile=false -p:PublishTrimmed=false
  - ps: dotnet publish "$env:appveyor_build_folder\Server\Server.csproj" --configuration $env:CONFIGURATION --output "$env:appveyor_build_folder\FinalFiles\any-$env:configuration\LMPServer" --self-contained false -p:PublishSingleFile=false
 after_build:
  #Client post build commands


### PR DESCRIPTION
### Fixes included in this PR:
This should fix Appveyor CI by switching the actual build and nuget restore to the MSBuild included in the manually installed dotnet CLI instead of using the pre-installed VS 2022 one (some MSBuild 17.x build). The pre-installed one was not able to build the project after the changes of #615.

Also disable trimming of the binaries, as this seems to be hard to impossible to get working in newer .NET releases, I already fought with it for #577 back then.
Unfortunately this will mean that the build sizes will increase by a lot (at least from what I remember), especially for the self-contained builds.

A third small fix is a bump of the devcontainer base image "base version", as otherwise the devcontainer build fails due to some external issues (outdated GPG key for Yarn in the base image).