### PR TITLE
Batch network sends — drain up to 128 messages per flush

### DIFF
--- a/LmpClient/Network/NetworkSender.cs
+++ b/LmpClient/Network/NetworkSender.cs
@@ -15,6 +15,7 @@ namespace LmpClient.Network
     public class NetworkSender
     {
         public static ConcurrentQueue<IMessageBase> OutgoingMessages { get; set; } = new ConcurrentQueue<IMessageBase>();
+        private const int MaxMessagesPerBatch = 128;
 
         /// <summary>
         /// Main sending thread
@@ -26,9 +27,18 @@ namespace LmpClient.Network
             {
                 while (!NetworkConnection.ResetRequested)
                 {
-                    if (OutgoingMessages.Count > 0 && OutgoingMessages.TryDequeue(out var sendMessage))
+                    var sentAnyMessages = false;
+                    var sentMessages = 0;
+
+                    while (sentMessages < MaxMessagesPerBatch && OutgoingMessages.TryDequeue(out var sendMessage))
                     {
-                        SendNetworkMessage(sendMessage);
+                        sentAnyMessages |= SendNetworkMessage(sendMessage);
+                        sentMessages++;
+                    }
+
+                    if (sentAnyMessages)
+                    {
+                        NetworkMain.ClientConnection?.FlushSendQueue();
                     }
                     else
                     {
@@ -55,7 +65,7 @@ namespace LmpClient.Network
         /// Sends the network message. It will skip client messages to send when we are not connected,
         /// except if it's directed at master servers, then it will start the NetClient and socket.
         /// </summary>
-        private static void SendNetworkMessage(IMessageBase message)
+        private static bool SendNetworkMessage(IMessageBase message)
         {
             message.Data.SentTime = LunaNetworkTime.UtcNow.Ticks;
             try
@@ -93,29 +103,28 @@ namespace LmpClient.Network
                         message.Serialize(lidgrenMsg);
                         NetworkMain.ClientConnection.SendUnconnectedMessage(lidgrenMsg, masterServer);
                     }
-                    // Force send of packets
-                    NetworkMain.ClientConnection.FlushSendQueue();
+                    message.Recycle();
+                    return true;
                 }
-                else
-                {
-                    if (NetworkMain.ClientConnection == null || NetworkMain.ClientConnection.Status == NetPeerStatus.NotRunning
-                        || MainSystem.NetworkState < ClientState.Connected)
-                    {
-                        return;
-                    }
-                    var lidgrenMsg = NetworkMain.ClientConnection.CreateMessage(message.GetMessageSize());
 
-                    message.Serialize(lidgrenMsg);
-                    NetworkMain.ClientConnection.SendMessage(lidgrenMsg, message.NetDeliveryMethod, message.Channel);
-                    // Force send of packets
-                    NetworkMain.ClientConnection.FlushSendQueue();
+                if (NetworkMain.ClientConnection == null || NetworkMain.ClientConnection.Status == NetPeerStatus.NotRunning
+                    || MainSystem.NetworkState < ClientState.Connected)
+                {
+                    return false;
                 }
+
+                var outgoingMessage = NetworkMain.ClientConnection.CreateMessage(message.GetMessageSize());
+
+                message.Serialize(outgoingMessage);
+                NetworkMain.ClientConnection.SendMessage(outgoingMessage, message.NetDeliveryMethod, message.Channel);
 
                 message.Recycle();
+                return true;
             }
             catch (Exception e)
             {
                 NetworkMain.HandleDisconnectException(e);
+                return false;
             }
         }
     }


### PR DESCRIPTION
Right now SendNetworkMessage dequeues one message, flushes the socket, and returns. During busy periods (vessel updates flying in, scenario sync on connect, etc.) this means we're doing a socket flush syscall for every single message, which adds up fast.

This changes it to drain up to 128 queued messages in a loop before doing one flush. The batch size is capped with a MaxMessagesPerBatch constant so it doesn't starve other work. message.Recycle() is called consistently inside the loop, and the method now returns a bool so callers can tell whether there was actually work to do.

In practice this mostly matters on busy servers — fewer flushes means less overhead during the spikes when multiple clients are sending position updates simultaneously.