### PR TITLE
Batched the server message queue instead of sending 1 message for each event

### DIFF
--- a/Dockerfile_MasterServer
+++ b/Dockerfile_MasterServer
@@ -28,7 +28,6 @@ COPY uhttpsharp/uhttpsharp.csproj           /LunaMultiplayer/uhttpsharp/uhttpsha
 COPY LmpUpdater/LmpUpdater.csproj           /LunaMultiplayer/LmpUpdater/LmpUpdater.csproj
 COPY LmpMasterServer/LmpMasterServer.csproj /LunaMultiplayer/LmpMasterServer/LmpMasterServer.csproj
 COPY MasterServer/MasterServer.csproj       /LunaMultiplayer/MasterServer/MasterServer.csproj
-COPY LmpUpdater/packages.config             /LunaMultiplayer/LmpUpdater/packages.config
 COPY uhttpsharp/packages.config             /LunaMultiplayer/uhttpsharp/packages.config
 
 ARG OS_BASE

--- a/LmpUpdater/packages.config
+++ b/LmpUpdater/packages.config
@@ -1,4 +1,0 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<packages>
-  <package id="DotNetZip" version="1.13.4" targetFramework="net471" />
-</packages>

--- a/Server/Client/ClientStructure.cs
+++ b/Server/Client/ClientStructure.cs
@@ -60,15 +60,19 @@ namespace Server.Client
             return Endpoint?.GetHashCode() ?? 0;
         }
 
+        private const int MaxMessagesPerBatch = 128;
+
         private async Task SendMessagesThreadAsync(CancellationToken token)
         {
             while (ConnectionStatus == ConnectionStatus.Connected)
             {
-                while (SendMessageQueue.TryDequeue(out var message) && message != null)
+                var sentCount = 0;
+                while (sentCount < MaxMessagesPerBatch && SendMessageQueue.TryDequeue(out var message) && message != null)
                 {
                     try
                     {
                         LidgrenServer.SendMessageToClient(this, message);
+                        sentCount++;
                     }
                     catch (Exception e)
                     {
@@ -78,6 +82,13 @@ namespace Server.Client
 
                     LmpPluginHandler.FireOnMessageSent(this, message);
                 }
+
+                if (sentCount > 0)
+                {
+                    LidgrenServer.FlushSendQueue();
+                    continue;
+                }
+
                 try
                 {
                     await Task.Delay(IntervalSettings.SettingsStore.SendReceiveThreadTickMs, token);

--- a/Server/Server/LidgrenServer.cs
+++ b/Server/Server/LidgrenServer.cs
@@ -86,6 +86,8 @@ namespace Server.Server
             ServerContext.Config.SimulatedMinimumLatency = (float)TimeSpan.FromMilliseconds((double)DebugSettings.SettingsStore?.MinSimulatedLatencyMs).TotalSeconds;
 #endif
 
+            ServerContext.Config.AutoFlushSendQueue = false;
+
             Server = new NetServer(ServerContext.Config);
             Server.Start();
 
@@ -198,8 +200,10 @@ namespace Server.Server
             client.BytesSent += outmsg.LengthBytes;
 
             var sendResult = Server.SendMessage(outmsg, client.Connection, message.NetDeliveryMethod, message.Channel);
+        }
 
-            //Force send of packets
+        public static void FlushSendQueue()
+        {
             Server.FlushSendQueue();
         }
 


### PR DESCRIPTION
## Summary

Previously, the server called `FlushSendQueue()` after every individual message sent to a client. This meant that for a busy server tick with many queued messages, each message triggered a separate network flush — a significant source of overhead under load.

This PR changes the send loop in `ClientStructure` to process up to 128 messages per iteration before flushing once, rather than flushing after each one. `AutoFlushSendQueue` is also explicitly set to `false` on the Lidgren config to prevent the library from auto-flushing per-send. If the batch was non-empty, the loop immediately continues to the next iteration without sleeping, draining the queue as fast as possible; the `Task.Delay` tick sleep is only hit when the queue is empty.

## Changes

- `Server/Client/ClientStructure.cs`: Added `MaxMessagesPerBatch = 128` cap to the send loop; calls `LidgrenServer.FlushSendQueue()` once per batch rather than per message; skips the tick delay when messages were sent.
- `Server/Server/LidgrenServer.cs`: Set `AutoFlushSendQueue = false` on server config; extracted `FlushSendQueue()` as a dedicated public static method.
- `Dockerfile_MasterServer`: Removed stale `COPY` line for `LmpUpdater/packages.config`, which was deleted and was causing the Docker CI build to fail.
