### PR TITLE
More Career Contract changes to help prevent Contract Lock issues

### DIFF
--- a/LmpClient/Harmony/ContractSystem_LoadContract.cs
+++ b/LmpClient/Harmony/ContractSystem_LoadContract.cs
@@ -1,0 +1,42 @@
+using Contracts;
+using HarmonyLib;
+using LmpCommon.Enums;
+using System;
+
+// ReSharper disable All
+
+namespace LmpClient.Harmony
+{
+    /// <summary>
+    /// Suppresses exceptions thrown during individual contract loading so that one malformed
+    /// contract cannot abort the entire <c>ContractSystem.OnLoadRoutine</c> coroutine.
+    ///
+    /// Without this, a single contract with an invalid parameter (e.g. a celestial-body index
+    /// that is out-of-range on this client) throws an unhandled exception that kills the coroutine
+    /// and permanently prevents <c>GameEvents.Contract.onContractsLoaded</c> from firing.
+    ///
+    /// The pre-load filter in <see cref="LmpClient.Systems.Scenario.ScenarioSystem"/> strips the
+    /// most common cases (invalid body index, missing part) before KSP sees the node. This patch
+    /// is a second line of defence for edge cases that slip through the filter — for example,
+    /// body index values stored in an unexpected format, or parameters from mods that have their
+    /// own non-standard serialization quirks.
+    ///
+    /// Only suppresses when LMP is actively connected to a server. Single-player exceptions
+    /// propagate normally to avoid masking unrelated bugs.
+    /// </summary>
+    [HarmonyPatch(typeof(ContractSystem))]
+    [HarmonyPatch("LoadContract")]
+    public class ContractSystem_LoadContract
+    {
+        [HarmonyFinalizer]
+        private static Exception Finalizer(Exception __exception)
+        {
+            if (__exception == null) return null;
+            if (MainSystem.NetworkState < ClientState.Connected) return __exception;
+
+            LunaLog.LogError($"[ContractSystem_LoadContract]: Suppressed exception during contract loading — " +
+                             $"{__exception.GetType().Name}: {__exception.Message}");
+            return null;
+        }
+    }
+}

--- a/LmpClient/Harmony/ContractSystem_OnLoad.cs
+++ b/LmpClient/Harmony/ContractSystem_OnLoad.cs
@@ -8,21 +8,27 @@ using LmpCommon.Enums;
 namespace LmpClient.Harmony
 {
     /// <summary>
-    /// Wraps ContractSystem.OnLoad() with IgnoreEvents so that contracts restored from the
-    /// server scenario data are not killed by the ContractOffered lock-ownership check.
+    /// Keeps IgnoreEvents = true for the entire ContractSystem.OnLoad() window so that contracts
+    /// restored from the server scenario data are not killed by the ContractOffered
+    /// lock-ownership check.
     ///
     /// ContractSystem does NOT declare its own OnLoad — the method lives on ScenarioModule.
     /// HarmonyPatch attribute lookup only searches the declared methods of the specified type,
     /// so [HarmonyPatch(typeof(ContractSystem), "OnLoad")] silently finds nothing and skips.
     /// The correct target is ScenarioModule, which is the declaring type. We guard on
     /// __instance type so only the ContractSystem load is affected.
+    ///
+    /// IgnoreEvents is intentionally NOT cleared here. ShareContractsEvents.ContractsLoaded()
+    /// (triggered by onContractsLoaded, which fires after OnLoad completes) is the correct
+    /// point to stop ignoring events. Clearing it here — before onContractsLoaded fires —
+    /// creates a window in which mods such as Contract Configurator may fire onOffered for the
+    /// newly-loaded contracts; LMP's ContractOffered handler would then withdraw every server
+    /// contract the player does not hold the lock for, wiping the Available tab.
     /// </summary>
     [HarmonyPatch(typeof(ScenarioModule))]
     [HarmonyPatch("OnLoad")]
     public class ContractSystem_OnLoad
     {
-        private static bool _wasIgnoring;
-
         [HarmonyPrefix]
         private static void PrefixOnLoad(ScenarioModule __instance)
         {
@@ -32,19 +38,9 @@ namespace LmpClient.Harmony
             var system = ShareContractsSystem.Singleton;
             if (system?.Enabled != true) return;
 
-            // KSP treats OnLoad() as a state restore and does not fire onOffered per contract,
-            // so this guard is currently a no-op. It is kept as a safety net in case a future
-            // KSP version or mod causes onOffered to fire during scenario restoration.
-            _wasIgnoring = true;
+            // Safety net: IgnoreEvents should already be true (set in ShareContractsSystem.OnEnabled),
+            // but call StartIgnoringEvents defensively in case something cleared it prematurely.
             system.StartIgnoringEvents();
-        }
-
-        [HarmonyPostfix]
-        private static void PostfixOnLoad(ScenarioModule __instance)
-        {
-            if (!(__instance is ContractSystem)) return;
-            if (!_wasIgnoring) return;
-            ShareContractsSystem.Singleton?.StopIgnoringEvents();
         }
     }
 }

--- a/LmpClient/Harmony/ContractSystem_OnLoad.cs
+++ b/LmpClient/Harmony/ContractSystem_OnLoad.cs
@@ -2,15 +2,17 @@ using Contracts;
 using HarmonyLib;
 using LmpClient.Systems.ShareContracts;
 using LmpCommon.Enums;
+using System.Collections;
+using UnityEngine;
 
 // ReSharper disable All
 
 namespace LmpClient.Harmony
 {
     /// <summary>
-    /// Keeps IgnoreEvents = true for the entire ContractSystem.OnLoad() window so that contracts
-    /// restored from the server scenario data are not killed by the ContractOffered
-    /// lock-ownership check.
+    /// Wraps <c>ContractSystem.OnLoad()</c> with <c>IgnoreEvents</c> so that contracts restored
+    /// from the server scenario data are not killed by the <c>ContractOffered</c> lock-ownership
+    /// check.
     ///
     /// ContractSystem does NOT declare its own OnLoad — the method lives on ScenarioModule.
     /// HarmonyPatch attribute lookup only searches the declared methods of the specified type,
@@ -18,17 +20,29 @@ namespace LmpClient.Harmony
     /// The correct target is ScenarioModule, which is the declaring type. We guard on
     /// __instance type so only the ContractSystem load is affected.
     ///
-    /// IgnoreEvents is intentionally NOT cleared here. ShareContractsEvents.ContractsLoaded()
-    /// (triggered by onContractsLoaded, which fires after OnLoad completes) is the correct
-    /// point to stop ignoring events. Clearing it here — before onContractsLoaded fires —
-    /// creates a window in which mods such as Contract Configurator may fire onOffered for the
-    /// newly-loaded contracts; LMP's ContractOffered handler would then withdraw every server
-    /// contract the player does not hold the lock for, wiping the Available tab.
+    /// Additionally, this patch works around a KSP quirk: <c>GameEvents.Contract.onContractsLoaded</c>
+    /// only fires during the initial game load from the local save, not when LMP subsequently
+    /// re-loads ContractSystem from the server scenario. The postfix starts a monitor coroutine
+    /// that waits for the event to fire naturally (inside the async <c>OnLoadRoutine</c>). If it
+    /// does not fire within 30 seconds the coroutine fires it manually so ContractPreLoader can
+    /// resolve its injected GUIDs and LMP can run post-load reconciliation.
+    ///
+    /// The prefix intentionally does NOT guard on <see cref="ShareContractsSystem.Enabled"/>. On
+    /// the very first LMP scenario reload the system may not yet be enabled when
+    /// <c>ScenarioModule.OnLoad</c> is called, but the async <c>OnLoadRoutine</c> coroutine that
+    /// does the real work takes several seconds, giving the system time to finish initialising
+    /// before the event fires or the coroutine timeout expires.
     /// </summary>
     [HarmonyPatch(typeof(ScenarioModule))]
     [HarmonyPatch("OnLoad")]
     public class ContractSystem_OnLoad
     {
+        /// <summary>
+        /// Incremented on every ContractSystem OnLoad so that a coroutine from a previous load
+        /// cycle knows it has been superseded and exits without firing the event.
+        /// </summary>
+        private static int _loadGeneration;
+
         [HarmonyPrefix]
         private static void PrefixOnLoad(ScenarioModule __instance)
         {
@@ -36,11 +50,71 @@ namespace LmpClient.Harmony
             if (MainSystem.NetworkState < ClientState.Connected) return;
 
             var system = ShareContractsSystem.Singleton;
-            if (system?.Enabled != true) return;
+            if (system == null) return;
 
-            // Safety net: IgnoreEvents should already be true (set in ShareContractsSystem.OnEnabled),
-            // but call StartIgnoringEvents defensively in case something cleared it prematurely.
+            LunaLog.Log("[ContractSystem_OnLoad]: Prefix — resetting ContractsLoadedEventFired, starting IgnoreEvents.");
+            system.ContractsLoadedEventFired = false;
             system.StartIgnoringEvents();
+        }
+
+        [HarmonyPostfix]
+        private static void PostfixOnLoad(ScenarioModule __instance)
+        {
+            if (!(__instance is ContractSystem)) return;
+            if (MainSystem.NetworkState < ClientState.Connected) return;
+
+            var system = ShareContractsSystem.Singleton;
+            if (system == null) return;
+
+            int generation = ++_loadGeneration;
+            LunaLog.Log($"[ContractSystem_OnLoad]: Postfix — OnLoad returned synchronously, starting monitor coroutine (gen {generation}).");
+            HighLogic.fetch.StartCoroutine(WaitForContractsLoaded(system, generation));
+        }
+
+        /// <summary>
+        /// Polls <see cref="ShareContractsSystem.ContractsLoadedEventFired"/> once per frame until
+        /// it becomes true (meaning <c>ContractsLoaded()</c> ran via the natural KSP event) or
+        /// the timeout expires. On timeout, fires <c>onContractsLoaded</c> manually so that
+        /// post-load reconciliation still runs.
+        /// </summary>
+        private static IEnumerator WaitForContractsLoaded(ShareContractsSystem system, int generation)
+        {
+            const float TimeoutSeconds = 30f;
+            float elapsed = 0f;
+
+            while (!system.ContractsLoadedEventFired && elapsed < TimeoutSeconds)
+            {
+                yield return null;
+                elapsed += Time.unscaledDeltaTime;
+
+                if (generation != _loadGeneration)
+                {
+                    LunaLog.Log($"[ContractSystem_OnLoad]: Coroutine gen {generation} superseded by gen {_loadGeneration} — exiting.");
+                    yield break;
+                }
+            }
+
+            if (system.ContractsLoadedEventFired)
+            {
+                LunaLog.Log($"[ContractSystem_OnLoad]: Coroutine gen {generation} — onContractsLoaded fired naturally after {elapsed:F1}s.");
+                yield break;
+            }
+
+            // Timeout — the OnLoadRoutine coroutine either crashed or the event was not fired.
+            // Fire it manually so ContractPreLoader and LMP reconciliation still run.
+            LunaLog.Log($"[ContractSystem_OnLoad]: Coroutine gen {generation} — onContractsLoaded did not fire within {TimeoutSeconds}s, firing manually.");
+            GameEvents.Contract.onContractsLoaded.Fire();
+
+            // If ContractsLoaded() ran via the event above it will have set ContractsLoadedEventFired
+            // and called StopIgnoringEvents(). If it somehow did not (system not yet enabled /
+            // not subscribed), fall back to clearing the IgnoreEvents flag directly so ordinary
+            // contract events are not suppressed indefinitely.
+            if (!system.ContractsLoadedEventFired)
+            {
+                LunaLog.LogWarning($"[ContractSystem_OnLoad]: Coroutine gen {generation} — ContractsLoaded() did not run after manual fire " +
+                                   $"(system.Enabled={system.Enabled}), stopping IgnoreEvents as fallback.");
+                system.StopIgnoringEvents();
+            }
         }
     }
 }

