### PR TITLE
Fix: warp display missing local player and duplicate entries

### DIFF
--- a/LmpClient/Systems/Warp/WarpEntryDisplay.cs
+++ b/LmpClient/Systems/Warp/WarpEntryDisplay.cs
@@ -32,12 +32,16 @@ namespace LmpClient.Systems.Warp
         /// </summary>
         private static void FillSubspaceDisplayEntriesNoneSubspace()
         {
-            if (System.SubspaceEntries.Count != 1 || System.ClientSubspaceList.Keys.Count != System.SubspaceEntries[0].Players.Count)
+            //Ensure the local player is in the dictionary (may not be if called before CurrentSubspace is set)
+            if (!System.ClientSubspaceList.ContainsKey(SettingsSystem.CurrentSettings.PlayerName))
+                System.ClientSubspaceList.TryAdd(SettingsSystem.CurrentSettings.PlayerName, 0);
+
+            var playerCount = System.ClientSubspaceList.Keys.Count;
+            if (System.SubspaceEntries.Count != 1 || playerCount != System.SubspaceEntries[0].Players.Count)
             {
                 System.SubspaceEntries.Clear();
 
-                var allPlayers = new List<string> { SettingsSystem.CurrentSettings.PlayerName };
-                allPlayers.AddRange(System.ClientSubspaceList.Keys);
+                var allPlayers = System.ClientSubspaceList.Keys.ToList();
                 allPlayers.Sort(PlayerSorter);
 
                 System.SubspaceEntries.Add(new SubspaceDisplayEntry


### PR DESCRIPTION
In the single-subspace display path (FillSubspaceDisplayEntriesNoneSubspace), the local player might not be in ClientSubspaceList yet when the display is first built -- for example before CurrentSubspace is assigned on initial connect. The old code worked around this by prepending the local player name to the list, but once the player was eventually added to ClientSubspaceList this produced a duplicate entry.

This adds a TryAdd for the local player before building the list, then constructs it directly from ClientSubspaceList.Keys instead of prepending. Fixes both the missing-player and duplicate-entry cases.