### PR TITLE
Zero throttle when acquiring vessel control lock

### DIFF
--- a/LmpClient/Systems/VesselLockSys/VesselLockEvents.cs
+++ b/LmpClient/Systems/VesselLockSys/VesselLockEvents.cs
@@ -94,7 +94,19 @@ namespace LmpClient.Systems.VesselLockSys
                     if (lockDefinition.PlayerName == SettingsSystem.CurrentSettings.PlayerName)
                     {
                         if (VesselCommon.IsSpectating)
+                        {
+                            // Zero the vessel's throttle before removing the spectate input lock.
+                            // The spectated vessel's ctrlState carries the previous controller's
+                            // last-sent throttle; without clearing it the new controller instantly
+                            // inherits full throttle on the frame the lock is granted.
+                            var spectatedVessel = FlightGlobals.FindVessel(lockDefinition.VesselId);
+                            if (spectatedVessel != null)
+                            {
+                                spectatedVessel.ctrlState.mainThrottle = 0f;
+                                spectatedVessel.ctrlState.wheelThrottle = 0f;
+                            }
                             VesselLockSystem.Singleton.StopSpectating();
+                        }
                         LockSystem.Singleton.AcquireUpdateLock(lockDefinition.VesselId, true);
                         LockSystem.Singleton.AcquireUnloadedUpdateLock(lockDefinition.VesselId, true);
                         LockSystem.Singleton.AcquireKerbalLock(lockDefinition.VesselId, true);


### PR DESCRIPTION
When a player acquires the control lock on a vessel they were spectating, the spectated vessel's `ctrlState` still carries the previous controller's last-sent throttle value. Without clearing it, the new controller instantly inherits whatever throttle the previous pilot was running — if they were at full thrust the vessel lurches forward the frame the lock is granted.

This zeros `mainThrottle` and `wheelThrottle` on the spectated vessel's `ctrlState` before calling `StopSpectating()`, so the new controller always starts from zero throttle and has to deliberately set it.