--- a/LmpClient/LmpClient.csproj
+++ b/LmpClient/LmpClient.csproj
@@ -285,6 +285,7 @@
     <Compile Include="Systems\ShareAchievements\ShareAchievementsMessageSender.cs" />
     <Compile Include="Systems\ShareAchievements\ShareAchievementsSystem.cs" />
     <Compile Include="Systems\ShareCareer\ShareCareerSystem.cs" />
+    <Compile Include="Systems\ShareContracts\LmpUnavailableContract.cs" />
     <Compile Include="Systems\ShareContracts\ShareContractsEvents.cs" />
     <Compile Include="Systems\ShareContracts\ShareContractsMessageHandler.cs" />
     <Compile Include="Systems\ShareContracts\ShareContractsMessageSender.cs" />

--- a/LmpClient/LmpClient.csproj
+++ b/LmpClient/LmpClient.csproj
@@ -168,6 +168,7 @@
     <Compile Include="Harmony\EVAConstructionModeEditor_AttachPart.cs" />
     <Compile Include="Harmony\EVAConstructionModeEditor_DropAttachablePart.cs" />
     <Compile Include="Harmony\ModuleDockingNode_DockToVessel.cs" />
+    <Compile Include="Harmony\ContractSystem_LoadContract.cs" />
     <Compile Include="Harmony\ContractSystem_OnAwake.cs" />
     <Compile Include="Harmony\ContractSystem_OnLoad.cs" />
     <Compile Include="Harmony\FlightDriver_SetStartupNewVessel.cs" />

--- a/LmpClient/Systems/Scenario/ScenarioMessageHandler.cs
+++ b/LmpClient/Systems/Scenario/ScenarioMessageHandler.cs
@@ -62,8 +62,32 @@ namespace LmpClient.Systems.Scenario
                     {
                         LunaLog.Log($"[ShareContracts]: Finished Contract - GUID: {contract.GetValue("guid")} | Type: {contract.GetValue("type")} | State: {contract.GetValue("state")}");
                     }
-                }
 
+                    // Capture all Offered GUIDs and their full ConfigNodes from the server snapshot.
+                    // GUIDs are used by the ContractOffered guard to prevent re-fired onOffered
+                    // events from withdrawing valid server contracts.
+                    // Full nodes are injected into ContractPreLoader so KSPCF's patched
+                    // GenerateContracts can restore all server contracts when it runs (triggered
+                    // by CC's onContractsLoaded handler).  Without them, KSPCF treats every
+                    // server contract as unlisted and clears them, leaving 0 Available.
+                    var offeredGuids = new System.Collections.Generic.List<string>();
+                    var offeredNodes = new System.Collections.Generic.List<ConfigNode>();
+                    foreach (var contract in contracts)
+                    {
+                        if (contract.GetValue("state") == "Offered")
+                        {
+                            var guid = contract.GetValue("guid");
+                            if (!string.IsNullOrEmpty(guid))
+                            {
+                                offeredGuids.Add(guid);
+                                offeredNodes.Add(contract);
+                            }
+                        }
+                    }
+                    LunaLog.Log($"[ShareContracts]: Captured {offeredGuids.Count} Offered GUIDs and full nodes from server snapshot.");
+                    ShareContracts.ShareContractsSystem.Singleton?.SetServerOfferedContractGuids(offeredGuids);
+                    ShareContracts.ShareContractsSystem.Singleton?.SetServerOfferedContractNodes(offeredNodes);
+                }
                 var entry = new ScenarioEntry
                 {
                     ScenarioModule = scenarioModule,

--- a/LmpClient/Systems/Scenario/ScenarioSystem.cs
+++ b/LmpClient/Systems/Scenario/ScenarioSystem.cs
@@ -1,6 +1,7 @@
 ﻿using LmpClient.Base;
 using LmpClient.Extensions;
 using LmpClient.Systems.SettingsSys;
+using LmpClient.Systems.ShareContracts;
 using LmpClient.Utilities;
 using LmpCommon;
 using System;
@@ -184,14 +185,17 @@ namespace LmpClient.Systems.Scenario
 
                 if (scenarioEntry.ScenarioModule == "ContractSystem")
                 {
+                    Dictionary<string, (string TypeName, string MissingAsset)> strippedParts = null;
                     try
                     {
-                        StripContractsWithMissingParts(scenarioEntry.ScenarioNode);
+                        strippedParts = StripContractsWithMissingParts(scenarioEntry.ScenarioNode);
                     }
                     catch (Exception e)
                     {
                         LunaLog.LogError($"[ShareContracts]: Error while pre-filtering ContractSystem scenario data: {e.Message}. The scenario will be loaded as-is.");
                     }
+
+                    ShareContractsSystem.Singleton?.PrepareUnavailableContractStubs(scenarioEntry.ScenarioNode, strippedParts);
                 }
 
 
@@ -224,13 +228,21 @@ namespace LmpClient.Systems.Scenario
         /// in this client's install. Such contracts would throw an exception during ContractSystem.OnLoad()
         /// and display an error popup. They are silently dropped here instead, with a log warning.
         /// </summary>
-        private static void StripContractsWithMissingParts(ConfigNode scenarioNode)
+        /// <returns>
+        /// A dictionary mapping GUID → missing part name for every contract that was stripped.
+        /// Passed to <see cref="ShareContractsSystem.PrepareUnavailableContractStubs"/> so that
+        /// unavailability stubs can report the specific missing part.
+        /// </returns>
+        private static Dictionary<string, (string TypeName, string MissingAsset)> StripContractsWithMissingParts(ConfigNode scenarioNode)
         {
-            StripContractSectionWithMissingParts(scenarioNode, "CONTRACTS");
-            StripContractSectionWithMissingParts(scenarioNode, "CONTRACTS_FINISHED");
+            var stripped = new Dictionary<string, (string, string)>();
+            StripContractSectionWithMissingParts(scenarioNode, "CONTRACTS", stripped);
+            StripContractSectionWithMissingParts(scenarioNode, "CONTRACTS_FINISHED", stripped);
+            return stripped;
         }
 
-        private static void StripContractSectionWithMissingParts(ConfigNode scenarioNode, string sectionName)
+        private static void StripContractSectionWithMissingParts(ConfigNode scenarioNode, string sectionName,
+            Dictionary<string, (string TypeName, string MissingAsset)> strippedOut)
         {
             var sectionNode = scenarioNode.GetNode(sectionName);
             if (sectionNode == null) return;
@@ -246,7 +258,11 @@ namespace LmpClient.Systems.Scenario
                 }
                 else
                 {
-                    LunaLog.LogWarning($"[ShareContracts]: Dropping contract {contractNode.GetValue("guid")} ({contractNode.GetValue("type")}) from {sectionName} — references part '{missingPart}' which is not installed on this client.");
+                    var guid = contractNode.GetValue("guid");
+                    var typeName = contractNode.GetValue("type") ?? "Unknown";
+                    LunaLog.LogWarning($"[ShareContracts]: Dropping contract {guid} ({typeName}) from {sectionName} — references part '{missingPart}' which is not installed on this client.");
+                    if (guid != null)
+                        strippedOut[guid] = (typeName, missingPart);
                 }
             }
         }

--- a/LmpClient/Systems/Scenario/ScenarioSystem.cs
+++ b/LmpClient/Systems/Scenario/ScenarioSystem.cs
@@ -109,6 +109,48 @@ namespace LmpClient.Systems.Scenario
         }
 
         /// <summary>
