### PR TITLE
Sanitize persistent IDs before vessel load to prevent freezes

### DIFF
--- a/LmpClient/VesselUtilities/VesselLoader.cs
+++ b/LmpClient/VesselUtilities/VesselLoader.cs
@@ -66,12 +66,7 @@ namespace LmpClient.VesselUtilities
                 LunaLog.Log($"[LMP]: Loading vessel {vesselProto.vesselID}");
             }
 
-            // Vessel.Start() calls Vessel.RebuildCrewList() which iterates protoModuleCrew on every
-            // ProtoPartSnapshot.  A null slot in that list causes a NullReferenceException that Unity
-            // catches internally (logged as [EXC]) — it never reaches our catch block below.  Strip
-            // nulls here so RebuildCrewList() always receives a clean list.
-            foreach (var snapshot in vesselProto.protoPartSnapshots)
-                snapshot.protoModuleCrew?.RemoveAll(c => c == null);
+            SanitizePersistentIds(vesselProto);
 
             try
             {
@@ -201,6 +196,55 @@ namespace LmpClient.VesselUtilities
             }
 
             return true;
+        }
+
+        #endregion
+
+        #region ID sanitization
+
+        /// <summary>
+        /// Proactively remaps any persistentId values in vesselProto that already exist in the
+        /// running FlightGlobals registries (PersistentVesselIds, PersistentLoadedPartIds,
+        /// PersistentUnloadedPartIds) before the vessel is loaded into the game.
+        ///
+        /// Without this, KSP's HandlePartPersistentIdCollision fires O(n) times per conflicting
+        /// part on the main thread, which under concurrent LMP vessel loads can cascade into a
+        /// freeze when many parts collide simultaneously.  By remapping upfront using
+        /// FlightGlobals.GetUniquepersistentId() we hand KSP clean IDs and the collision handler
+        /// never fires.
+        ///
+        /// The incoming proto IDs are transient transport values — they only need to be unique on
+        /// this client.  The authoritative state is the server's save, so remapping here is safe.
+        /// </summary>
+        private static void SanitizePersistentIds(ProtoVessel vesselProto)
+        {
+            // Strip null crew slots before load — Vessel.Start() calls RebuildCrewList() which
+            // iterates protoModuleCrew on every ProtoPartSnapshot; a null slot causes a
+            // NullReferenceException that Unity catches internally (never reaches our catch block).
+            foreach (var snapshot in vesselProto.protoPartSnapshots)
+                snapshot.protoModuleCrew?.RemoveAll(c => c == null);
+
+            // Vessel-level persistentId
+            if (FlightGlobals.PersistentVesselIds.ContainsKey(vesselProto.persistentId))
+            {
+                var newId = FlightGlobals.GetUniquepersistentId();
+                LunaLog.Log($"[LMP]: PersistentId collision — remapping vessel {vesselProto.vesselID} " +
+                            $"vessel persistentId {vesselProto.persistentId} → {newId}");
+                vesselProto.persistentId = newId;
+            }
+
+            // Per-part persistentId (ProtoPartSnapshot)
+            foreach (var part in vesselProto.protoPartSnapshots)
+            {
+                if (FlightGlobals.PersistentLoadedPartIds.ContainsKey(part.persistentId) ||
+                    FlightGlobals.PersistentUnloadedPartIds.ContainsKey(part.persistentId))
+                {
+                    var newId = FlightGlobals.GetUniquepersistentId();
+                    LunaLog.Log($"[LMP]: PersistentId collision — remapping vessel {vesselProto.vesselID} " +
+                                $"part {part.partName} persistentId {part.persistentId} → {newId}");
+                    part.persistentId = newId;
+                }
+            }
         }
 
         #endregion


### PR DESCRIPTION
KSP assigns every vessel and part a `persistentId` that must be unique within the running game. When LMP loads a vessel from the server, the incoming proto often carries IDs that already exist locally (because the vessel was loaded before, or another client chose the same IDs). KSP handles this with `HandlePartPersistentIdCollision`, but that handler fires **per conflicting part on the main thread** — and under concurrent LMP vessel loads (multiple vessels arriving in the same frame), the collision cascade causes multi-second freezes proportional to vessel part count.

This adds a `SanitizePersistentIds` pass before `ProtoVessel.Load()` that checks every vessel-level and part-level `persistentId` against the live `FlightGlobals` registries (`PersistentVesselIds`, `PersistentLoadedPartIds`, `PersistentUnloadedPartIds`) and remaps any collisions using `FlightGlobals.GetUniquepersistentId()`. The collision handler never fires because KSP sees clean IDs.

The incoming IDs are transient transport values that only need to be unique on this client — the server's save is authoritative, so remapping is safe. Logs each remap for observability.

Upstream recently added zombie-vessel cleanup and a try/catch around `Load()` in the same file — those changes are in the full-reload path while this sits immediately before the `Load()` call and in a new region at the bottom. No overlap.