### PR TITLE
Relax resource allowlist check to warn instead of block

### DIFF
--- a/LmpClient/Extensions/ProtoVesselExtension.cs
+++ b/LmpClient/Extensions/ProtoVesselExtension.cs
@@ -42,17 +42,16 @@ namespace LmpClient.Extensions
                     return true;
                 }
 
-                var invalidResources = pps.resources.Select(r => r.resourceName).Except(ModSystem.Singleton.AllowedResources).ToArray();
-                if (ModSystem.Singleton.ModControl && invalidResources.Any())
+                var nonWhitelistedResources = pps.resources.Select(r => r.resourceName)
+                    .Except(ModSystem.Singleton.AllowedResources)
+                    .Where(r => PartResourceLibrary.Instance.resourceDefinitions.Contains(r))
+                    .Distinct()
+                    .ToArray();
+                if (ModSystem.Singleton.ModControl && nonWhitelistedResources.Any() && verboseErrors)
                 {
-                    if (verboseErrors)
-                    {
-                        var msg = $"Protovessel {pv.vesselID} ({pv.vesselName}) contains the BANNED RESOURCE/S '{string.Join(", ", invalidResources)}' ON PART '{pps.partName}'. Skipping load.";
-                        LunaLog.LogWarning(msg);
-                        ChatSystem.Singleton.PmMessageServer(msg);
-                    }
-
-                    return true;
+                    var msg = $"Protovessel {pv.vesselID} ({pv.vesselName}) contains RESOURCE/S '{string.Join(", ", nonWhitelistedResources)}' not present in the server allowlist on part '{pps.partName}'. Allowing load because the resources exist locally.";
+                    LunaLog.LogWarning(msg);
+                    ChatSystem.Singleton.PmMessageServer(msg);
                 }
 
                 if (pps.partInfo == null)


### PR DESCRIPTION
The mod-control resource validation in `HasInvalidParts` currently blocks the entire vessel from loading if any resource isn't on the server's allowlist. In practice this is too strict — modded resources from CRP, Kerbalism, Near Future, etc. are perfectly valid on the client even when they aren't listed in the server's mod-control config. The result is that vessels with modded resources silently fail to appear for other players.

This changes the check from a hard block to a warning. Resources that aren't on the allowlist but **do** exist in the local `PartResourceLibrary` (i.e. the player has the mod installed) now log a warning and PM the server, but the vessel still loads. Resources that don't exist locally at all are ignored entirely since they'll be handled by KSP's normal missing-resource path.

Also adds `.Distinct()` to avoid duplicate warnings when the same resource appears on multiple parts.