### PR TITLE
Fix scenario ConfigNode parsing and add error handling

### DIFF
--- a/Server/System/Scenario/ScenarioAchievementsDataUpdater.cs
+++ b/Server/System/Scenario/ScenarioAchievementsDataUpdater.cs
@@ -1,6 +1,6 @@
 using LmpCommon.Message.Data.ShareProgress;
-using LunaConfigNode.CfgNode;
-using System.Text;
+using Server.Log;
+using System;
 using System.Threading.Tasks;
 
 namespace Server.System.Scenario
@@ -14,24 +14,31 @@ namespace Server.System.Scenario
         {
             _ = Task.Run(() =>
             {
-                lock (Semaphore.GetOrAdd("ProgressTracking", new object()))
+                try
                 {
-                    if (!ScenarioStoreSystem.CurrentScenarios.TryGetValue("ProgressTracking", out var scenario)) return;
-
-                    var progressNodeHeader = scenario.GetNode("Progress").Value;
-                    if (progressNodeHeader != null)
+                    lock (Semaphore.GetOrAdd("ProgressTracking", new object()))
                     {
-                        var specificNode = progressNodeHeader.GetNode(achievementMsg.Id);
-                        var receivedNode = new ConfigNode(Encoding.UTF8.GetString(achievementMsg.Data, 0, achievementMsg.NumBytes)) { Name = achievementMsg.Id };
-                        if (specificNode != null)
+                        if (!ScenarioStoreSystem.CurrentScenarios.TryGetValue("ProgressTracking", out var scenario)) return;
+
+                        var progressNodeHeader = scenario.GetNode("Progress")?.Value;
+                        if (progressNodeHeader != null)
                         {
-                            progressNodeHeader.ReplaceNode(specificNode.Value, receivedNode);
-                        }
-                        else
-                        {
-                            progressNodeHeader.AddNode(receivedNode);
+                            var specificNode = progressNodeHeader.GetNode(achievementMsg.Id);
+                            var receivedNode = ParseClientConfigNode(achievementMsg.Data, achievementMsg.NumBytes, achievementMsg.Id);
+                            if (specificNode != null)
+                            {
+                                progressNodeHeader.ReplaceNode(specificNode.Value, receivedNode);
+                            }
+                            else
+                            {
+                                progressNodeHeader.AddNode(receivedNode);
+                            }
                         }
                     }
+                }
+                catch (Exception e)
+                {
+                    LunaLog.Error($"Error updating achievement scenario data: {e}");
                 }
             });
         }

--- a/Server/System/Scenario/ScenarioBaseDataUpdater.cs
+++ b/Server/System/Scenario/ScenarioBaseDataUpdater.cs
@@ -1,5 +1,8 @@
 using LunaConfigNode.CfgNode;
+using Server.Log;
+using System;
 using System.Collections.Concurrent;
+using System.Text;
 using System.Threading.Tasks;
 
 namespace Server.System.Scenario
@@ -16,13 +19,35 @@ namespace Server.System.Scenario
         #endregion
 
         /// <summary>
