### PR TITLE
Fix: NaN orbit no longer permanently deletes vessel from server

### DIFF
--- a/LmpClient/Harmony/OrbitDriver_UpdateFromParameters.cs
+++ b/LmpClient/Harmony/OrbitDriver_UpdateFromParameters.cs
@@ -48,8 +48,12 @@ namespace LmpClient.Harmony
                     Debug.LogWarning(string.Concat("[LMP - OrbitDriver Warning!]: ", driver.vessel.vesselName, " had a NaN Orbit and was removed."));
                     driver.vessel.Unload();
 
-                    VesselRemoveSystem.Singleton.MessageSender.SendVesselRemove(driver.vessel.id, true);
-                    VesselRemoveSystem.Singleton.KillVessel(driver.vessel.id, true, "Corrupt vessel orbit");
+                    // Do NOT send a server remove for a corrupt orbit — the orbit data is a client-side load
+                    // issue (bad server ConfigNode) and the server should keep the vessel so it can be
+                    // repaired by an admin.  Sending remove here permanently deletes the vessel from the
+                    // server and adds it to the in-memory kill-list, making recovery impossible without a
+                    // server restart.
+                    VesselRemoveSystem.Singleton.KillVessel(driver.vessel.id, false, "Corrupt vessel orbit");
 
                     return;
                 }


### PR DESCRIPTION
When a vessel's orbit calculation produces NaN (typically from patched-conics numerical instability during SOI transitions), the current code sends VesselRemove to the server and calls KillVessel with addToKillList=true. This permanently deletes the .vcproto file and adds the vessel to the in-memory kill list, making it irrecoverable for all players without a server restart and manual file restoration.

The NaN is a client-side calculation artifact -- the server's stored data is almost always valid. This change removes the SendVesselRemove call and passes false to KillVessel, so the vessel is cleaned up locally but the server retains it. Other clients are unaffected, and the vessel reloads normally on reconnect.

Normal vessel destruction (crashes, overheating, overpressure, G-forces) is unaffected -- those go through Part.Die / Vessel.Die / onVesselWillDestroy, a completely separate code path.