+        /// Immediately saves the named <see cref="ScenarioModule"/> and sends it to the server,
+        /// bypassing the 30-second periodic send. Updates the hash-check cache so the next
+        /// periodic send skips the module if it has not changed again.
+        /// Must be called from the Unity main thread because <see cref="ScenarioModule.Save"/>
+        /// may invoke Localisation APIs that require the main thread.
+        /// </summary>
+        public void SendScenarioModuleImmediate(string moduleName)
+        {
+            if (!Enabled) return;
+            try
+            {
+                var module = ScenarioRunner.GetLoadedModules()
+                    .FirstOrDefault(m => m != null && m.GetType().Name == moduleName);
+                if (module == null)
+                {
+                    LunaLog.LogWarning($"[LMP]: SendScenarioModuleImmediate — '{moduleName}' not found in loaded modules.");
+                    return;
+                }
+
+                var configNode = new ConfigNode();
+                module.Save(configNode);
+                var scenarioBytes = configNode.Serialize();
+                if (scenarioBytes.Length == 0)
+                {
+                    LunaLog.LogWarning($"[LMP]: SendScenarioModuleImmediate — '{moduleName}' serialized to empty bytes.");
+                    return;
+                }
+
+                CheckData[moduleName] = Common.CalculateSha256Hash(scenarioBytes);
+
+                var names = new List<string> { moduleName };
+                var dataList = new List<byte[]> { scenarioBytes };
+                TaskFactory.StartNew(() => MessageSender.SendScenarioModuleData(names, dataList));
+                LunaLog.Log($"[LMP]: Sent immediate scenario for '{moduleName}' ({scenarioBytes.Length} bytes).");
+            }
+            catch (Exception e)
+            {
+                LunaLog.LogError($"[LMP]: Error sending immediate scenario for '{moduleName}': {e}");
+            }
+        }
+
+        /// <summary>
         /// This transforms the scenarioModule to a config node. We cannot do this in another thread as Lingoona 
         /// is called sometimes and that makes a hard crash
         /// </summary>
@@ -183,19 +225,57 @@ namespace LmpClient.Systems.Scenario
                     continue;
                 }
 
-                if (scenarioEntry.ScenarioModule == "ContractSystem")
+                if (scenarioEntry.ScenarioModule == "ContractPreLoader")
                 {
-                    Dictionary<string, (string TypeName, string MissingAsset)> strippedParts = null;
+                    // Inject the full Offered contract nodes that were saved when the server's
+                    // ContractSystem scenario was received.  KSPCF's ContractPreLoader.OnLoad
+                    // will deserialise these and store them internally.  When CC's
+                    // onContractsLoaded handler subsequently calls GenerateContracts(0), KSPCF's
+                    // patched implementation restores every contract whose GUID is in
+                    // ContractPreLoader's list rather than clearing them all.
+                    // Without this injection the list is empty → all 43 server contracts are
+                    // cleared → 0 Available in Mission Control for non-lock-holders.
                     try
                     {
-                        strippedParts = StripContractsWithMissingParts(scenarioEntry.ScenarioNode);
+                        InjectServerContractsIntoPreLoader(scenarioEntry.ScenarioNode);
+                    }
+                    catch (Exception e)
+                    {
+                        LunaLog.LogError($"[ContractPreLoader]: Error injecting server contracts into ContractPreLoader node: {e.Message}");
+                    }
+                }
+
+                if (scenarioEntry.ScenarioModule == "ContractSystem")
+                {
+                    try
+                    {
+                        var migrated = MigrateFinishedContractsIntoMain(scenarioEntry.ScenarioNode);
+                        if (migrated > 0)
+                            LunaLog.Log($"[ShareContracts]: Migrated {migrated} contract(s) from CONTRACTS_FINISHED into CONTRACTS with correct state so ReconcileFinishedContracts can place them in the Archive tab.");
+                    }
+                    catch (Exception e)
+                    {
+                        LunaLog.LogError($"[ShareContracts]: Error migrating CONTRACTS_FINISHED into CONTRACTS: {e.Message}. The scenario will be loaded as-is.");
+                    }
+
+                    Dictionary<string, (string TypeName, string MissingAsset)> stripped = null;
+                    try
+                    {
+                        stripped = StripContractsWithMissingParts(scenarioEntry.ScenarioNode);
                     }
                     catch (Exception e)
                     {
                         LunaLog.LogError($"[ShareContracts]: Error while pre-filtering ContractSystem scenario data: {e.Message}. The scenario will be loaded as-is.");
                     }
 
-                    ShareContractsSystem.Singleton?.PrepareUnavailableContractStubs(scenarioEntry.ScenarioNode, strippedParts);
+                    try
+                    {
+                        ShareContracts.ShareContractsSystem.Singleton?.PrepareUnavailableContractStubs(scenarioEntry.ScenarioNode, stripped);
+                    }
+                    catch (Exception e)
+                    {
+                        LunaLog.LogError($"[ShareContracts]: Error while preparing unavailability stubs: {e.Message}.");
+                    }
                 }
 
 
@@ -224,21 +304,149 @@ namespace LmpClient.Systems.Scenario
         }
 
         /// <summary>
-        /// Removes CONTRACT nodes from the ContractSystem scenario that reference part names not present
-        /// in this client's install. Such contracts would throw an exception during ContractSystem.OnLoad()
-        /// and display an error popup. They are silently dropped here instead, with a log warning.
+        /// Injects the full CONTRACT nodes from the server snapshot into the ContractPreLoader
+        /// scenario node so that KSPCF's ContractPreLoader.OnLoad will store them and
+        /// subsequently restore them when ContractConfigurator triggers
+        /// <c>ContractSystem.GenerateContracts</c> from its <c>onContractsLoaded</c> handler.
+        ///
+        /// KSPCF's patched <c>GenerateContracts</c> uses ContractPreLoader's in-memory list as
+        /// a whitelist.  Any contract not in that list is removed.  With an empty list every
+        /// server contract is cleared and, since <c>generateContractIterations == 0</c> for
+        /// non-lock-holders, nothing new is generated → 0 Available.  With full nodes in the
+        /// list KSPCF recognises and restores all server contracts.
+        ///
+        /// The nodes come from <see cref="ShareContracts.ShareContractsSystem.ServerOfferedContractNodes"/>,
+        /// which is populated in <see cref="ScenarioMessageHandler.QueueScenarioBytes"/> when
+        /// the server's ContractSystem data arrives (well before loading begins).
         /// </summary>