-        /// Raw updates a scenario in the dictionary
+        /// Creates a ConfigNode from raw bytes, stripping the outer { } braces that KSP's
+        /// ConfigNode.WriteNode() adds. LunaConfigNode's parser wraps braced content in an
+        /// unnamed child node, which causes GetValue() on the root to return null.
+        /// </summary>
+        private static ConfigNode ParseClientConfigNode(byte[] data, int numBytes, string nodeName)
+        {
+            var raw = Encoding.UTF8.GetString(data, 0, numBytes);
+            var trimmed = raw.Trim();
+
+            // KSP serializes unnamed ConfigNodes as "{\n\tkey = val\n}" — strip the wrapper
+            if (trimmed.StartsWith("{") && trimmed.EndsWith("}"))
+                trimmed = trimmed.Substring(1, trimmed.Length - 2);
+
+            return new ConfigNode(trimmed) { Name = nodeName };
+        }
+
+        /// <summary>
+        /// Raw updates a scenario in the dictionary, stripping outer { } braces
+        /// that KSP's ConfigNode serializer adds (same fix as ParseClientConfigNode).
         /// </summary>
         public static void RawConfigNodeInsertOrUpdate(string scenarioModule, string scenarioAsConfigNode)
         {
             _ = Task.Run(() =>
             {
-                var scenario = new ConfigNode(scenarioAsConfigNode);
+                var trimmed = scenarioAsConfigNode.Trim();
+                if (trimmed.StartsWith("{") && trimmed.EndsWith("}"))
+                    trimmed = trimmed.Substring(1, trimmed.Length - 2);
+
+                var scenario = new ConfigNode(trimmed) { Name = scenarioModule };
                 lock (Semaphore.GetOrAdd(scenarioModule, new object()))
                 {
                     ScenarioStoreSystem.CurrentScenarios.AddOrUpdate(scenarioModule, scenario, (key, existingVal) => scenario);

--- a/Server/System/Scenario/ScenarioContractsDataUpdater.cs
+++ b/Server/System/Scenario/ScenarioContractsDataUpdater.cs
@@ -1,8 +1,9 @@
 using LmpCommon.Message.Data.ShareProgress;
 using LunaConfigNode.CfgNode;
+using Server.Log;
+using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Text;
 using System.Threading.Tasks;
 
 namespace Server.System.Scenario
@@ -25,58 +26,65 @@ namespace Server.System.Scenario
         {
             _ = Task.Run(() =>
             {
-                lock (Semaphore.GetOrAdd("ContractSystem", new object()))
+                try
                 {
-                    if (!ScenarioStoreSystem.CurrentScenarios.TryGetValue("ContractSystem", out var scenario)) return;
-
-                    var contractsNode = scenario.GetNode("CONTRACTS")?.Value;
-                    if (contractsNode == null) return;
-
-                    // Get CONTRACTS_FINISHED, creating it if the scenario pre-dates the node.
-                    var finishedNodeEntry = scenario.GetNode("CONTRACTS_FINISHED");
-                    ConfigNode finishedNode;
-                    if (finishedNodeEntry == null)
+                    lock (Semaphore.GetOrAdd("ContractSystem", new object()))
                     {
-                        finishedNode = new ConfigNode("") { Name = "CONTRACTS_FINISHED" };
-                        scenario.AddNode(finishedNode);
-                    }
-                    else
-                    {
-                        finishedNode = finishedNodeEntry.Value;
-                    }
+                        if (!ScenarioStoreSystem.CurrentScenarios.TryGetValue("ContractSystem", out var scenario)) return;
 
-                    var existingActive   = contractsNode.GetNodes("CONTRACT").Select(c => c.Value).ToArray();
-                    var existingFinished = finishedNode.GetNodes("CONTRACT").Select(c => c.Value).ToArray();
+                        var contractsNode = scenario.GetNode("CONTRACTS")?.Value;
+                        if (contractsNode == null) return;
 
-                    foreach (var contract in contractsMsg.Contracts.Select(v => new ConfigNode(Encoding.UTF8.GetString(v.Data, 0, v.NumBytes)) { Name = "CONTRACT" }))
-                    {
-                        var guid  = contract.GetValue("guid")?.Value;
-                        var state = contract.GetValue("state")?.Value ?? string.Empty;
-
-                        var inActive   = existingActive.FirstOrDefault(n => n.GetValue("guid")?.Value == guid);
-                        var inFinished = existingFinished.FirstOrDefault(n => n.GetValue("guid")?.Value == guid);
-
-                        if (FinishedContractStates.Contains(state))
+                        // Get CONTRACTS_FINISHED, creating it if the scenario pre-dates the node.
+                        var finishedNodeEntry = scenario.GetNode("CONTRACTS_FINISHED");
+                        ConfigNode finishedNode;
+                        if (finishedNodeEntry == null)
                         {
-                            // Remove from active list so it no longer blocks an offered-contract slot.
-                            if (inActive != null)
-                                contractsNode.RemoveNode(inActive);
-
-                            // Upsert into CONTRACTS_FINISHED.
-                            if (inFinished != null)
-                                finishedNode.ReplaceNode(inFinished, contract);
-                            else
-                                finishedNode.AddNode(contract);
+                            finishedNode = new ConfigNode("") { Name = "CONTRACTS_FINISHED" };
+                            scenario.AddNode(finishedNode);
                         }
                         else
                         {
-                            // Not finished — update in place within CONTRACTS.
-                            if (inActive != null)
-                                contractsNode.ReplaceNode(inActive, contract);
+                            finishedNode = finishedNodeEntry.Value;
+                        }
+
+                        var existingActive   = contractsNode.GetNodes("CONTRACT").Select(c => c.Value).ToArray();
+                        var existingFinished = finishedNode.GetNodes("CONTRACT").Select(c => c.Value).ToArray();
+
+                        foreach (var contract in contractsMsg.Contracts.Select(v => ParseClientConfigNode(v.Data, v.NumBytes, "CONTRACT")))
+                        {
+                            var guid  = contract.GetValue("guid")?.Value;
+                            var state = contract.GetValue("state")?.Value ?? string.Empty;
+
+                            var inActive   = existingActive.FirstOrDefault(n => n.GetValue("guid")?.Value == guid);
+                            var inFinished = existingFinished.FirstOrDefault(n => n.GetValue("guid")?.Value == guid);
+
+                            if (FinishedContractStates.Contains(state))
+                            {
+                                // Remove from active list so it no longer blocks an offered-contract slot.
+                                if (inActive != null)
+                                    contractsNode.RemoveNode(inActive);
+
+                                // Upsert into CONTRACTS_FINISHED.
+                                if (inFinished != null)
+                                    finishedNode.ReplaceNode(inFinished, contract);
+                                else
+                                    finishedNode.AddNode(contract);
+                            }
                             else
-                                contractsNode.AddNode(contract);
+                            {
+                                // Not finished — update in place within CONTRACTS.
+                                if (inActive != null)
+                                    contractsNode.ReplaceNode(inActive, contract);
+                                else
+                                    contractsNode.AddNode(contract);
+                            }
                         }
                     }
+                }
+                catch (Exception e)
+                {
+                    LunaLog.Error($"Error updating contract scenario data: {e}");
                 }
             });
         }

--- a/Server/System/Scenario/ScenarioScienceSubjectDataUpdater.cs
+++ b/Server/System/Scenario/ScenarioScienceSubjectDataUpdater.cs
@@ -1,7 +1,7 @@
 using LmpCommon.Message.Data.ShareProgress;
-using LunaConfigNode.CfgNode;
+using Server.Log;
+using System;
 using System.Linq;
-using System.Text;
 using System.Threading.Tasks;
 
 namespace Server.System.Scenario
@@ -15,23 +15,42 @@ namespace Server.System.Scenario
         {
             _ = Task.Run(() =>
             {
-                lock (Semaphore.GetOrAdd("ResearchAndDevelopment", new object()))
+                try
                 {
-                    if (!ScenarioStoreSystem.CurrentScenarios.TryGetValue("ResearchAndDevelopment", out var scenario)) return;
-
-                    var receivedNode = new ConfigNode(Encoding.UTF8.GetString(scienceSubject.Data, 0, scienceSubject.NumBytes)) { Parent = scenario, Name = "Science" };
-                    if (receivedNode.IsEmpty()) return;
-
-                    var techNodes = scenario.GetNodes("Science").Select(v => v.Value);
-                    var specificTechNode = techNodes.FirstOrDefault(n => n.GetValue("id").Value == receivedNode.GetValue("id").Value);
-                    if (specificTechNode != null)
+                    lock (Semaphore.GetOrAdd("ResearchAndDevelopment", new object()))
                     {
-                        scenario.ReplaceNode(specificTechNode, receivedNode);
+                        if (!ScenarioStoreSystem.CurrentScenarios.TryGetValue("ResearchAndDevelopment", out var scenario)) return;
+
+                        var receivedNode = ParseClientConfigNode(scienceSubject.Data, scienceSubject.NumBytes, "Science");
+                        receivedNode.Parent = scenario;
+                        if (receivedNode.IsEmpty()) return;
+
+                        var receivedId = receivedNode.GetValue("id");
+                        if (receivedId == null)
+                        {
+                            LunaLog.Error("Science subject update received with no id — skipping");
+                            return;
+                        }
+
+                        var scienceNodes = scenario.GetNodes("Science").Select(v => v.Value);
+                        var specificNode = scienceNodes.FirstOrDefault(n =>
+                        {
+                            var id = n.GetValue("id");
+                            return id != null && id.Value == receivedId.Value;
+                        });
+                        if (specificNode != null)
+                        {
+                            scenario.ReplaceNode(specificNode, receivedNode);
+                        }
+                        else
+                        {
+                            scenario.AddNode(receivedNode);
+                        }
                     }
-                    else
-                    {
-                        scenario.AddNode(receivedNode);
-                    }
+                }
+                catch (Exception e)
+                {
+                    LunaLog.Error($"Error updating science subject scenario data: {e}");
                 }
             });
         }

--- a/Server/System/Scenario/ScenarioStrategyDataUpdater.cs
+++ b/Server/System/Scenario/ScenarioStrategyDataUpdater.cs
@@ -1,7 +1,7 @@
 using LmpCommon.Message.Data.ShareProgress;
-using LunaConfigNode.CfgNode;
+using Server.Log;
+using System;
 using System.Linq;
-using System.Text;
 using System.Threading.Tasks;
 
 namespace Server.System.Scenario
@@ -15,25 +15,38 @@ namespace Server.System.Scenario
         {
             _ = Task.Run(() =>
             {
-                lock (Semaphore.GetOrAdd("StrategySystem", new object()))
+                try
                 {
-                    if (!ScenarioStoreSystem.CurrentScenarios.TryGetValue("StrategySystem", out var scenario)) return;
-
-                    var receivedNode = new ConfigNode(Encoding.UTF8.GetString(strategy.Data, 0, strategy.NumBytes)) { Name = "STRATEGY" };
-                    if (receivedNode.IsEmpty()) return;
-
-                    var strategiesNode = scenario.GetNode("STRATEGIES").Value;
-                    if (strategiesNode != null)
+                    lock (Semaphore.GetOrAdd("StrategySystem", new object()))
                     {
-                        var strategiesList = strategiesNode.GetNodes("STRATEGY").Select(v => v.Value);
-                        var specificstrategyNode = strategiesList.FirstOrDefault(n => n.GetValue("name").Value == strategy.Name);
-                        if (specificstrategyNode != null)
-                        {
-                            strategiesNode.ReplaceNode(specificstrategyNode, receivedNode);
-                        }
+                        if (!ScenarioStoreSystem.CurrentScenarios.TryGetValue("StrategySystem", out var scenario)) return;
 
-                        strategiesNode.AddNode(receivedNode);
+                        var receivedNode = ParseClientConfigNode(strategy.Data, strategy.NumBytes, "STRATEGY");
+                        if (receivedNode.IsEmpty()) return;
+
+                        var strategiesNode = scenario.GetNode("STRATEGIES")?.Value;
+                        if (strategiesNode != null)
+                        {
+                            var strategiesList = strategiesNode.GetNodes("STRATEGY").Select(v => v.Value);
+                            var specificstrategyNode = strategiesList.FirstOrDefault(n =>
+                            {
+                                var name = n.GetValue("name");
+                                return name != null && name.Value == strategy.Name;
+                            });
+                            if (specificstrategyNode != null)
+                            {
+                                strategiesNode.ReplaceNode(specificstrategyNode, receivedNode);
+                            }
+                            else
+                            {
+                                strategiesNode.AddNode(receivedNode);
+                            }
+                        }
                     }
+                }
+                catch (Exception e)
+                {
+                    LunaLog.Error($"Error updating strategy scenario data: {e}");
                 }
             });
         }

--- a/Server/System/Scenario/ScenarioTechnologyDataUpdater.cs
+++ b/Server/System/Scenario/ScenarioTechnologyDataUpdater.cs
@@ -1,7 +1,7 @@
 using LmpCommon.Message.Data.ShareProgress;
-using LunaConfigNode.CfgNode;
+using Server.Log;
+using System;
 using System.Linq;
-using System.Text;
 using System.Threading.Tasks;
 
 namespace Server.System.Scenario
@@ -15,18 +15,29 @@ namespace Server.System.Scenario
         {
             _ = Task.Run(() =>
             {
-                lock (Semaphore.GetOrAdd("ResearchAndDevelopment", new object()))
+                try
                 {
-                    if (!ScenarioStoreSystem.CurrentScenarios.TryGetValue("ResearchAndDevelopment", out var scenario)) return;
+                    lock (Semaphore.GetOrAdd("ResearchAndDevelopment", new object()))
+                    {
+                        if (!ScenarioStoreSystem.CurrentScenarios.TryGetValue("ResearchAndDevelopment", out var scenario)) return;
 
-                    var receivedNode = new ConfigNode(Encoding.UTF8.GetString(techMsg.TechNode.Data, 0, techMsg.TechNode.NumBytes)) { Name = "Tech" };
-                    if (receivedNode.IsEmpty()) return;
+                        var receivedNode = ParseClientConfigNode(techMsg.TechNode.Data, techMsg.TechNode.NumBytes, "Tech");
+                        if (receivedNode.IsEmpty()) return;
 
-                    var techNodes = scenario.GetNodes("Tech").Select(v => v.Value);
-                    var specificTechNode = techNodes.FirstOrDefault(n => n.GetValue("id").Value == techMsg.TechNode.Id);
-                    if (specificTechNode != null) return; //The science node already exists so quit
+                        var techNodes = scenario.GetNodes("Tech").Select(v => v.Value);
+                        var specificTechNode = techNodes.FirstOrDefault(n =>
+                        {
+                            var id = n.GetValue("id");
+                            return id != null && id.Value == techMsg.TechNode.Id;
+                        });
+                        if (specificTechNode != null) return; //The tech node already exists so quit
 
-                    scenario.AddNode(receivedNode);
+                        scenario.AddNode(receivedNode);
+                    }
+                }
+                catch (Exception e)
+                {
+                    LunaLog.Error($"Error updating technology scenario data: {e}");
                 }
             });
         }

--- a/Server/System/ScenarioStoreSystem.cs
+++ b/Server/System/ScenarioStoreSystem.cs
@@ -20,12 +20,18 @@ namespace Server.System
         private static readonly object BackupLock = new object();
 
         /// <summary>
-        /// Returns a scenario in the standard KSP format
+        /// Returns a scenario as text for sending to clients.
+        /// Must NOT have outer { } braces — KSP's RecurseFormat treats bare lines as
+        /// root-level key-value pairs, which is what ProtoScenarioModule expects.
+        /// Wrapping in braces would nest everything in an unnamed child node,
+        /// causing node.GetValue("name") to return null on the client.
         /// </summary>
         public static string GetScenarioInConfigNodeFormat(string scenarioName)
         {
-            return CurrentScenarios.TryGetValue(scenarioName, out var scenario) ?
-                scenario.ToString() : null;
+            if (!CurrentScenarios.TryGetValue(scenarioName, out var scenario))
+                return null;
+
+            return scenario.ToString();
         }
 
         /// <summary>
@@ -38,7 +44,11 @@ namespace Server.System
             {
                 foreach (var file in Directory.GetFiles(ScenarioSystem.ScenariosPath).Where(f => Path.GetExtension(f) == ScenarioSystem.ScenarioFileFormat))
                 {
-                    CurrentScenarios.TryAdd(Path.GetFileNameWithoutExtension(file), new ConfigNode(File.ReadAllText(file)));
+                    var raw = File.ReadAllText(file).Trim();
+                    if (raw.StartsWith("{") && raw.EndsWith("}"))
+                        raw = raw.Substring(1, raw.Length - 2);
+
+                    CurrentScenarios.TryAdd(Path.GetFileNameWithoutExtension(file), new ConfigNode(raw) { Name = Path.GetFileNameWithoutExtension(file) });
                 }
 
                 if (createdFromScratch)


### PR DESCRIPTION
KSP's ConfigNode.WriteNode() wraps unnamed nodes in outer { } braces when serializing. LunaConfigNode's parser treats braced content as an unnamed child node, so when the server tries to do GetValue() on the parsed result it gets null back — and the scenario update silently does nothing. This has been quietly breaking contract, science, technology, strategy, and achievement sync on the server for any client that sends data through the normal share-progress path.

This adds a shared ParseClientConfigNode() helper in ScenarioBaseDataUpdater that strips the outer braces before parsing, and uses it in all six scenario data updaters. The same stripping is applied in LoadExistingScenarios (for scenario files read from disk) and GetScenarioInConfigNodeFormat so the format is consistent everywhere.

Every GetValue() call that previously assumed non-null (and would NRE on malformed data) now null-checks first. Every Task.Run body is wrapped in try/catch with LunaLog.Error so exceptions don't silently swallow scenario updates anymore.

Also fixes a logic bug in the strategy updater where AddNode was being called unconditionally after the FirstOrDefault search instead of only when no existing node matched — so duplicate strategies would pile up in the scenario file.

The contracts updater incorporates the recent upstream finished-contract handling (moving completed/failed/cancelled contracts to CONTRACTS_FINISHED) with the brace-stripping fix applied on top.