### PR TITLE
Fix throttle spike when taking control of a spectated vessel

### DIFF
--- a/LmpClient/Systems/VesselLockSys/VesselLockEvents.cs
+++ b/LmpClient/Systems/VesselLockSys/VesselLockEvents.cs
@@ -94,14 +94,32 @@ namespace LmpClient.Systems.VesselLockSys
                     if (lockDefinition.PlayerName == SettingsSystem.CurrentSettings.PlayerName)
                     {
                         if (VesselCommon.IsSpectating)
+                        {
+                            var spectatedVessel = FlightGlobals.FindVessel(lockDefinition.VesselId);
+
+                            // Remove the FlyByWire callback FIRST so the next physics tick cannot
+                            // overwrite our throttle zero with the previous controller's last state.
+                            VesselCommon.RemoveVesselFromSystems(lockDefinition.VesselId);
+
+                            // Zero the vessel's throttle before removing the spectate input lock.
+                            // The spectated vessel's ctrlState carries the previous controller's
+                            // last-sent throttle; without clearing it the new controller instantly
+                            // inherits full throttle on the frame the lock is granted.
+                            if (spectatedVessel != null)
+                            {
+                                spectatedVessel.ctrlState.mainThrottle = 0f;
+                                spectatedVessel.ctrlState.wheelThrottle = 0f;
+                            }
                             VesselLockSystem.Singleton.StopSpectating();
+                        }
                         LockSystem.Singleton.AcquireUpdateLock(lockDefinition.VesselId, true);
                         LockSystem.Singleton.AcquireUnloadedUpdateLock(lockDefinition.VesselId, true);
                         LockSystem.Singleton.AcquireKerbalLock(lockDefinition.VesselId, true);
 
                         //As we got the lock of that vessel, remove its FS and position updates
                         //This is done so even if the vessel has queued updates, we ignore them as we are controlling it
-                        VesselCommon.RemoveVesselFromSystems(lockDefinition.VesselId);
+                        if (!VesselCommon.IsSpectating) // already removed above if we were spectating
+                            VesselCommon.RemoveVesselFromSystems(lockDefinition.VesselId);
                     }
                     else
                     {


### PR DESCRIPTION
When a player takes control of a vessel they were spectating, the vessel could jump to full throttle for a frame. The previous controller's last throttle value was still being applied by the FlyByWire callback on the same tick that we zeroed ctrlState, overwriting the zero before it took effect.

Fix: call RemoveVesselFromSystems before zeroing the throttle, so the FlyByWire delegate is detached before the next physics tick.