### PR TITLE
Fix: Suppress first-run popups in multiplayer

### DIFF
--- a/LmpClient/Base/HarmonyPatcher.cs
+++ b/LmpClient/Base/HarmonyPatcher.cs
@@ -1,5 +1,5 @@
-﻿using System.Reflection;
-
+﻿using System;
+using System.Reflection;
 namespace LmpClient.Base
 {
     public static class HarmonyPatcher
@@ -9,6 +9,58 @@ namespace LmpClient.Base
         public static void Awake()
         {
             HarmonyInstance.PatchAll(Assembly.GetExecutingAssembly());
+            PatchOptionalMods();
         }
+
+        /// <summary>
+        /// Runtime patches for mods that aren't compile-time dependencies.
+        /// Each patch is wrapped in try/catch so missing mods are silently skipped.
+        /// </summary>
+        private static void PatchOptionalMods()
+        {
+            SuppressClickThroughBlockerPopup();
+        }
+
+        /// <summary>
+        /// CTB's OneTimePopup shows every time you enter the KSC scene. It reads
+        /// PopUpShown.cfg to check if it was already shown, but something in LMP's
+        /// game creation process causes it to re-trigger on every server join.
+        /// Since the user has already configured CTB (PopUpShown.cfg = true),
+        /// suppress the popup entirely when LMP is loaded.
+        /// </summary>
+        private static void SuppressClickThroughBlockerPopup()
+        {
+            try
+            {
+                // CTB's OneTimePopup class is in the root namespace (no namespace),
+                // not "ClickThroughBlocker.OneTimePopup" despite the assembly name.
+                var popupType = HarmonyLib.AccessTools.TypeByName("OneTimePopup");
+                if (popupType == null)
+                {
+                    LunaLog.Log("[LMP]: ClickThroughBlocker OneTimePopup type not found — mod not installed, skipping");
+                    return;
+                }
+
+                var startMethod = HarmonyLib.AccessTools.Method(popupType, "Start");
+                if (startMethod == null)
+                {
+                    LunaLog.LogWarning("[LMP]: OneTimePopup.Start method not found — CTB version mismatch?");
+                    return;
+                }
+
+                var prefix = new HarmonyLib.HarmonyMethod(typeof(HarmonyPatcher), nameof(SkipMethod));
+                HarmonyInstance.Patch(startMethod, prefix: prefix);
+                LunaLog.Log("[LMP]: Patched OneTimePopup.Start — CTB popup suppressed");
+            }
+            catch (Exception e)
+            {
+                LunaLog.LogWarning($"[LMP]: Could not patch ClickThroughBlocker popup: {e.Message}");
+            }
+        }
+
+        /// <summary>
+        /// Generic prefix that skips the original method entirely.
+        /// </summary>
+        private static bool SkipMethod() => false;
     }
 }

--- a/LmpClient/Harmony/ScenarioNewGameIntro_OnLoad.cs
+++ b/LmpClient/Harmony/ScenarioNewGameIntro_OnLoad.cs
@@ -1,0 +1,29 @@
+using HarmonyLib;
+
+// ReSharper disable All
+
+namespace LmpClient.Harmony
+{
+    /// <summary>
+    /// LMP rebuilds the game from scratch on every server connection and blocks
+    /// ScenarioNewGameIntro from server sync (IgnoredScenarios), so the tutorial
+    /// flags are always false on load. This causes the KSC welcome popup and VAB/
+    /// tracking station tutorials to trigger every session.
+    ///
+    /// Fix: prefix that sets all tutorial flags to true and skips stock OnLoad,
+    /// unconditionally suppressing all tutorials in multiplayer.
+    /// </summary>
+    [HarmonyPatch(typeof(ScenarioNewGameIntro))]
+    [HarmonyPatch("OnLoad")]
+    public class ScenarioNewGameIntro_OnLoad
+    {
+        [HarmonyPrefix]
+        private static bool PrefixOnLoad(ScenarioNewGameIntro __instance)
+        {
+            __instance.kscComplete = true;
+            __instance.editorComplete = true;
+            __instance.tsComplete = true;
+            return false; // Skip stock OnLoad
+        }
+    }
+}

--- a/LmpClient/LmpClient.csproj
+++ b/LmpClient/LmpClient.csproj
@@ -194,6 +194,7 @@
     <Compile Include="Harmony\ScenarioDiscoverableObjects_SpawnAsteroid.cs" />
     <Compile Include="Harmony\ScenarioDiscoverableObjects_SpawnComet.cs" />
     <Compile Include="Harmony\ScenarioDiscoverableObjects_UpdateSpaceObjects.cs" />
+    <Compile Include="Harmony\ScenarioNewGameIntro_OnLoad.cs" />
     <Compile Include="Harmony\ShipConstruction_AssembleForLaunch.cs" />
     <Compile Include="Harmony\SpaceTracking_StopTrackingObject.cs" />
     <Compile Include="Harmony\SpaceTracking_StartTrackingObject.cs" />

--- a/LmpCommon/IgnoredScenarios.cs
+++ b/LmpCommon/IgnoredScenarios.cs
@@ -6,6 +6,7 @@ namespace LmpCommon
     {
         public static List<string> IgnoreReceive { get; } = new List<string>
         {
+            "ScenarioNewGameIntro", //Don't receive this - it resets the "new game" flag and triggers first-run popups (e.g. ClickThroughBlocker)
             "ScenarioDiscoverableObjects", //Asteroids have their own system
             "ScenarioCustomWaypoints", //Don't sync this
         };


### PR DESCRIPTION
LMP rebuilds the game object from scratch on every server connection and excludes ScenarioNewGameIntro from scenario sync. This means the tutorial flags (kscComplete, editorComplete, tsComplete) are always false when loading, so the KSC welcome popup, VAB tutorial, and tracking station tutorial re-trigger every session.

ScenarioNewGameIntro_OnLoad.cs is a Harmony prefix on ScenarioNewGameIntro.OnLoad that sets all three tutorial flags to true and skips the stock OnLoad body. This prevents the KSC welcome popup from spawning and marks all tutorials as complete for the session.

HarmonyPatcher.cs adds a PatchOptionalMods() call after PatchAll, with an initial entry for ClickThroughBlocker. CTB's OneTimePopup.Start gets re-triggered on every server join despite PopUpShown.cfg already being set, presumably because LMP's fresh Game creation confuses CTB's first-run detection. The patch looks up the type by name at runtime so it's safely a no-op if CTB isn't installed.

IgnoredScenarios.cs adds ScenarioNewGameIntro to IgnoreReceive. It was already in IgnoreSend with a matching comment, but not in IgnoreReceive — meaning a scenario packet from the server could still overwrite the local flags back to false.