### PR TITLE
Fix: null-guard SafetyBubble launch site iteration for modded planet packs

### DIFF
--- a/LmpClient/Systems/SafetyBubble/SafetyBubbleSystem.cs
+++ b/LmpClient/Systems/SafetyBubble/SafetyBubbleSystem.cs
@@ -156,25 +156,39 @@ namespace LmpClient.Systems.SafetyBubble
 
         private void FillUpPositions()
         {
-            foreach (var launchsite in PSystemSetup.Instance.SpaceCenterFacilityLaunchSites)
-            {
-                if (!SpawnPoints.ContainsKey(launchsite.hostBody.name))
-                    SpawnPoints.Add(launchsite.hostBody.name, new List<SpawnPointLocation>());
+            if (PSystemSetup.Instance == null) return;
 
-                foreach (var spawnPoint in launchsite.spawnPoints)
+            var facilityLaunchSites = PSystemSetup.Instance.SpaceCenterFacilityLaunchSites;
+            if (facilityLaunchSites != null)
+            {
+                foreach (var launchsite in facilityLaunchSites)
                 {
-                    SpawnPoints[launchsite.hostBody.name].Add(new SpawnPointLocation(spawnPoint, launchsite.hostBody));
+                    if (launchsite?.hostBody == null) continue;
+
+                    if (!SpawnPoints.ContainsKey(launchsite.hostBody.name))
+                        SpawnPoints.Add(launchsite.hostBody.name, new List<SpawnPointLocation>());
+
+                    foreach (var spawnPoint in launchsite.spawnPoints)
+                    {
+                        SpawnPoints[launchsite.hostBody.name].Add(new SpawnPointLocation(spawnPoint, launchsite.hostBody));
+                    }
                 }
             }
 
-            foreach (var launchsite in PSystemSetup.Instance.StockLaunchSites)
+            var stockLaunchSites = PSystemSetup.Instance.StockLaunchSites;
+            if (stockLaunchSites != null)
             {
-                if (!SpawnPoints.ContainsKey(launchsite.Body.name))
-                    SpawnPoints.Add(launchsite.Body.name, new List<SpawnPointLocation>());
-
-                foreach (var spawnPoint in launchsite.spawnPoints)
+                foreach (var launchsite in stockLaunchSites)
                 {
-                    SpawnPoints[launchsite.Body.name].Add(new SpawnPointLocation(spawnPoint, launchsite.Body));
+                    if (launchsite?.Body == null) continue;
+
+                    if (!SpawnPoints.ContainsKey(launchsite.Body.name))
+                        SpawnPoints.Add(launchsite.Body.name, new List<SpawnPointLocation>());
+
+                    foreach (var spawnPoint in launchsite.spawnPoints)
+                    {
+                        SpawnPoints[launchsite.Body.name].Add(new SpawnPointLocation(spawnPoint, launchsite.Body));
+                    }
                 }
             }
         }


### PR DESCRIPTION
FillUpPositions() iterates PSystemSetup.Instance.SpaceCenterFacilityLaunchSites and StockLaunchSites without null checks. On modded planet packs like RSS, PSystemSetup.Instance can be null during early loading, the launch site arrays can be null if replaced by a mod, and individual entries can have null body references when the stock KSC doesn't exist on Kerbin. Any of these produces an NRE that crashes the safety bubble system entirely.

This adds null guards at three levels: PSystemSetup.Instance (early return), the two launch site arrays (null check before foreach), and individual launchsite body references (continue on null). The logic is otherwise identical and stock installs are unaffected.