### PR TITLE
Lowered the number of Debug messages per ship (From N to 1) for missing flags 

### DIFF
--- a/LmpClient/Extensions/ProtoVesselExtension.cs
+++ b/LmpClient/Extensions/ProtoVesselExtension.cs
@@ -2,6 +2,7 @@
 using LmpClient.Systems.Flag;
 using LmpClient.Systems.Mod;
 using System;
+using System.Collections.Generic;
 using System.Linq;
 
 namespace LmpClient.Extensions
@@ -145,13 +146,21 @@ namespace LmpClient.Extensions
             }
 
             //Fix the flags urls in the vessel. The flag have the value as: "Squad/Flags/default"
+            var missingFlagCounts = new Dictionary<string, int>();
             foreach (var part in protoVessel.protoPartSnapshots.Where(p => !string.IsNullOrEmpty(p.flagURL)))
             {
                 if (!FlagSystem.Singleton.FlagExists(part.flagURL))
                 {
-                    if (verboseErrors) LunaLog.Log($"[LMP]: Flag '{part.flagURL}' doesn't exist, setting to default!");
+                    if (!missingFlagCounts.ContainsKey(part.flagURL))
+                        missingFlagCounts[part.flagURL] = 0;
+                    missingFlagCounts[part.flagURL]++;
                     part.flagURL = "Squad/Flags/default";
                 }
+            }
+            if (verboseErrors)
+            {
+                foreach (var kvp in missingFlagCounts)
+                    LunaLog.Log($"[LMP]: Flag '{kvp.Key}' doesn't exist - replaced on {kvp.Value} part(s) with default.");
             }
             return true;
         }


### PR DESCRIPTION
## Summary

In ProtoVesselExtension.Validate, the flag-URL fix loop previously emitted a LunaLog debug message for **every part** whose flag was missing. On vessels with many parts sharing the same custom flag this could spam the log with dozens of identical lines per validation call.

### Change

Instead of logging inside the loop, missing flags are now accumulated in a Dictionary<string, int> that tracks how many parts referenced each missing URL. After the loop completes, a single consolidated message is logged per unique missing flag URL, reporting the affected part count.

**Before:**
`
[LMP]: Flag 'MyMod/Flags/myflag' doesn't exist, setting to default!

[LMP]: Flag 'MyMod/Flags/myflag' doesn't exist, setting to default!

[LMP]: Flag 'MyMod/Flags/myflag' doesn't exist, setting to default!

... (repeated for every part with that flag)
`

**After:**
`
[LMP]: Flag 'MyMod/Flags/myflag' doesn't exist - replaced on 12 part(s) with default.
`

### Impact
- No behaviour change — flags are still silently replaced with Squad/Flags/default.
- Log output is reduced from O(parts) messages per missing flag to O(unique missing flags) messages per vessel validation.
- The fix is scoped entirely to LmpClient/Extensions/ProtoVesselExtension.cs and has no effect on any other system.