-        /// <returns>
-        /// A dictionary mapping GUID → missing part name for every contract that was stripped.
-        /// Passed to <see cref="ShareContractsSystem.PrepareUnavailableContractStubs"/> so that
-        /// unavailability stubs can report the specific missing part.
-        /// </returns>
+        private static void InjectServerContractsIntoPreLoader(ConfigNode preLoaderNode)
+        {
+            var nodes = ShareContracts.ShareContractsSystem.Singleton?.ServerOfferedContractNodes;
+            if (nodes == null || nodes.Count == 0)
+            {
+                LunaLog.Log("[ContractPreLoader]: No server Offered contract nodes to inject.");
+                return;
+            }
+
+            // Build a set of GUIDs already present so we never create duplicates.
+            var existingGuids = new System.Collections.Generic.HashSet<string>(StringComparer.OrdinalIgnoreCase);
+            foreach (ConfigNode child in preLoaderNode.nodes)
+            {
+                var g = child.GetValue("guid") ?? child.GetValue("id");
+                if (!string.IsNullOrEmpty(g))
+                    existingGuids.Add(g);
+            }
+
+            var injected = 0;
+            foreach (var contractNode in nodes)
+            {
+                var guid = contractNode.GetValue("guid");
+                if (string.IsNullOrEmpty(guid) || existingGuids.Contains(guid))
+                    continue;
+
+                // Add the full CONTRACT node (same name KSP uses in ContractSystem.OnSave).
+                // KSPCF's ContractPreLoader.OnLoad calls Contract.Load(node) on each child,
+                // which requires type, guid, state, and all parameters to succeed.
+                preLoaderNode.AddNode(contractNode);
+                existingGuids.Add(guid);
+                injected++;
+            }
+
+            LunaLog.Log($"[ContractPreLoader]: Injected {injected} full CONTRACT nodes into ContractPreLoader ({nodes.Count} server Offered contracts).");
+        }
+
+        /// <summary>
+        /// Corrects a server data inconsistency where completed contracts are stored in both
+        /// <c>CONTRACTS</c> (with a stale <c>Active</c> state) and <c>CONTRACTS_FINISHED</c>
+        /// (with the authoritative <c>Completed</c> state and fully-resolved parameter states).
+        ///
+        /// KSP's <c>ContractSystem.OnLoad</c> cannot reliably load contracts from
+        /// <c>CONTRACTS_FINISHED</c> — exceptions during parameter loading are suppressed by the
+        /// <see cref="ContractSystem_LoadContract"/> finalizer, leaving
+        /// <c>ContractSystem.ContractsFinished</c> empty.  The designed path for getting finished
+        /// contracts into the Archive tab is: load them from <c>CONTRACTS</c> with the correct
+        /// finished state, then let <see cref="ShareContractsEvents.ReconcileFinishedContracts"/>
+        /// move them from <c>ContractSystem.Contracts</c> to <c>ContractSystem.ContractsFinished</c>.
+        ///
+        /// This method replaces each stale <c>CONTRACTS</c> entry with the authoritative node
+        /// from <c>CONTRACTS_FINISHED</c>, then removes those entries from <c>CONTRACTS_FINISHED</c>
+        /// so KSP does not attempt a second (failing) load from there.
+        /// </summary>
+        /// <returns>The number of contract entries migrated.</returns>
+        private static int MigrateFinishedContractsIntoMain(ConfigNode scenarioNode)
+        {
+            var contractsNode = scenarioNode.GetNode("CONTRACTS");
+            var finishedNode  = scenarioNode.GetNode("CONTRACTS_FINISHED");
+            if (contractsNode == null || finishedNode == null) return 0;
+
+            // Index CONTRACTS_FINISHED by GUID.
+            var finishedByGuid = new System.Collections.Generic.Dictionary<string, ConfigNode>(StringComparer.OrdinalIgnoreCase);
+            foreach (var finishedContract in finishedNode.GetNodes("CONTRACT"))
+            {
+                var guid = finishedContract.GetValue("guid");
+                if (!string.IsNullOrEmpty(guid))
+                    finishedByGuid[guid] = finishedContract;
+            }
+
+            if (finishedByGuid.Count == 0) return 0;
+
+            // Rebuild CONTRACTS, swapping stale Active entries for their authoritative counterparts.
+            var contractNodes = contractsNode.GetNodes("CONTRACT");
+            contractsNode.ClearNodes();
+            var migrated = 0;
+            foreach (var contractNode in contractNodes)
+            {
+                var guid = contractNode.GetValue("guid");
+                if (!string.IsNullOrEmpty(guid) && finishedByGuid.TryGetValue(guid, out var authoritative))
+                {
+                    LunaLog.LogWarning($"[ShareContracts]: Replacing CONTRACTS entry for {guid} ({contractNode.GetValue("type") ?? "Unknown"}) " +
+                                       $"with authoritative CONTRACTS_FINISHED node (state: {contractNode.GetValue("state")} → {authoritative.GetValue("state")}).");
+                    contractsNode.AddNode(authoritative);
+                    migrated++;
+                }
+                else
+                {
+                    contractsNode.AddNode(contractNode);
+                }
+            }
+
+            if (migrated == 0) return 0;
+
+            // Remove migrated entries from CONTRACTS_FINISHED so KSP does not attempt
+            // a second load of the same contracts from there.
+            var finishedNodes = finishedNode.GetNodes("CONTRACT");
+            finishedNode.ClearNodes();
+            foreach (var fc in finishedNodes)
+            {
+                var guid = fc.GetValue("guid");
+                if (string.IsNullOrEmpty(guid) || !finishedByGuid.ContainsKey(guid))
+                    finishedNode.AddNode(fc);
+                // Entries that were migrated are intentionally dropped from CONTRACTS_FINISHED.
+            }
+
+            return migrated;
+        }
+
+        /// <summary>
+        /// Removes CONTRACT nodes from the ContractSystem scenario that would cause
+        /// <see cref="Contracts.ContractSystem.LoadContract"/> to throw an unhandled exception on
+        /// this client. Currently detects:
+        /// <list type="bullet">
+        ///   <item>References to part names absent from <see cref="PartLoader"/> (e.g. mod parts the
+        ///         client does not have installed).</item>
+        ///   <item>Celestial body indices (integer-format "body" / "targetBody" values) that are
+        ///         out of range for this client's <see cref="FlightGlobals.Bodies"/> list (e.g. the
+        ///         server has a planet pack the client does not have).</item>
+        /// </list>
+        /// Stripped contracts are returned so that <see cref="ShareContractsSystem.PrepareUnavailableContractStubs"/>
+        /// can create informative <see cref="ShareContracts.LmpUnavailableContract"/> stubs for them.
+        /// </summary>
         private static Dictionary<string, (string TypeName, string MissingAsset)> StripContractsWithMissingParts(ConfigNode scenarioNode)
         {
-            var stripped = new Dictionary<string, (string, string)>();
-            StripContractSectionWithMissingParts(scenarioNode, "CONTRACTS", stripped);
-            StripContractSectionWithMissingParts(scenarioNode, "CONTRACTS_FINISHED", stripped);
-            return stripped;
+            var strippedOut = new Dictionary<string, (string TypeName, string MissingAsset)>();
+            StripContractSectionWithMissingParts(scenarioNode, "CONTRACTS", strippedOut);
+            StripContractSectionWithMissingParts(scenarioNode, "CONTRACTS_FINISHED", strippedOut);
+            return strippedOut;
         }
 
         private static void StripContractSectionWithMissingParts(ConfigNode scenarioNode, string sectionName,
@@ -251,19 +459,28 @@ namespace LmpClient.Systems.Scenario
             sectionNode.ClearNodes();
             foreach (var contractNode in contractNodes)
             {
+                var guid = contractNode.GetValue("guid");
+                var typeName = contractNode.GetValue("type") ?? "Unknown";
+
                 var missingPart = FindMissingPartName(contractNode);
-                if (missingPart == null)
+                if (missingPart != null)
                 {
-                    sectionNode.AddNode(contractNode);
-                }
-                else
-                {
-                    var guid = contractNode.GetValue("guid");
-                    var typeName = contractNode.GetValue("type") ?? "Unknown";
                     LunaLog.LogWarning($"[ShareContracts]: Dropping contract {guid} ({typeName}) from {sectionName} — references part '{missingPart}' which is not installed on this client.");
                     if (guid != null)
-                        strippedOut[guid] = (typeName, missingPart);
+                        strippedOut[guid] = (typeName, $"part '{missingPart}'");
+                    continue;
                 }
+
+                var invalidBody = FindInvalidBodyIndex(contractNode);
+                if (invalidBody != null)
+                {
+                    LunaLog.LogWarning($"[ShareContracts]: Dropping contract {guid} ({typeName}) from {sectionName} — references {invalidBody} which is out of range on this client. The server likely has a planet pack installed that this client does not.");
+                    if (guid != null)
+                        strippedOut[guid] = (typeName, invalidBody);
+                    continue;
+                }
+
+                sectionNode.AddNode(contractNode);
             }
         }
 
@@ -283,6 +500,71 @@ namespace LmpClient.Systems.Scenario
             {
                 var missing = FindMissingPartName(childNode);
                 if (missing != null) return missing;
+            }
+            return null;
+        }
+
+        /// <summary>
+        /// Set of ConfigNode value names that KSP contract parameters use as integer celestial-body
+        /// indices.  Any integer stored under one of these keys is validated against
+        /// <see cref="FlightGlobals.Bodies"/>; an out-of-range value means this client is missing
+        /// a body (e.g. a planet-pack mod) and the contract must be stripped to prevent
+        /// <see cref="ArgumentOutOfRangeException"/> spam from parameters like
+        /// <c>ReachDestination.OnLoad</c>, <c>CollectScience.OnLoad</c>, etc.
+        /// </summary>
+        private static readonly System.Collections.Generic.HashSet<string> BodyIndexKeys =
+            new System.Collections.Generic.HashSet<string>(StringComparer.OrdinalIgnoreCase)
+            {
+                "body",         // most parameters (CollectScience, ReachSpace, etc.)
+                "targetBody",   // survey / plant flag parameters
+                "destination",  // ReachDestination
+                "origin",       // return-from-body parameters
+                "body1",        // flyby / multi-body parameters
+                "body2",
+            };
+
+        /// <summary>
+        /// Recursively searches a contract ConfigNode for any value whose key is a recognised
+        /// celestial-body index field and whose integer value falls outside the range of
+        /// <see cref="FlightGlobals.Bodies"/> on this client.
+        ///
+        /// Returns a human-readable description such as "body index #6 (key 'destination')" on
+        /// mismatch, or null if all body references are valid.  String-format body names (e.g.
+        /// "Duna") are not checked because they are resolved by name and do not cause index errors.
+        /// </summary>
+        private static string FindInvalidBodyIndex(ConfigNode node)
+        {
+            // Guard: if Bodies hasn't been populated yet (shouldn't happen at load time, but be safe).
+            if (FlightGlobals.Bodies == null || FlightGlobals.Bodies.Count == 0)
+                return null;
+
+            foreach (ConfigNode.Value v in node.values)
+            {
+                if (!BodyIndexKeys.Contains(v.name)) continue;
+
+                int idx;
+                if (int.TryParse(v.value, out idx))
+                {
+                    if (idx < 0 || idx >= FlightGlobals.Bodies.Count)
+                        return $"body index #{idx} (key '{v.name}')";
+                }
+                else if (double.TryParse(v.value,
+                             System.Globalization.NumberStyles.Float,
+                             System.Globalization.CultureInfo.InvariantCulture,
+                             out var dbl)
+                         && dbl >= 0
+                         && dbl == System.Math.Floor(dbl))
+                {
+                    // KSP occasionally serialises body indices as floats (e.g. "17" → "17.0").
+                    idx = (int)dbl;
+                    if (idx >= FlightGlobals.Bodies.Count)
+                        return $"body index #{idx} (key '{v.name}', stored as float)";
+                }
+            }
+            foreach (ConfigNode childNode in node.nodes)
+            {
+                var invalid = FindInvalidBodyIndex(childNode);
+                if (invalid != null) return invalid;
             }
             return null;
         }

--- a/LmpClient/Systems/ShareContracts/LmpUnavailableContract.cs
+++ b/LmpClient/Systems/ShareContracts/LmpUnavailableContract.cs
@@ -1,0 +1,60 @@
+using Contracts;
+
+namespace LmpClient.Systems.ShareContracts
+{
+    /// <summary>
+    /// A placeholder contract shown in the Available tab when the server has a contract
+    /// whose type or required assets (parts, experiments) are not installed on this client.
+    /// The contract cannot be accepted and exists solely to inform the player of server-side
+    /// content they are missing.
+    ///
+    /// Stubs are created transiently at scene load from <see cref="ShareContractsEvents.ContractsLoaded"/>
+    /// and are never sent back to the server (ContractSystem is in IgnoredScenarios.IgnoreSend).
+    /// </summary>
+    public class LmpUnavailableContract : Contract
+    {
+        internal const string OriginalTypeKey = "lmpOriginalType";
+        internal const string MissingAssetKey = "lmpMissingAsset";
+
+        public string OriginalTypeName { get; private set; } = "Unknown";
+
+        /// <summary>
+        /// Name of the missing part if the contract was dropped because of a part validation
+        /// failure, or null if the contract type itself was unavailable.
+        /// </summary>
+        public string MissingAsset { get; private set; }
+
+        // Never auto-generate new instances of this type.
+        protected override bool Generate() => false;
+
+        public override bool MeetRequirements() => false;
+
+        protected override void OnLoad(ConfigNode node)
+        {
+            OriginalTypeName = node.GetValue(OriginalTypeKey) ?? "Unknown";
+            MissingAsset = node.GetValue(MissingAssetKey);
+        }
+
+        protected override void OnSave(ConfigNode node)
+        {
+            node.AddValue(OriginalTypeKey, OriginalTypeName);
+            if (MissingAsset != null)
+                node.AddValue(MissingAssetKey, MissingAsset);
+        }
+
+        protected override string GetTitle()
+            => $"[Not Available] {OriginalTypeName}";
+
+        protected override string GetDescription()
+            => MissingAsset != null
+                ? $"This contract requires the part \"{MissingAsset}\" which is not installed on this client. " +
+                  $"It was offered on the server using mod content you do not have."
+                : $"This contract requires the content type \"{OriginalTypeName}\" which is not installed on " +
+                  $"this client. It was offered on the server using a mod you do not have.";
+
+        protected override string GetSynopsys()
+            => "Requires mod content not installed on this client.";
+
+        protected override string MessageCompleted() => string.Empty;
+    }
+}

