### PR TITLE
Some fixes for the time warp to run extra sanity checks

### DIFF
--- a/LmpClient/Harmony/UIPlanetariumDateTime_SetTime.cs
+++ b/LmpClient/Harmony/UIPlanetariumDateTime_SetTime.cs
@@ -1,0 +1,41 @@
+using HarmonyLib;
+using KSP.UI;
+using LmpCommon.Enums;
+using System;
+
+// ReSharper disable All
+
+namespace LmpClient.Harmony
+{
+    /// <summary>
+    /// Suppresses the per-frame OverflowException thrown by KSP's date formatter when the server's game
+    /// Universal Time exceeds int.MaxValue (~2.147e9 seconds, roughly 233 Kerbin years).
+    /// KSP internally casts the UT double to int inside get_date_from_UT; for very large values that cast
+    /// produces int.MinValue, and Math.Abs(int.MinValue) then throws. LMP cannot control the server's
+    /// game time, so we silence the crash here and warn once.
+    /// </summary>
+    [HarmonyPatch(typeof(UIPlanetariumDateTime))]
+    [HarmonyPatch("SetTime")]
+    public class UIPlanetariumDateTime_SetTime
+    {
+        private static bool _overflowWarningLogged;
+
+        [HarmonyFinalizer]
+        private static Exception Finalizer(Exception __exception)
+        {
+            if (__exception is OverflowException && MainSystem.NetworkState >= ClientState.Connected)
+            {
+                if (!_overflowWarningLogged)
+                {
+                    LunaLog.LogWarning("[LMP]: KSP date formatter overflow suppressed: the server's game time " +
+                                       $"({Planetarium.GetUniversalTime():F0}s) exceeds int.MaxValue (~233 Kerbin years). " +
+                                       "The in-game date display will not update while connected to this server.");
+                    _overflowWarningLogged = true;
+                }
+                return null;
+            }
+
+            return __exception;
+        }
+    }
+}

--- a/LmpClient/LmpClient.csproj
+++ b/LmpClient/LmpClient.csproj
@@ -201,6 +201,7 @@
     <Compile Include="Harmony\TourismContract_ClearKerbalsHard.cs" />
     <Compile Include="Harmony\TourismContract_ClearKerbalsSoft.cs" />
     <Compile Include="Harmony\UIPartActionButton_OnClick.cs" />
+    <Compile Include="Harmony\UIPlanetariumDateTime_SetTime.cs" />
     <Compile Include="Harmony\DebugScreen_OnGameSceneLoad.cs" />
     <Compile Include="Harmony\DebugToolbar_WindowCheats.cs" />
     <Compile Include="Harmony\DestructibleBuilding_OnCollisionEnter.cs" />

--- a/LmpClient/Systems/TimeSync/TimeSyncSystem.cs
+++ b/LmpClient/Systems/TimeSync/TimeSyncSystem.cs
@@ -207,6 +207,12 @@ namespace LmpClient.Systems.TimeSync
         /// </summary>
         public void SetGameTime(double targetTick)
         {
+            if (double.IsNaN(targetTick) || double.IsInfinity(targetTick) || targetTick < 0)
+            {
+                LunaLog.LogWarning($"[LMP]: Ignoring invalid game-time sync target {targetTick} — value is non-finite or negative. This indicates a server time-difference calculation error.");
+                return;
+            }
+
             if (HighLogic.LoadedSceneIsFlight)
             {
                 //As we are syncing to a new game time, we must advance all the ship positions and put them in the correct orbit "epoch"

--- a/LmpClient/Systems/Warp/WarpSystem.cs
+++ b/LmpClient/Systems/Warp/WarpSystem.cs
@@ -247,7 +247,17 @@ namespace LmpClient.Systems.Warp
         /// </summary>
         public double GetSubspaceTime(int subspace)
         {
-            return Subspaces.ContainsKey(subspace) ? TimeSyncSystem.ServerClockSec + Subspaces[subspace] : 0d;
+            if (!Subspaces.ContainsKey(subspace)) return 0d;
+
+            var result = TimeSyncSystem.ServerClockSec + Subspaces[subspace];
+            if (double.IsNaN(result) || double.IsInfinity(result) || result < 0)
+            {
+                LunaLog.LogWarning($"[LMP]: GetSubspaceTime({subspace}) produced invalid result {result} " +
+                                   $"(ServerClockSec={TimeSyncSystem.ServerClockSec}, offset={Subspaces[subspace]}). Returning 0.");
+                return 0d;
+            }
+
+            return result;
         }
 
         public int GetPlayerSubspace(string playerName)

--- a/LmpClient/Windows/Status/StatusTexts.cs
+++ b/LmpClient/Windows/Status/StatusTexts.cs
@@ -37,6 +37,9 @@ namespace LmpClient.Windows.Status
 
             var subspaceTime = WarpSystem.Singleton.GetSubspaceTime(currentEntry.SubspaceId);
 
+            if (subspaceTime <= 0d)
+                return "----";
+
             StringBuilder.Append(KSPUtil.PrintDateCompact(subspaceTime, true, true));
 
             if (WarpSystem.Singleton.CurrentSubspace != currentEntry.SubspaceId)


### PR DESCRIPTION
## Summary

This PR adds several defensive sanity checks to prevent crashes and undefined behaviour when a server's game time has advanced to an extreme value (e.g. hundreds of Kerbin years forward).

### Changes

- **`Harmony/UIPlanetariumDateTime_SetTime.cs`** _(new)_ — Adds a Harmony finalizer patch on `UIPlanetariumDateTime.SetTime` that silently suppresses the `OverflowException` KSP throws when Universal Time exceeds `int.MaxValue` (~233 Kerbin years). The cast from `double` to `int` inside KSP's date formatter produces `int.MinValue` at that point, and the subsequent `Math.Abs` call overflows. LMP cannot control the server's game time, so the exception is caught, a one-time warning is logged, and the in-game date display is left static for the duration of the session.

- **`Systems/TimeSync/TimeSyncSystem.cs`** — `SetGameTime` now rejects any `targetTick` that is NaN, infinite, or negative before attempting to apply it, logging a warning and returning early. This prevents downstream vessel-orbit calculations from receiving garbage time values.

- **`Systems/Warp/WarpSystem.cs`** — `GetSubspaceTime` now validates the computed `ServerClockSec + subspace-offset` result. If the result is NaN, infinite, or negative (indicating a corrupted server-clock or subspace-offset), the method returns `0` and logs a warning rather than propagating the bad value.

- **`Windows/Status/StatusTexts.cs`** — The subspace time label now returns `"----"` instead of attempting to format a time of `0` or below, giving a clear visual indication that the time value is unavailable rather than showing a nonsensical date.
