### PR TITLE
Added Debug and Release arguments to the build script

### DIFF
--- a/Scripts/build-lmp-projects.bat
+++ b/Scripts/build-lmp-projects.bat
@@ -1,33 +1,61 @@
 @echo off
 setlocal
-REM Builds LMPClient, Server, and MasterServer in Debug then Release (in that order).
+REM Builds LMPClient, Server, and MasterServer.
+REM Usage: build-lmp-projects.bat [--debug | --release]
+REM   --debug    Build Debug only
+REM   --release  Build Release only
+REM   (no arg)   Build Debug then Release
 cd /d "%~dp0.."
 
-dotnet build LmpClient\LmpClient.csproj -c Debug || exit /b 1
-echo.
-echo.
-echo.
+set BUILD_DEBUG=1
+set BUILD_RELEASE=1
 
-dotnet build LmpClient\LmpClient.csproj -c Release || exit /b 1
-echo.
-echo.
-echo.
+if /i "%~1"=="--debug"   set BUILD_RELEASE=0
+if /i "%~1"=="--release" set BUILD_DEBUG=0
 
-dotnet build Server\Server.csproj -c Debug || exit /b 1
-echo.
-echo.
-echo.
+if "%~1" NEQ "" if /i "%~1" NEQ "--debug" if /i "%~1" NEQ "--release" (
+    echo Unknown argument: %~1
+    echo Usage: build-lmp-projects.bat [--debug ^| --release]
+    exit /b 1
+)
 
-dotnet build Server\Server.csproj -c Release || exit /b 1
-echo.
-echo.
-echo.
+if %BUILD_DEBUG%==1 (
+    dotnet build LmpClient\LmpClient.csproj -c Debug || exit /b 1
+    echo.
+    echo.
+    echo.
+)
 
-dotnet build MasterServer\MasterServer.csproj -c Debug || exit /b 1
-echo.
-echo.
-echo.
+if %BUILD_RELEASE%==1 (
+    dotnet build LmpClient\LmpClient.csproj -c Release || exit /b 1
+    echo.
+    echo.
+    echo.
+)
 
-dotnet build MasterServer\MasterServer.csproj -c Release || exit /b 1
+if %BUILD_DEBUG%==1 (
+    dotnet build Server\Server.csproj -c Debug || exit /b 1
+    echo.
+    echo.
+    echo.
+)
+
+if %BUILD_RELEASE%==1 (
+    dotnet build Server\Server.csproj -c Release || exit /b 1
+    echo.
+    echo.
+    echo.
+)
+
+if %BUILD_DEBUG%==1 (
+    dotnet build MasterServer\MasterServer.csproj -c Debug || exit /b 1
+    echo.
+    echo.
+    echo.
+)
+
+if %BUILD_RELEASE%==1 (
+    dotnet build MasterServer\MasterServer.csproj -c Release || exit /b 1
+)
 
 endlocal


### PR DESCRIPTION
You can now call the build script with --release or --debug to only build release or debug of Client, Server, and MasterServer respectively