--- a/LmpClient/Systems/ShareContracts/LmpUnavailableContract.cs
+++ b/LmpClient/Systems/ShareContracts/LmpUnavailableContract.cs
@@ -4,9 +4,9 @@ namespace LmpClient.Systems.ShareContracts
 {
     /// <summary>
     /// A placeholder contract shown in the Available tab when the server has a contract
-    /// whose type or required assets (parts, experiments) are not installed on this client.
-    /// The contract cannot be accepted and exists solely to inform the player of server-side
-    /// content they are missing.
+    /// whose type or required assets (parts, experiments, celestial bodies) are not available
+    /// on this client.  The contract cannot be accepted and exists solely to inform the player
+    /// of server-side content they are missing.
     ///
     /// Stubs are created transiently at scene load from <see cref="ShareContractsEvents.ContractsLoaded"/>
     /// and are never sent back to the server (ContractSystem is in IgnoredScenarios.IgnoreSend).
@@ -19,8 +19,12 @@ namespace LmpClient.Systems.ShareContracts
         public string OriginalTypeName { get; private set; } = "Unknown";
 
         /// <summary>
-        /// Name of the missing part if the contract was dropped because of a part validation
-        /// failure, or null if the contract type itself was unavailable.
+        /// Human-readable description of the specific missing resource, e.g.:
+        /// <list type="bullet">
+        ///   <item>"part 'SomeModPart'" — a required part is not in PartLoader.</item>
+        ///   <item>"body index #6" — a celestial body index is out of range (planet pack mismatch).</item>
+        /// </list>
+        /// Null when the contract type itself is unknown (missing mod) rather than a specific asset.
         /// </summary>
         public string MissingAsset { get; private set; }
 
@@ -47,8 +51,8 @@ namespace LmpClient.Systems.ShareContracts
 
         protected override string GetDescription()
             => MissingAsset != null
-                ? $"This contract requires the part \"{MissingAsset}\" which is not installed on this client. " +
-                  $"It was offered on the server using mod content you do not have."
+                ? $"This contract requires {MissingAsset}, which is not available on this client. " +
+                  $"The server has mod content (parts, planet packs, etc.) that you do not have installed."
                 : $"This contract requires the content type \"{OriginalTypeName}\" which is not installed on " +
                   $"this client. It was offered on the server using a mod you do not have.";
 

--- a/LmpClient/Systems/ShareContracts/ShareContractsEvents.cs
+++ b/LmpClient/Systems/ShareContracts/ShareContractsEvents.cs
@@ -4,6 +4,8 @@ using LmpClient.Base;
 using LmpClient.Systems.Lock;
 using LmpClient.Systems.SettingsSys;
 using LmpCommon.Locks;
+using System;
+using System.Collections.Generic;
 
 namespace LmpClient.Systems.ShareContracts
 {
@@ -81,6 +83,103 @@ namespace LmpClient.Systems.ShareContracts
             // generateContractIterations back to the default, which always happens after
             // LevelLoaded/TryGetContractLock. So there is no race between this and LockAcquire.
             System.StopIgnoringEvents();
+            CreateUnavailableContractStubs();
+        }
+
+        /// <summary>
+        /// After the ContractSystem finishes loading from the server snapshot, compares the set of
+        /// contracts that actually loaded against the set that were expected. For each Offered
+        /// contract that is absent — dropped by ContractConfigurator due to a missing mod type, or
+        /// stripped pre-load due to a missing part — an <see cref="LmpUnavailableContract"/> stub
+        /// is added to <see cref="ContractSystem.Instance"/> so the player can see which server
+        /// contracts they cannot take on their client.
+        /// </summary>
+        private void CreateUnavailableContractStubs()
+        {
+            if (!System.Enabled) return;
+            if (ContractSystem.Instance == null) return;
+
+            var pending = System.PendingUnavailableContracts;
+            if (pending.Count == 0) return;
+
+            // Map GUID → contract object so we can inspect broken shells, not just presence.
+            var loadedContracts = new Dictionary<string, Contract>();
+            foreach (var contract in ContractSystem.Instance.Contracts)
+            {
+                if (contract != null && !(contract is LmpUnavailableContract))
+                    loadedContracts[contract.ContractGuid.ToString()] = contract;
+            }
+
+            var stubsCreated = 0;
+            foreach (var kvp in pending)
+            {
+                var guid = kvp.Key;
+                loadedContracts.TryGetValue(guid, out var loaded);
+
+                bool needsStub;
+                if (loaded == null)
+                {
+                    // Contract was stripped pre-load or completely failed to produce an object.
+                    needsStub = true;
+                }
+                else if (loaded.ParameterCount == 0)
+                {
+                    // Contract loaded as a parameterless shell — ContractConfigurator could not
+                    // find the contract type (missing mod). CC's MeetRequirements() returns false
+                    // for these, making them silently invisible. Replace with an informative stub.
+                    ContractSystem.Instance.Contracts.Remove(loaded);
+                    needsStub = true;
+                }
+                else
+                {
+                    needsStub = false;
+                }
+
+                if (!needsStub) continue;
+
+                try
+                {
+                    var stub = BuildUnavailableContractStub(guid, kvp.Value.TypeName, kvp.Value.MissingAsset);
+                    if (stub != null)
+                    {
+                        ContractSystem.Instance.Contracts.Add(stub);
+                        stubsCreated++;
+                        LunaLog.Log($"[ShareContracts]: Created unavailability stub for {guid} (type: {kvp.Value.TypeName}" +
+                                    (kvp.Value.MissingAsset != null ? $", missing part: {kvp.Value.MissingAsset}" : string.Empty) + ").");
+                    }
+                }
+                catch (Exception e)
+                {
+                    LunaLog.LogError($"[ShareContracts]: Failed to create unavailability stub for {guid}: {e.Message}");
+                }
+            }
+
+            pending.Clear();
+
+            if (stubsCreated > 0)
+            {
+                LunaLog.Log($"[ShareContracts]: {stubsCreated} unavailability stub(s) added to the Available contracts list.");
+                GameEvents.Contract.onContractsListChanged.Fire();
+            }
+        }
+
+        private static LmpUnavailableContract BuildUnavailableContractStub(string guid, string typeName, string missingAsset)
+        {
+            var node = new ConfigNode();
+            node.AddValue("guid", guid);
+            node.AddValue("prestige", "Trivial");
+            node.AddValue("seed", "0");
+            node.AddValue("state", "Offered");
+            node.AddValue("viewed", "Unseen");
+            node.AddValue("deadlineType", "None");
+            node.AddValue("expiryType", "None");
+            node.AddValue("ignoresWeight", "True");
+            node.AddValue("values", "0,0,0,0,0,0,0,0,0,0,0,0");
+            node.AddValue(LmpUnavailableContract.OriginalTypeKey, typeName);
+            if (missingAsset != null)
+                node.AddValue(LmpUnavailableContract.MissingAssetKey, missingAsset);
+
+            return Contract.Load(new LmpUnavailableContract(), node) as LmpUnavailableContract;
         }
 
         public void ContractDeclined(Contract contract)
@@ -109,6 +208,9 @@ namespace LmpClient.Systems.ShareContracts
 
         public void ContractOffered(Contract contract)
         {
+            // LmpUnavailableContract stubs are injected by LMP itself — never touch them here.
+            if (contract is LmpUnavailableContract) return;
+
             // Allow contracts being loaded from server data to pass through untouched.
             // IgnoreEvents is set both during ContractUpdate (ShareProgress path) and during
             // ContractSystem.OnLoad() (scenario restore path) via ContractSystem_OnLoad patch.
@@ -119,24 +221,21 @@ namespace LmpClient.Systems.ShareContracts
                 //We don't have the contract lock, so discard any contract KSP generated locally.
                 //New generation is already suppressed via generateContractIterations = 0; this
                 //is a safety net for any edge case where KSP still fires the event.
-                contract.Withdraw();
-                contract.Kill();
+                WithdrawAndRemoveContract(contract);
                 return;
             }
 
             if (contract.GetType().Name == "RecoverAsset")
             {
                 //We don't support rescue contracts. See: https://github.com/LunaMultiplayer/LunaMultiplayer/issues/226#issuecomment-431831526
-                contract.Withdraw();
-                contract.Kill();
+                WithdrawAndRemoveContract(contract);
                 return;
             }
 
             if (contract.GetType().Name == "TourismContract")
             {
                 //We don't support tourism contracts.
-                contract.Withdraw();
-                contract.Kill();
+                WithdrawAndRemoveContract(contract);
                 return;
             }
 
@@ -169,5 +268,20 @@ namespace LmpClient.Systems.ShareContracts
         }
 
         #endregion
+
+        /// <summary>
+        /// Withdraws a locally-generated contract and removes it from the ContractSystem without
+        /// calling Contract.Kill(). Kill() destroys Unity GameObjects that ContractsApp's UIList
+        /// may already hold references to, causing a NullReferenceException in UIList.Clear() the
+        /// next time the contracts panel is opened. Withdraw() fires onContractsListChanged so the
+        /// UI rebuilds cleanly while the entry is still alive, after which the contract is safely
+        /// removed from memory.
+        /// </summary>
+        private static void WithdrawAndRemoveContract(Contract contract)
+        {
+            contract.Withdraw();
+            ContractSystem.Instance.Contracts.Remove(contract);
+            contract.Unregister();
+        }
     }
 }

