### PR TITLE
Changes the build script so that if there is no KSPPATH specified, no assumption

### DIFF
--- a/Scripts/CopyToKSPDirectory.bat
+++ b/Scripts/CopyToKSPDirectory.bat
@@ -7,7 +7,7 @@
 :: SET KSPPATH2=C:\Users\Malte\Desktop\Kerbal Space Program
 call "%~dp0\SetDirectories.bat"
 
-IF DEFINED KSPPATH (ECHO KSPPATH is defined) ELSE (SET KSPPATH=C:\Kerbal Space Program)
+IF DEFINED KSPPATH (ECHO KSPPATH is defined) ELSE (ECHO KSPPATH not set in SetDirectories.bat — skipping KSP install. && EXIT /B 0)
 IF DEFINED KSPPATH2 (ECHO KSPPATH2 is defined)
 ::%1
 SET SOLUTIONCONFIGURATION=Debug


### PR DESCRIPTION
## Summary

Previously, `CopyToKSPDirectory.bat` would proceed with the copy operations even when `KSPPATH` was not set in `SetDirectories.bat`, which could lead it to silently assume a default path (e.g. `C:/KSP`) and either fail unexpectedly or copy files to the wrong location on machines where KSP is not installed there.

This change adds an explicit check at the top of `CopyToKSPDirectory.bat`: if `KSPPATH` is not defined, the script now prints a clear message (`KSPPATH not set in SetDirectories.bat — skipping KSP install.`) and exits cleanly with code `0`. This makes the KSP install step opt-in — contributors who have not configured a local KSP path will no longer encounter spurious errors or unintended file system side effects during the build.

`KSPPATH2` behavior is unchanged; it remains optional and is only acted upon when defined.
