### PR TITLE
Reduce network overhead: batch message sending and suppress duplicate flight states

### DIFF
--- a/LmpClient/Network/NetworkSender.cs
+++ b/LmpClient/Network/NetworkSender.cs
@@ -15,6 +15,7 @@ namespace LmpClient.Network
     public class NetworkSender
     {
         public static ConcurrentQueue<IMessageBase> OutgoingMessages { get; set; } = new ConcurrentQueue<IMessageBase>();
+        private const int MaxMessagesPerBatch = 128;
 
         /// <summary>
         /// Main sending thread
@@ -26,9 +27,18 @@ namespace LmpClient.Network
             {
                 while (!NetworkConnection.ResetRequested)
                 {
-                    if (OutgoingMessages.Count > 0 && OutgoingMessages.TryDequeue(out var sendMessage))
+                    var sentAnyMessages = false;
+                    var sentMessages = 0;
+
+                    while (sentMessages < MaxMessagesPerBatch && OutgoingMessages.TryDequeue(out var sendMessage))
                     {
-                        SendNetworkMessage(sendMessage);
+                        sentAnyMessages |= SendNetworkMessage(sendMessage);
+                        sentMessages++;
+                    }
+
+                    if (sentAnyMessages)
+                    {
+                        NetworkMain.ClientConnection?.FlushSendQueue();
                     }
                     else
                     {
@@ -55,7 +65,7 @@ namespace LmpClient.Network
         /// Sends the network message. It will skip client messages to send when we are not connected,
         /// except if it's directed at master servers, then it will start the NetClient and socket.
         /// </summary>
-        private static void SendNetworkMessage(IMessageBase message)
+        private static bool SendNetworkMessage(IMessageBase message)
         {
             message.Data.SentTime = LunaNetworkTime.UtcNow.Ticks;
             try
@@ -93,29 +103,28 @@ namespace LmpClient.Network
                         message.Serialize(lidgrenMsg);
                         NetworkMain.ClientConnection.SendUnconnectedMessage(lidgrenMsg, masterServer);
                     }
-                    // Force send of packets
-                    NetworkMain.ClientConnection.FlushSendQueue();
+                    message.Recycle();
+                    return true;
                 }
-                else
-                {
-                    if (NetworkMain.ClientConnection == null || NetworkMain.ClientConnection.Status == NetPeerStatus.NotRunning
-                        || MainSystem.NetworkState < ClientState.Connected)
-                    {
-                        return;
-                    }
-                    var lidgrenMsg = NetworkMain.ClientConnection.CreateMessage(message.GetMessageSize());
 
-                    message.Serialize(lidgrenMsg);
-                    NetworkMain.ClientConnection.SendMessage(lidgrenMsg, message.NetDeliveryMethod, message.Channel);
-                    // Force send of packets
-                    NetworkMain.ClientConnection.FlushSendQueue();
+                if (NetworkMain.ClientConnection == null || NetworkMain.ClientConnection.Status == NetPeerStatus.NotRunning
+                    || MainSystem.NetworkState < ClientState.Connected)
+                {
+                    return false;
                 }
+
+                var outgoingMessage = NetworkMain.ClientConnection.CreateMessage(message.GetMessageSize());
+
+                message.Serialize(outgoingMessage);
+                NetworkMain.ClientConnection.SendMessage(outgoingMessage, message.NetDeliveryMethod, message.Channel);
 
                 message.Recycle();
+                return true;
             }
             catch (Exception e)
             {
                 NetworkMain.HandleDisconnectException(e);
+                return false;
             }
         }
     }

--- a/LmpClient/Systems/VesselFlightStateSys/VesselFlightStateMessageSender.cs
+++ b/LmpClient/Systems/VesselFlightStateSys/VesselFlightStateMessageSender.cs
@@ -6,11 +6,17 @@ using LmpClient.Systems.Warp;
 using LmpCommon.Message.Client;
 using LmpCommon.Message.Data.Vessel;
 using LmpCommon.Message.Interface;
+using System;
 
 namespace LmpClient.Systems.VesselFlightStateSys
 {
     public class VesselFlightStateMessageSender : SubSystem<VesselFlightStateSystem>, IMessageSender
     {
+        private const double ForceResyncIntervalMs = 500;
+        private static readonly FlightCtrlState LastSentFlightState = new FlightCtrlState();
+        private static Guid _lastSentVesselId;
+        private static DateTime _lastFlightStateSentAt = DateTime.MinValue;
+
         public void SendMessage(IMessageData msg)
         {
             NetworkSender.QueueOutgoingMessage(MessageFactory.CreateNew<VesselCliMsg>(msg));
@@ -21,13 +27,18 @@ namespace LmpClient.Systems.VesselFlightStateSys
             var flightState = new FlightCtrlState();
             flightState.CopyFrom(FlightGlobals.ActiveVessel.ctrlState);
 
+            var vesselId = FlightGlobals.ActiveVessel.id;
+            var forceResync = vesselId != _lastSentVesselId || (DateTime.UtcNow - _lastFlightStateSentAt).TotalMilliseconds >= ForceResyncIntervalMs;
+            if (!forceResync && FlightStatesAreEquivalent(flightState, LastSentFlightState))
+                return;
+
             var msgData = NetworkMain.CliMsgFactory.CreateNewMessageData<VesselFlightStateMsgData>();
             msgData.PingSec = NetworkStatistics.PingSec;
 
             msgData.GameTime = TimeSyncSystem.UniversalTime;
             msgData.SubspaceId = WarpSystem.Singleton.CurrentSubspace;
 
-            msgData.VesselId = FlightGlobals.ActiveVessel.id;
+            msgData.VesselId = vesselId;
             msgData.GearDown = flightState.gearDown;
             msgData.GearUp = flightState.gearUp;
             msgData.Headlight = flightState.headlight;
@@ -48,6 +59,37 @@ namespace LmpClient.Systems.VesselFlightStateSys
             msgData.Z = flightState.Z;
 
             SendMessage(msgData);
+
+            LastSentFlightState.CopyFrom(flightState);
+            _lastSentVesselId = vesselId;
+            _lastFlightStateSentAt = DateTime.UtcNow;
+        }
+
+        private static bool FlightStatesAreEquivalent(FlightCtrlState current, FlightCtrlState previous)
+        {
+            return ApproximatelyEqual(current.mainThrottle, previous.mainThrottle)
+                && ApproximatelyEqual(current.wheelThrottle, previous.wheelThrottle)
+                && ApproximatelyEqual(current.wheelThrottleTrim, previous.wheelThrottleTrim)
+                && ApproximatelyEqual(current.X, previous.X)
+                && ApproximatelyEqual(current.Y, previous.Y)
+                && ApproximatelyEqual(current.Z, previous.Z)
+                && current.killRot == previous.killRot
+                && current.gearUp == previous.gearUp
+                && current.gearDown == previous.gearDown
+                && current.headlight == previous.headlight
+                && ApproximatelyEqual(current.pitch, previous.pitch)
+                && ApproximatelyEqual(current.roll, previous.roll)
+                && ApproximatelyEqual(current.yaw, previous.yaw)
+                && ApproximatelyEqual(current.pitchTrim, previous.pitchTrim)
+                && ApproximatelyEqual(current.rollTrim, previous.rollTrim)
+                && ApproximatelyEqual(current.yawTrim, previous.yawTrim)
+                && ApproximatelyEqual(current.wheelSteer, previous.wheelSteer)
+                && ApproximatelyEqual(current.wheelSteerTrim, previous.wheelSteerTrim);
+        }
+
+        private static bool ApproximatelyEqual(float left, float right)
+        {
+            return Math.Abs(left - right) < 0.001f;
         }
     }
 }


### PR DESCRIPTION
Two related changes that reduce per-frame network overhead on the client.

NetworkSender now dequeues up to 128 messages per loop iteration and does a single FlushSendQueue() at the end, instead of flushing after every individual message. This cuts Lidgren flush overhead when many vessels are in physics range.

VesselFlightStateMessageSender now tracks the last-sent flight state per vessel and skips sending when all control axes and buttons are unchanged (within 0.001 tolerance). A forced resync fires every 500ms or on vessel switch. For parked vessels with no control inputs, this eliminates roughly 50 redundant messages per second of pure noise on the wire.
