### PR TITLE
Fix: vessel position interpolation — use rb directly, fix stale rotation offset

### DIFF
--- a/LmpClient/Systems/VesselPositionSys/ExtensionMethods/VesselPositioner.cs
+++ b/LmpClient/Systems/VesselPositionSys/ExtensionMethods/VesselPositioner.cs
@@ -79,13 +79,30 @@ namespace LmpClient.Systems.VesselPositionSys.ExtensionMethods
             {
                 for (var i = 0; i < vessel.parts.Count; i++)
                 {
-                    vessel.parts[i].partTransform.rotation = rotation * vessel.parts[i].orgRot;
-                    if (vessel.packed || vessel.parts[i].physicalSignificance == Part.PhysicalSignificance.FULL)
+                    var part = vessel.parts[i];
+                    var partRotation = rotation * part.orgRot;
+                    part.partTransform.rotation = partRotation;
+
+                    if (vessel.packed || part.physicalSignificance == Part.PhysicalSignificance.FULL)
                     {
-                        vessel.parts[i].partTransform.position = position + vessel.vesselTransform.rotation * vessel.parts[i].orgPos;
+                        // Use the interpolated rotation for part offsets — vessel.vesselTransform.rotation
+                        // is stale (previous frame) and causes rotational position lag on large vessels
+                        var partPosition = position + rotation * part.orgPos;
+                        part.partTransform.position = partPosition;
                     }
+
+                    // For unpacked parts with rigidbodies, sync rb directly so the physics engine
+                    // doesn't fight LMP's positioning on the next step (setting only transform.position
+                    // on a non-kinematic Rigidbody causes visible oscillation as physics snaps it back)
+                    if (!vessel.packed && part.rb)
+                    {
+                        part.rb.rotation = partRotation;
+                        if (part.physicalSignificance == Part.PhysicalSignificance.FULL)
+                            part.rb.position = part.partTransform.position;
+                    }
+
                     //We always need to set the part velocity (and it's rigidbody velocity)! Otherwise during dockings it won't be possible to dock
-                    vessel.parts[i].ResumeVelocity();
+                    part.ResumeVelocity();
                 }
             }
         }


### PR DESCRIPTION
Two related fixes in SetVesselPositionAndRotation that eliminate visible artifacts on spectated (non-controlled) vessels.

Part position offsets were computed using vessel.vesselTransform.rotation, which reflects the previous frame's rotation rather than the one being applied in the current call. On multi-part vessels like space stations this one-frame lag causes parts to visibly orbit and spin around the root part. Fixed by using the interpolated rotation parameter passed into the method.

For unpacked (off-rails) parts with rigidbodies, only transform.position and transform.rotation were being set. Unity's physics engine treats this as an external teleport and snaps the rigidbody back toward its last solved position on the next FixedUpdate, causing visible vibration and shaking. Fixed by also setting part.rb.rotation and part.rb.position directly so the physics engine stays in sync with the interpolation.

No effect on packed (on-rails) vessels or on the active vessel, which isn't positioned by this code path.