### PR TITLE
Fix launching server with Docker

### DIFF
--- a/Dockerfile_Server
+++ b/Dockerfile_Server
@@ -61,7 +61,7 @@ RUN case "${TARGETARCH}" in \
     arm) DOTNET_RID=linux-musl-arm ;; \
     *) echo "Unsupported TARGETARCH=${TARGETARCH}"; exit 1 ;; \
   esac && \
-  dotnet publish -c Release -r ${DOTNET_RID} -o Publish
+  dotnet publish -c Release -r ${DOTNET_RID} --self-contained true -o Publish
 
 FROM ${OS_BASE}:${OS_VERSION}
 RUN apk add icu-libs libstdc++ libgcc


### PR DESCRIPTION
Before fix when launching server using latest docker image the following message is displayed:
<details>
<summary>Docker logs</summary>

```
ksp  | You must install .NET to run this application.
ksp  | 
ksp  | App: /LMPServer/Server
ksp  | Architecture: arm64
ksp  | App host version: 10.0.5
ksp  | .NET location: Not found
ksp  | 
ksp  | The following locations were searched:
ksp  |   Application directory:
ksp  |     /LMPServer/
ksp  |   Environment variable:
ksp  |     DOTNET_ROOT_ARM64 = <not set>
ksp  |     DOTNET_ROOT = <not set>
ksp  |   Registered location:
ksp  |     /etc/dotnet/install_location_arm64 = <not set>
ksp  |   Default location:
ksp  |     /usr/share/dotnet
ksp  | 
ksp  | Learn more:
ksp  | https://aka.ms/dotnet/app-launch-failed
ksp  | 
ksp  | Download the .NET runtime:
ksp  | https://aka.ms/dotnet-core-applaunch?missing_runtime=true&arch=arm64&rid=linux-musl-arm64&os=alpine.3.20&apphost_version=10.0.5
```
</details>