### PR TITLE
Guard referenceTransformId overwrite on active vessel

### DIFF
--- a/LmpClient/Systems/VesselUpdateSys/VesselUpdate.cs
+++ b/LmpClient/Systems/VesselUpdateSys/VesselUpdate.cs
@@ -31,7 +31,6 @@ namespace LmpClient.Systems.VesselUpdateSys
         public bool WasControllable;
         public int Stage;
         public float[] Com = new float[3];
-        public string BodyName;
 
         #endregion
 
@@ -87,7 +86,15 @@ namespace LmpClient.Systems.VesselUpdateSys
             vessel.launchTime = LaunchTime;
             vessel.lastUT = LastUt;
             vessel.isPersistent = Persistent;
-            vessel.referenceTransformId = RefTransformId;
+
+            // Don't override referenceTransformId for the active vessel.
+            // The local player's "Control From Here" choice should be authoritative;
+            // overwriting it with server data causes mods like FastVesselChanger to
+            // lose the user's control reference every sync tick.
+            if (!vessel.isActiveVessel)
+                vessel.referenceTransformId = RefTransformId;
+            else if (vessel.referenceTransformId != RefTransformId)
+                UnityEngine.Debug.Log("[LMP-CFH] Guard: skipped overwrite of active vessel refTransformId (local=" + vessel.referenceTransformId + " server=" + RefTransformId + ")");
 
             if (AutoClean)
             {
@@ -122,6 +129,11 @@ namespace LmpClient.Systems.VesselUpdateSys
         {
             if (protoVessel == null) return;
 
+            // Determine whether this protoVessel belongs to the active vessel so we
+            // can skip the referenceTransform override (same reasoning as UpdateVesselFields).
+            var isActive = FlightGlobals.ActiveVessel != null
+                && FlightGlobals.ActiveVessel.protoVessel == protoVessel;
+
             protoVessel.vesselName = Name;
             protoVessel.vesselType = (VesselType)Enum.Parse(typeof(VesselType), Type);
             protoVessel.distanceTraveled = DistanceTraveled;
@@ -134,7 +146,9 @@ namespace LmpClient.Systems.VesselUpdateSys
             protoVessel.launchTime = LaunchTime;
             protoVessel.lastUT = LastUt;
             protoVessel.persistent = Persistent;
-            protoVessel.refTransform = RefTransformId;
+
+            if (!isActive)
+                protoVessel.refTransform = RefTransformId;
             protoVessel.autoClean = AutoClean;
             protoVessel.autoCleanReason = AutoCleanReason;
             protoVessel.wasControllable = WasControllable;


### PR DESCRIPTION
When another player (or the server) sends a vessel update, the sync system overwrites every field on the local vessel — including `referenceTransformId`. For the **active** vessel this is wrong: the local player's 'Control From Here' choice is authoritative, and the server's copy is always at least one round-trip behind. Overwriting it every tick:

- Resets the player's control-from-here selection to whatever the server last saw
- Breaks mods like FastVesselChanger that explicitly set the reference transform

This PR guards both `UpdateVesselFields` and `UpdateProtoVesselValues` so that `referenceTransformId` / `refTransform` are only written for **remote** vessels. The active vessel keeps its local value. A debug log fires when a skip occurs so the behaviour is visible in the log.

Remote vessels are unaffected — they continue receiving the server's reference transform as before.

Upstream added a new `BodyName` field to the same class, but that doesn't touch the referenceTransformId lines.