### PR TITLE
Fix: send scenario modules before disconnecting, not after

### DIFF
--- a/LmpClient/MainSystem.cs
+++ b/LmpClient/MainSystem.cs
@@ -319,8 +319,8 @@ namespace LmpClient
         public void DisconnectFromGame()
         {
             ForceQuit = true;
-            NetworkConnection.Disconnect("Quit");
             ScenarioSystem.Singleton.SendScenarioModules();
+            NetworkConnection.Disconnect("Quit");
         }
 
         #endregion


### PR DESCRIPTION
DisconnectFromGame() was calling NetworkConnection.Disconnect() before SendScenarioModules(), so the final scenario sync was sent on a closed connection and silently lost. Swaps the order so scenario data is sent while the connection is still alive.