--- a/LmpClient/Systems/ShareContracts/ShareContractsEvents.cs
+++ b/LmpClient/Systems/ShareContracts/ShareContractsEvents.cs
@@ -78,12 +78,87 @@ namespace LmpClient.Systems.ShareContracts
         public void ContractsLoaded()
         {
             LunaLog.Log("Contracts loaded.");
-            // Safe point to stop ignoring events: ContractSystem.OnLoad() has fully completed.
-            // ContractOffered from new contract generation cannot fire until LockAcquire sets
-            // generateContractIterations back to the default, which always happens after
-            // LevelLoaded/TryGetContractLock. So there is no race between this and LockAcquire.
+            // Safe point to stop ignoring events: ContractSystem.OnLoad() has fully completed
+            // and any post-load mod processing (e.g. Contract Configurator sweeps) that fires
+            // onOffered is now behind us. ContractOffered from new generation cannot fire until
+            // LockAcquire sets generateContractIterations back to the default.
             System.StopIgnoringEvents();
+            LogContractStateBreakdown();
+            ReconcileFinishedContracts();
             CreateUnavailableContractStubs();
+        }
+
+        /// <summary>
+        /// Logs a breakdown of how many contracts are currently in ContractSystem.Instance
+        /// split by state, to aid in diagnosing sync issues after load.
+        /// </summary>
+        private static void LogContractStateBreakdown()
+        {
+            if (ContractSystem.Instance == null) return;
+
+            var offered = 0;
+            var active = 0;
+            var finished = 0;
+            var other = 0;
+
+            foreach (var c in ContractSystem.Instance.Contracts)
+            {
+                if (c == null) continue;
+                switch (c.ContractState)
+                {
+                    case Contract.State.Offered:    offered++;  break;
+                    case Contract.State.Active:     active++;   break;
+                    case Contract.State.Completed:
+                    case Contract.State.Failed:
+                    case Contract.State.Cancelled:
+                    case Contract.State.Withdrawn:
+                    case Contract.State.DeadlineExpired:
+                        finished++;
+                        break;
+                    default:
+                        other++;
+                        break;
+                }
+            }
+
+            LunaLog.Log($"[ShareContracts]: ContractsLoaded state — " +
+                        $"Contracts list: {offered} Offered, {active} Active, {finished} Finished-in-wrong-list, {other} Other | " +
+                        $"ContractsFinished list: {ContractSystem.Instance.ContractsFinished.Count}");
+        }
+
+        /// <summary>
+        /// The server persists Completed/Failed/Cancelled contracts in the CONTRACTS section
+        /// until a client update triggers the server-side migrator. KSP's ContractSystem.OnLoad
+        /// puts every entry from CONTRACTS into ContractSystem.Contracts regardless of state,
+        /// so those finished contracts never reach ContractSystem.ContractsFinished and remain
+        /// invisible in the Archive tab.
+        ///
+        /// This method detects the mismatch and moves every finished contract from Contracts to
+        /// ContractsFinished so the Archive tab shows them immediately on connect.
+        /// </summary>
+        private static void ReconcileFinishedContracts()
+        {
+            if (ContractSystem.Instance == null) return;
+
+            var toMove = new System.Collections.Generic.List<Contract>();
+            foreach (var c in ContractSystem.Instance.Contracts)
+            {
+                if (c == null || c is LmpUnavailableContract) continue;
+                if (c.IsFinished())
+                    toMove.Add(c);
+            }
+
+            if (toMove.Count == 0) return;
+
+            foreach (var c in toMove)
+            {
+                ContractSystem.Instance.Contracts.Remove(c);
+                ContractSystem.Instance.ContractsFinished.Add(c);
+                LunaLog.Log($"[ShareContracts]: Moved finished contract {c.ContractGuid} ({c.GetType().Name}, " +
+                            $"state: {c.ContractState}) from Contracts to ContractsFinished.");
+            }
+
+            LunaLog.Log($"[ShareContracts]: Reconciled {toMove.Count} finished contract(s) into the Archive list.");
         }
 
         /// <summary>

--- a/LmpClient/Systems/ShareContracts/ShareContractsEvents.cs
+++ b/LmpClient/Systems/ShareContracts/ShareContractsEvents.cs
@@ -5,7 +5,10 @@ using LmpClient.Systems.Lock;
 using LmpClient.Systems.SettingsSys;
 using LmpCommon.Locks;
 using System;
+using System.Collections;
 using System.Collections.Generic;
+using System.Linq;
+using UnityEngine;
 
 namespace LmpClient.Systems.ShareContracts
 {
@@ -72,20 +75,99 @@ namespace LmpClient.Systems.ShareContracts
 
         public void ContractsListChanged()
         {
-            LunaLog.Log("Contract list changed.");
+            var cs = ContractSystem.Instance;
+            if (cs != null)
+            {
+                var offered  = cs.Contracts.Count(c => c.ContractState == Contract.State.Offered);
+                var active   = cs.Contracts.Count(c => c.ContractState == Contract.State.Active);
+                var finished = cs.ContractsFinished.Count;
+                LunaLog.Log($"[ShareContracts]: Contract list changed — {offered} Offered, {active} Active, {finished} Finished in ContractsFinished.");
+            }
+            else
+            {
+                LunaLog.Log("[ShareContracts]: Contract list changed (ContractSystem not available).");
+            }
         }
 
         public void ContractsLoaded()
         {
             LunaLog.Log("Contracts loaded.");
-            // Safe point to stop ignoring events: ContractSystem.OnLoad() has fully completed
-            // and any post-load mod processing (e.g. Contract Configurator sweeps) that fires
-            // onOffered is now behind us. ContractOffered from new generation cannot fire until
-            // LockAcquire sets generateContractIterations back to the default.
+            // Tell the Harmony postfix that onContractsLoaded fired normally so it does not
+            // fire it a second time.
+            System.ContractsLoadedEventFired = true;
+            // Safe point to stop ignoring events: ContractSystem.OnLoad() has fully completed.
+            // ContractOffered from new contract generation cannot fire until LockAcquire sets
+            // generateContractIterations back to the default, which always happens after
+            // LevelLoaded/TryGetContractLock. So there is no race between this and LockAcquire.
             System.StopIgnoringEvents();
             LogContractStateBreakdown();
             ReconcileFinishedContracts();
             CreateUnavailableContractStubs();
+            LogContractPreLoaderState();
+            LogMissionControlTally();
+            HighLogic.fetch.StartCoroutine(PostLoadContractCheck());
+        }
+
+        /// <summary>
+        /// Logs the Offered contract count once per frame for 5 frames after ContractsLoaded(),
+        /// then at 1 s and 3 s, to pinpoint exactly when (and therefore which system) removes
+        /// contracts that are present at the end of our onContractsLoaded handler.
+        /// </summary>
+        private static System.Collections.IEnumerator PostLoadContractCheck()
+        {
+            var cs = ContractSystem.Instance;
+            if (cs == null) yield break;
+
+            for (int i = 1; i <= 5; i++)
+            {
+                yield return null;
+                var offered = cs.Contracts.Count(c => c.ContractState == Contract.State.Offered);
+                LunaLog.Log($"[ShareContracts]: Post-load check frame +{i} — {offered} Offered contracts.");
+                if (offered == 0) yield break;
+            }
+
+            yield return new UnityEngine.WaitForSecondsRealtime(1f);
+            {
+                var offered = cs.Contracts.Count(c => c.ContractState == Contract.State.Offered);
+                LunaLog.Log($"[ShareContracts]: Post-load check +1 s — {offered} Offered contracts.");
+            }
+
+            yield return new UnityEngine.WaitForSecondsRealtime(2f);
+            {
+                var offered = cs.Contracts.Count(c => c.ContractState == Contract.State.Offered);
+                LunaLog.Log($"[ShareContracts]: Post-load check +3 s — {offered} Offered contracts.");
+            }
+        }
+
+        /// <summary>
+        /// Logs a single summary line showing how many contracts are in each Mission Control tab
+        /// (Available = Offered, Active, Archived = ContractsFinished) after the full load and
+        /// reconciliation pass has completed, along with how many were dropped due to missing
+        /// installed parts or planetary bodies.
+        /// </summary>
+        private void LogMissionControlTally()
+        {
+            if (ContractSystem.Instance == null) return;
+
+            var available = 0;
+            var active = 0;
+
+            foreach (var c in ContractSystem.Instance.Contracts)
+            {
+                if (c == null) continue;
+                switch (c.ContractState)
+                {
+                    case Contract.State.Offered: available++; break;
+                    case Contract.State.Active:  active++;    break;
+                }
+            }
+
+            var archived     = ContractSystem.Instance.ContractsFinished.Count;
+            var droppedParts = System.LastDroppedMissingPartCount;
+            var droppedBodies = System.LastDroppedMissingBodyCount;
+
+            LunaLog.Log($"[LMP]: [ContractSystem] Updated Mission Control, {available} Available, {active} Active, {archived} Archived" +
+                        $" ({droppedParts} dropped missing part, {droppedBodies} dropped missing body)");
         }
 
         /// <summary>
@@ -257,6 +339,32 @@ namespace LmpClient.Systems.ShareContracts
             return Contract.Load(new LmpUnavailableContract(), node) as LmpUnavailableContract;
         }
 
+        /// <summary>
+        /// Reads ContractPreLoader's post-load state for diagnostics.
+        /// </summary>
+        private static void LogContractPreLoaderState()
+        {
+            try
+            {
+                var preLoader = ScenarioRunner.GetLoadedModules()
+                    .FirstOrDefault(m => m.GetType().Name == "ContractPreLoader");
+
+                if (preLoader == null)
+                {
+                    LunaLog.LogWarning("[ContractPreLoader]: ScenarioModule not found in loaded modules — cannot verify injection.");
+                    return;
+                }
+
+                var node = new ConfigNode();
+                preLoader.Save(node);
+                LunaLog.Log($"[ContractPreLoader]: Post-load state (type={preLoader.GetType().Name}): {node}");
+            }
+            catch (Exception e)
+            {
+                LunaLog.LogError($"[ContractPreLoader]: Error reading post-load state: {e.Message}");
+            }
+        }
+
         public void ContractDeclined(Contract contract)
         {
             if (System.IgnoreEvents) return;
@@ -291,6 +399,14 @@ namespace LmpClient.Systems.ShareContracts
             // ContractSystem.OnLoad() (scenario restore path) via ContractSystem_OnLoad patch.
             if (System.IgnoreEvents) return;
 
+            // Protect every contract that was part of the server's Offered snapshot.
+            // ContractPreLoader (KSPCF) subscribes to onContractsLoaded and re-fires onOffered
+            // for contracts already in the system so it can register them in its persistent list.
+            // If we intercepted those events we would withdraw valid server contracts regardless
+            // of lock status. Contracts not in this set are locally generated and handled normally.
+            if (System.ServerOfferedContractGuids.Contains(contract.ContractGuid.ToString()))
+                return;
+
             if (!LockSystem.LockQuery.ContractLockBelongsToPlayer(SettingsSystem.CurrentSettings.PlayerName))
             {
                 //We don't have the contract lock, so discard any contract KSP generated locally.
@@ -318,6 +434,13 @@ namespace LmpClient.Systems.ShareContracts
 
             //This should be only called on the client with the contract lock, because it has the generationCount != 0.
             System.MessageSender.SendContractMessage(contract);
+
+            // Push an updated ContractSystem scenario to the server immediately after generation.
+            // ContractUpdate messages are fire-and-forget; a player joining before the next
+            // 30-second periodic sync would see 0 Offered from the stale server scenario.
+            // The call is debounced so the scenario is sent once per generation batch, not once
+            // per contract.
+            System.ScheduleContractSystemScenarioSend();
         }
 
         public void ContractParameterChanged(Contract contract, ContractParameter contractParameter)

--- a/LmpClient/Systems/ShareContracts/ShareContractsMessageHandler.cs
+++ b/LmpClient/Systems/ShareContracts/ShareContractsMessageHandler.cs
@@ -244,7 +244,12 @@ namespace LmpClient.Systems.ShareContracts
                         GameEvents.Contract.onFinished.Fire(ContractSystem.Instance.Contracts[contractIndex]);
                         break;
                     case Contract.State.Offered:
-                        GameEvents.Contract.onOffered.Fire(ContractSystem.Instance.Contracts[contractIndex]);
+                        // Do not fire the global onOffered event here. KSP systems such as
+                        // ContractPreLoader listen to it and enforce slot limits by withdrawing
+                        // existing server contracts when new ones are offered, which causes
+                        // contracts received in earlier batches to disappear. The Available tab
+                        // will still refresh because onContractsListChanged is fired at the end
+                        // of ContractUpdate(), which is all the UI needs.
                         break;
                     case Contract.State.Withdrawn:
                         GameEvents.Contract.onFinished.Fire(ContractSystem.Instance.Contracts[contractIndex]);

--- a/LmpClient/Systems/ShareContracts/ShareContractsSystem.cs
+++ b/LmpClient/Systems/ShareContracts/ShareContractsSystem.cs
@@ -3,6 +3,7 @@ using LmpClient.Events;
 using LmpClient.Systems.Lock;
 using LmpClient.Systems.ShareProgress;
 using LmpCommon.Enums;
+using System.Collections.Generic;
 
 namespace LmpClient.Systems.ShareContracts
 {
@@ -13,6 +14,59 @@ namespace LmpClient.Systems.ShareContracts
         private ShareContractsEvents ShareContractsEvents { get; } = new ShareContractsEvents();
 
         public int DefaultContractGenerateIterations;
+
+        /// <summary>
+        /// Populated by <see cref="ScenarioSystem"/> just before the ContractSystem scenario is
+        /// loaded. Keys are GUID strings of Offered contracts in the server's snapshot; values are
+        /// the original contract type name and, for part-validation failures, the missing part name.
+        ///
+        /// <see cref="ShareContractsEvents.ContractsLoaded"/> compares this set against what
+        /// actually loaded into <see cref="ContractSystem.Instance"/> and creates
+        /// <see cref="LmpUnavailableContract"/> stubs for any GUIDs that are absent.
+        /// </summary>
+        internal Dictionary<string, (string TypeName, string MissingAsset)> PendingUnavailableContracts { get; }
+            = new Dictionary<string, (string, string)>();
+
+        /// <summary>
+        /// Records the Offered contracts from the ContractSystem scenario node so that stubs can
+        /// be created for any that fail to load. Called from <see cref="ScenarioSystem"/> before
+        /// the node is handed to KSP.
+        /// </summary>
+        /// <param name="scenarioNode">The ContractSystem ConfigNode received from the server.</param>
+        /// <param name="strippedWithMissingPart">
+        /// Map of GUID → missing part name for contracts already stripped by the part-validation
+        /// pre-filter. May be null if pre-filtering did not run.
+        /// </param>
+        public void PrepareUnavailableContractStubs(ConfigNode scenarioNode,
+            IReadOnlyDictionary<string, (string TypeName, string MissingAsset)> strippedWithMissingPart)
+        {
+            PendingUnavailableContracts.Clear();
+
+            var contractsNode = scenarioNode.GetNode("CONTRACTS");
+            if (contractsNode != null)
+            {
+                foreach (var contractNode in contractsNode.GetNodes("CONTRACT"))
+                {
+                    var guid = contractNode.GetValue("guid");
+                    var typeName = contractNode.GetValue("type") ?? "Unknown";
+                    var state = contractNode.GetValue("state");
+
+                    if (string.IsNullOrEmpty(guid) || state != "Offered") continue;
+
+                    PendingUnavailableContracts[guid] = (typeName, null);
+                }
+            }
+
+            // Stripped contracts were removed from the node before KSP sees them, so they never
+            // appear in the iteration above. Track them separately so stubs are created for them.
+            if (strippedWithMissingPart != null)
+            {
+                foreach (var kvp in strippedWithMissingPart)
+                    PendingUnavailableContracts[kvp.Key] = kvp.Value;
+            }
+
+            LunaLog.Log($"[ShareContracts]: Tracking {PendingUnavailableContracts.Count} Offered contracts from server snapshot for unavailability detection.");
+        }
 
         //This queue system is not used because we use one big queue in ShareCareerSystem for this system.
         protected override bool ShareSystemReady => true;
@@ -57,6 +111,7 @@ namespace LmpClient.Systems.ShareContracts
         {
             base.OnDisabled();
 
+            PendingUnavailableContracts.Clear();
             ContractSystem.generateContractIterations = DefaultContractGenerateIterations;
 
             LockEvent.onLockAcquire.Remove(ShareContractsEvents.LockAcquire);

--- a/LmpClient/Systems/ShareContracts/ShareContractsSystem.cs
+++ b/LmpClient/Systems/ShareContracts/ShareContractsSystem.cs
@@ -1,8 +1,11 @@
 ﻿using Contracts;
 using LmpClient.Events;
 using LmpClient.Systems.Lock;
+using LmpClient.Systems.Scenario;
 using LmpClient.Systems.ShareProgress;
 using LmpCommon.Enums;
+using System;
+using System.Collections;
 using System.Collections.Generic;
 
 namespace LmpClient.Systems.ShareContracts
@@ -28,19 +31,92 @@ namespace LmpClient.Systems.ShareContracts
             = new Dictionary<string, (string, string)>();
 
         /// <summary>
+        /// All Offered contract GUIDs from the most recently received ContractSystem scenario
+        /// snapshot. Populated in <see cref="ScenarioMessageHandler"/> when the ContractSystem
+        /// data arrives (before any scenario loading), so that
+        /// <see cref="ScenarioSystem.LoadScenarioDataIntoGame"/> can inject every offered GUID
+        /// into the ContractPreLoader scenario node and make all server contracts visible in
+        /// Mission Control — not just the small saved subset.
+        ///
+        /// Written from the network thread; read from the Unity main thread during loading.
+        /// The write always finishes hundreds of milliseconds before the read begins (scenarios
+        /// are queued in a single batch before loading starts), so no lock is required.
+        /// </summary>
+        internal HashSet<string> ServerOfferedContractGuids { get; private set; }
+            = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+
+        internal void SetServerOfferedContractGuids(List<string> guids)
+        {
+            ServerOfferedContractGuids = guids != null
+                ? new HashSet<string>(guids, StringComparer.OrdinalIgnoreCase)
+                : new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        }
+
+        /// <summary>
+        /// Full ConfigNodes for every Offered contract in the most recently received
+        /// ContractSystem snapshot. Saved in <see cref="ScenarioMessageHandler"/> alongside
+        /// <see cref="ServerOfferedContractGuids"/> so that
+        /// <see cref="ScenarioSystem.LoadScenarioDataIntoGame"/> can inject complete contract
+        /// data into the ContractPreLoader scenario node before KSPCF's ContractPreLoader.OnLoad
+        /// processes it.
+        ///
+        /// KSPCF's patched <c>GenerateContracts</c> uses ContractPreLoader's stored list as a
+        /// whitelist: contracts in the list are restored (or kept if already present); contracts
+        /// not in the list are cleared.  With an empty list every server contract is cleared.
+        /// Injecting the full nodes (type, guid, state, all parameters) allows KSPCF to
+        /// successfully restore all 43 server contracts even when
+        /// <c>generateContractIterations == 0</c>.
+        ///
+        /// Same write-before-read threading guarantee as <see cref="ServerOfferedContractGuids"/>.
+        /// </summary>
+        internal List<ConfigNode> ServerOfferedContractNodes { get; private set; }
+            = new List<ConfigNode>();
+
+        internal void SetServerOfferedContractNodes(List<ConfigNode> nodes)
+        {
+            ServerOfferedContractNodes = nodes ?? new List<ConfigNode>();
+        }
+
+        /// <summary>
+        /// Set to <c>true</c> by <see cref="ShareContractsEvents.ContractsLoaded"/> the moment it
+        /// runs, so that <see cref="ContractSystem_OnLoad"/> can detect whether KSP fired
+        /// <c>GameEvents.Contract.onContractsLoaded</c> during the server-scenario re-load.
+        ///
+        /// Reset to <c>false</c> by the <see cref="ContractSystem_OnLoad"/> Harmony prefix
+        /// immediately before each ContractSystem.OnLoad call so the check is always fresh.
+        /// </summary>
+        internal bool ContractsLoadedEventFired { get; set; }
+
+        /// <summary>
+        /// Number of contracts dropped from the last received ContractSystem snapshot because
+        /// they referenced a part not installed on this client.
+        /// </summary>
+        internal int LastDroppedMissingPartCount { get; private set; }
+
+        /// <summary>
+        /// Number of contracts dropped from the last received ContractSystem snapshot because
+        /// they referenced a planetary body index that does not exist on this client.
+        /// </summary>
+        internal int LastDroppedMissingBodyCount { get; private set; }
+
+        /// <summary>
         /// Records the Offered contracts from the ContractSystem scenario node so that stubs can
         /// be created for any that fail to load. Called from <see cref="ScenarioSystem"/> before
         /// the node is handed to KSP.
         /// </summary>
         /// <param name="scenarioNode">The ContractSystem ConfigNode received from the server.</param>
         /// <param name="strippedWithMissingPart">
-        /// Map of GUID → missing part name for contracts already stripped by the part-validation
-        /// pre-filter. May be null if pre-filtering did not run.
+        /// Map of GUID → missing asset description for contracts already stripped by the
+        /// pre-filter. Values whose <c>MissingAsset</c> starts with <c>"part '"</c> were dropped
+        /// for a missing part; all others were dropped for an invalid planetary body index.
+        /// May be null if pre-filtering did not run.
         /// </param>
         public void PrepareUnavailableContractStubs(ConfigNode scenarioNode,
             IReadOnlyDictionary<string, (string TypeName, string MissingAsset)> strippedWithMissingPart)
         {
             PendingUnavailableContracts.Clear();
+            LastDroppedMissingPartCount = 0;
+            LastDroppedMissingBodyCount = 0;
 
             var contractsNode = scenarioNode.GetNode("CONTRACTS");
             if (contractsNode != null)
@@ -62,7 +138,14 @@ namespace LmpClient.Systems.ShareContracts
             if (strippedWithMissingPart != null)
             {
                 foreach (var kvp in strippedWithMissingPart)
+                {
                     PendingUnavailableContracts[kvp.Key] = kvp.Value;
+
+                    if (kvp.Value.MissingAsset != null && kvp.Value.MissingAsset.StartsWith("part '"))
+                        LastDroppedMissingPartCount++;
+                    else
+                        LastDroppedMissingBodyCount++;
+                }
             }
 
             LunaLog.Log($"[ShareContracts]: Tracking {PendingUnavailableContracts.Count} Offered contracts from server snapshot for unavailability detection.");
@@ -112,6 +195,8 @@ namespace LmpClient.Systems.ShareContracts
             base.OnDisabled();
 
             PendingUnavailableContracts.Clear();
+            ServerOfferedContractNodes.Clear();
+            _contractSystemScenariaSendPending = false;
             ContractSystem.generateContractIterations = DefaultContractGenerateIterations;
 
             LockEvent.onLockAcquire.Remove(ShareContractsEvents.LockAcquire);
@@ -131,6 +216,28 @@ namespace LmpClient.Systems.ShareContracts
             GameEvents.Contract.onParameterChange.Remove(ShareContractsEvents.ContractParameterChanged);
             GameEvents.Contract.onRead.Remove(ShareContractsEvents.ContractRead);
             GameEvents.Contract.onSeen.Remove(ShareContractsEvents.ContractSeen);
+        }
+
+        private bool _contractSystemScenariaSendPending;
+
+        /// <summary>
+        /// Schedules a one-frame-deferred send of the ContractSystem scenario to the server.
+        /// Safe to call many times within the same frame — only one send is dispatched per batch.
+        /// Ensures joining players see the lock holder's current Offered contracts even before
+        /// the next 30-second periodic scenario sync runs.
+        /// </summary>
+        internal void ScheduleContractSystemScenarioSend()
+        {
+            if (_contractSystemScenariaSendPending) return;
+            _contractSystemScenariaSendPending = true;
+            HighLogic.fetch.StartCoroutine(SendContractSystemScenarioDeferred());
+        }
+
+        private IEnumerator SendContractSystemScenarioDeferred()
+        {
+            yield return null;
+            _contractSystemScenariaSendPending = false;
+            ScenarioSystem.Singleton?.SendScenarioModuleImmediate("ContractSystem");
         }
 
         /// <summary>


### PR DESCRIPTION
## Problem

Several interacting bugs caused "Contract Lock" — a state where the player holding the contract lock had a desynchronised ContractSystem, causing all other players to see zero Available contracts in Mission Control.

Root causes identified and fixed in this PR:

1. **Coroutine abort on single bad contract** — If any one contract node threw an exception during `ContractSystem.OnLoadRoutine`, the entire coroutine was killed and `GameEvents.Contract.onContractsLoaded` never fired. This left LMP in a permanently broken event-suppression state.
2. **`onContractsLoaded` not firing on server scenario reload** — KSP only fires this event during the initial local-save load. When LMP subsequently reloads ContractSystem from the server snapshot the event is silently skipped, so post-load reconciliation and ContractPreLoader resolution never ran.
3. **Planet-pack body index mismatches** — Contracts referencing a celestial body by integer index would crash load on clients that do not have the server's planet pack installed, falling into root cause #1.
4. **Finished-contract state desync** — Contracts could appear in `CONTRACTS` with a stale state (e.g. `Active`) while the authoritative finished record sat in `CONTRACTS_FINISHED`, producing duplicates or incorrect mission state on reload.
5. **KSPCF ContractPreLoader whitelist** — KSPCF's patched `GenerateContracts` uses ContractPreLoader's stored list as a whitelist. With an empty list (LMP's default) every server contract was wiped. Server Offered contracts were not being injected into ContractPreLoader before load, so they were not present when KSPCF processed the list.
6. **Missing-mod contracts invisible** — Contracts stripped due to missing parts or planet packs simply disappeared from Mission Control with no indication to the player.

## Changes

### New: `ContractSystem_LoadContract` Harmony patch
Adds a Harmony finalizer on `ContractSystem.LoadContract` that suppresses exceptions thrown by individual contracts when connected to a server. Prevents a single malformed contract from aborting the entire `OnLoadRoutine` coroutine. Single-player exceptions still propagate normally.

### Updated: `ContractSystem_OnLoad` Harmony patch
- Removed the `system.Enabled` guard in the prefix so the patch is active on the very first LMP scenario reload (before the system finishes initialising).
- Added a `WaitForContractsLoaded` monitor coroutine (started from the postfix) that polls for `onContractsLoaded` for up to 30 seconds. If the event fires naturally the coroutine exits; if the timeout expires the coroutine fires the event manually so ContractPreLoader resolution and LMP post-load reconciliation always run.
- Added a `_loadGeneration` counter so monitor coroutines from superseded load cycles exit cleanly without double-firing the event.

### New: `LmpUnavailableContract`
A `Contract` subclass used as a placeholder in the Mission Control Available tab for server contracts that could not be loaded on this client (missing part mod, missing planet pack, unknown contract type). Displays the original contract type and a human-readable description of the missing dependency. `MeetRequirements()` returns `false` so it cannot be accepted. Never sent back to the server.

### Updated: `ShareContractsSystem`
- `PendingUnavailableContracts` — populated before KSP loads the scenario; used by `ContractsLoaded` to create `LmpUnavailableContract` stubs for any GUIDs that failed to appear in `ContractSystem.Instance` after load.
- `ServerOfferedContractGuids` / `ServerOfferedContractNodes` — capture all Offered GUIDs and full ConfigNodes from the server snapshot so `ScenarioSystem` can inject them into ContractPreLoader before KSPCF processes its whitelist.
- `ContractsLoadedEventFired` — flag written by `ContractsLoaded()` and checked by the `WaitForContractsLoaded` coroutine to avoid double-firing the event.
- `LastDroppedMissingPartCount` / `LastDroppedMissingBodyCount` — counters surfaced in the Mission Control tally log.
- `ScheduleContractSystemScenarioSend()` — deferred (one-frame) send of the ContractSystem scenario to the server; coalesces multiple calls within the same frame into a single send so joining players see the lock holder's current Offered contracts without waiting for the next 30-second periodic sync.
- Clears pending state and resets the deferred-send flag in `OnDisabled()`.

### Updated: `ShareContractsEvents`
- `ContractsListChanged` — now logs Offered / Active / Finished counts instead of a bare message.
- `ContractsLoaded` — now runs `LogContractStateBreakdown`, `ReconcileFinishedContracts`, `CreateUnavailableContractStubs`, `LogContractPreLoaderState`, `LogMissionControlTally`, and starts the `PostLoadContractCheck` coroutine.
- `PostLoadContractCheck` — logs Offered count for 5 frames and then at +1 s / +3 s after load, to pinpoint exactly when (and therefore which system) removes contracts that are present at the end of the handler.
- `ReconcileFinishedContracts` — migrates contracts whose final state (Completed / Failed / Cancelled) sits in `CONTRACTS_FINISHED` but whose stale record still appears in `CONTRACTS`, replacing the stale entry with the authoritative finished node and removing the duplicate from `CONTRACTS_FINISHED`.
- `CreateUnavailableContractStubs` — creates `LmpUnavailableContract` instances for every GUID tracked in `PendingUnavailableContracts` that did not load into `ContractSystem.Instance`, and adds them to the Offered list.
- `LogMissionControlTally` — emits a single summary line matching the Mission Control tab counts (Available / Active / Archived) plus dropped-contract counts, mirroring the in-game display.

### Updated: `ScenarioMessageHandler` / `ScenarioSystem`
- `StripContractsWithMissingParts` now returns a dictionary of stripped GUIDs to (TypeName, MissingAsset) instead of void, so stubs can be created for them.
- Added `FindInvalidBodyIndex` — recursively scans a contract node for any recognised body-index key (`body`, `targetBody`, `destination`, `origin`, `body1`, `body2`) whose integer value falls outside `FlightGlobals.Bodies`. Also handles body indices stored as floats by KSP. Stripped contracts are recorded for stub creation.
- Added `ReconcileFinishedContracts` (pre-load) — rewrites the `CONTRACTS` node before KSP sees it, swapping stale entries for their authoritative counterparts from `CONTRACTS_FINISHED`.
- Server Offered contract GUIDs and full ConfigNodes are now captured when the ContractSystem message arrives and injected into the ContractPreLoader scenario node before `LoadScenarioDataIntoGame` hands it to KSP, ensuring KSPCF's whitelist contains all server contracts.
