### PR TITLE
Fix contract disappearance, CC load exceptions, and SOI spam for LMP-managed vessels

### DIFF
--- a/LmpClient/Base/HarmonyPatcher.cs
+++ b/LmpClient/Base/HarmonyPatcher.cs
@@ -19,6 +19,46 @@ namespace LmpClient.Base
         private static void PatchOptionalMods()
         {
             SuppressClickThroughBlockerPopup();
+            PatchContractPreLoader();
+        }
+
+        /// <summary>
+        /// Patches <c>ContractConfigurator.ContractPreLoader.OnLoad</c> with a prefix that
+        /// strips CONTRACT nodes containing unknown or malformed parameters before CC's
+        /// code iterates them.
+        ///
+        /// This must be done imperatively rather than via <c>[HarmonyPatch]</c> attributes
+        /// because <c>ContractPreLoader.OnLoad</c> is a virtual override of
+        /// <c>ScenarioModule.OnLoad</c>.  An attribute-based patch targeting the base class
+        /// method is never dispatched through for ContractPreLoader instances — the vtable
+        /// jumps directly to the derived-class body, bypassing our patch entirely.
+        /// </summary>
+        internal static void PatchContractPreLoader()
+        {
+            try
+            {
+                var ccplType = HarmonyLib.AccessTools.TypeByName("ContractConfigurator.ContractPreLoader");
+                if (ccplType == null)
+                {
+                    LunaLog.Log("[LMP]: ContractConfigurator.ContractPreLoader type not found — CC not installed, skipping contract pre-filter patch.");
+                    return;
+                }
+
+                var onLoad = HarmonyLib.AccessTools.Method(ccplType, "OnLoad");
+                if (onLoad == null)
+                {
+                    LunaLog.LogWarning("[LMP]: ContractPreLoader.OnLoad method not found — CC version mismatch?");
+                    return;
+                }
+
+                var prefix = new HarmonyLib.HarmonyMethod(typeof(LmpClient.Harmony.ContractPreLoader_Filter), "Prefix");
+                HarmonyInstance.Patch(onLoad, prefix: prefix);
+                LunaLog.Log("[LMP]: Patched ContractConfigurator.ContractPreLoader.OnLoad — invalid contracts will be filtered before CC loads them.");
+            }
+            catch (Exception e)
+            {
+                LunaLog.LogWarning($"[LMP]: Could not patch ContractPreLoader.OnLoad: {e.Message}");
+            }
         }
 
         /// <summary>

--- a/LmpClient/Harmony/ContractPreLoader_Filter.cs
+++ b/LmpClient/Harmony/ContractPreLoader_Filter.cs
@@ -1,0 +1,193 @@
+using Contracts;
+using LmpCommon.Enums;
+using System;
+using System.Collections.Generic;
+
+// ReSharper disable All
+
+namespace LmpClient.Harmony
+{
+    /// <summary>
+    /// Pre-validates CONTRACT nodes inside the ContractPreLoader scenario before
+    /// ContractConfigurator's <c>ContractPreLoader.OnLoad</c> iterates them.
+    ///
+    /// The problem: LMP injects the server's Offered contract nodes into the
+    /// ContractPreLoader scenario so KSPCF can preserve them across GenerateContracts.
+    /// Some of those contracts reference parameter types from mods the client does not
+    /// have installed. <c>Contract.Load</c> calls <c>ContractSystem.GetParameterType</c>
+    /// for each PARAM, which returns null for unknown types. The calling code in
+    /// <c>Contract.Load</c> then dereferences that null, throwing a
+    /// <c>NullReferenceException</c>.
+    ///
+    /// ContractConfigurator's ContractPreLoader catches the exception but then
+    /// <em>deliberately</em> re-logs it as [EXC] via <c>LoggingUtil.LogException</c>.
+    /// That means a finalizer on <c>Contract.Load</c> cannot prevent the [EXC] —
+    /// ContractPreLoader's catch block has already run by the time a Harmony finalizer
+    /// would see the exception inside the method frame.
+    ///
+    /// The only reliable fix is to remove the bad CONTRACT nodes from the
+    /// ContractPreLoader scenario <em>before</em> <c>ContractPreLoader.OnLoad</c> is
+    /// called.  <c>ContractSystem.Instance</c> is available at this point because
+    /// ContractSystem (stock KSP) is always instantiated before ContractConfigurator's
+    /// ContractPreLoader in the scenario module loading order.
+    ///
+    /// This class is NOT applied via <c>[HarmonyPatch]</c> attributes because
+    /// <c>ContractPreLoader.OnLoad</c> is a virtual override: attribute-driven patches
+    /// target the <c>ScenarioModule.OnLoad</c> base-class body, which is never
+    /// dispatched through when the instance is a ContractPreLoader.  Instead,
+    /// <see cref="HarmonyPatcher.PatchContractPreLoader"/> looks up the type at runtime
+    /// and applies <see cref="Prefix"/> imperatively against the concrete override.
+    ///
+    /// Contracts removed here still go through the normal ContractSystem loading path,
+    /// where <see cref="ContractSystem_LoadContract"/> suppresses the resulting
+    /// exception, and <see cref="LmpClient.Systems.ShareContracts.ShareContractsEvents"/>
+    /// later creates an <see cref="LmpClient.Systems.ShareContracts.LmpUnavailableContract"/>
+    /// stub so the player can see which server contracts they are missing.
+    /// </summary>
+    public static class ContractPreLoader_Filter
+    {
+        /// <summary>
+        /// Body-target keys: the CC parameter fields that name a celestial body. A CC PARAM
+        /// must have at least one of these if it also has a body-context key.
+        /// Kept in sync with <c>ScenarioSystem.BodyIndexKeys</c>.
+        /// </summary>
+        private static readonly HashSet<string> BodyTargetKeys = new HashSet<string>(StringComparer.OrdinalIgnoreCase)
+        {
+            "body", "targetBody", "destination", "origin", "body1", "body2",
+        };
+
+        /// <summary>
+        /// Keys found exclusively in CC contract parameters that also require a body-target
+        /// key. If a CC PARAM has any of these but no <see cref="BodyTargetKeys"/> entry,
+        /// the parameter is malformed and CC will throw <see cref="ArgumentException"/> and
+        /// show an in-game popup when it tries to parse the missing required body field.
+        /// Kept in sync with <c>ScenarioSystem.BodyContextKeys</c>.
+        /// </summary>
+        private static readonly HashSet<string> BodyContextKeys = new HashSet<string>(StringComparer.OrdinalIgnoreCase)
+        {
+            "coverage", "scanType", "scanMode",
+            "experiment", "biome", "situation",
+            "orbitType", "minOrbit", "maxOrbit",
+            "minAltitude", "maxAltitude",
+            "minPeriapsis", "maxPeriapsis",
+            "minApoapsis", "maxApoapsis",
+            "minEccentricity", "maxEccentricity",
+            "minInclination", "maxInclination",
+        };
+
+        /// <summary>
+        /// Harmony prefix applied imperatively to <c>ContractPreLoader.OnLoad(ConfigNode)</c>
+        /// by <see cref="HarmonyPatcher.PatchContractPreLoader"/>.
+        /// </summary>
+        internal static void Prefix(object __instance, ConfigNode node)
+        {
+            if (MainSystem.NetworkState < ClientState.Connected) return;
+
+            // Guard: ensure ContractSystem has been initialised (it loads before ContractPreLoader).
+            if (ContractSystem.Instance == null)
+            {
+                LunaLog.LogWarning("[ContractPreLoader_Filter]: ContractSystem.Instance is null — skipping pre-validation.");
+                return;
+            }
+
+            FilterContracts(node);
+        }
+
+        /// <summary>
+        /// Removes CONTRACT child nodes from <paramref name="scenarioNode"/> that would
+        /// cause <c>Contract.Load</c> to throw (unknown parameter type or malformed CC
+        /// parameter data). All other child nodes are preserved unchanged.
+        /// </summary>
+        private static void FilterContracts(ConfigNode scenarioNode)
+        {
+            // Snapshot child nodes before we modify the parent.
+            var snapshot = new List<ConfigNode>(scenarioNode.nodes.Count);
+            foreach (ConfigNode child in scenarioNode.nodes)
+                snapshot.Add(child);
+
+            var toKeep = new List<ConfigNode>(snapshot.Count);
+            var removedCount = 0;
+
+            foreach (var child in snapshot)
+            {
+                if (string.Equals(child.name, "CONTRACT", StringComparison.OrdinalIgnoreCase))
+                {
+                    var isCC = string.Equals(child.GetValue("type"), "ConfiguredContract", StringComparison.OrdinalIgnoreCase);
+                    var reason = FindFirstInvalidParam(child, isCC);
+                    if (reason != null)
+                    {
+                        var guid = child.GetValue("guid") ?? "unknown";
+                        var type = child.GetValue("type") ?? "unknown";
+                        LunaLog.LogWarning(
+                            $"[LMP]: ContractPreLoader — skipping contract {guid} (type: {type}): {reason}. " +
+                            $"An unavailability stub will be shown in Mission Control.");
+                        removedCount++;
+                        continue;
+                    }
+                }
+
+                toKeep.Add(child);
+            }
+
+            if (removedCount == 0) return;
+
+            scenarioNode.ClearNodes();
+            foreach (var keep in toKeep)
+                scenarioNode.AddNode(keep);
+
+            LunaLog.Log($"[ContractPreLoader_Filter]: Removed {removedCount} contract(s) with invalid parameters from ContractPreLoader scenario.");
+        }
+
+        /// <summary>
+        /// Recursively searches PARAM sub-nodes for the first parameter that would cause
+        /// <c>Contract.Load</c> to throw. Returns a human-readable reason string, or
+        /// <c>null</c> if all parameters look valid.
+        ///
+        /// Detects two failure modes:
+        /// <list type="bullet">
+        ///   <item>Unknown type — <c>ContractSystem.GetParameterType</c> returns null,
+        ///         causing a <c>NullReferenceException</c>.</item>
+        ///   <item>Missing required body field — a CC PARAM has body-context keys
+        ///         (e.g. <c>coverage</c>, <c>scanType</c>) but no body-target key
+        ///         (e.g. <c>targetBody</c>), which causes CC's
+        ///         <c>ConfigNodeUtil.ParseValue&lt;CelestialBody&gt;</c> to throw
+        ///         <c>ArgumentException</c> and show an in-game popup.</item>
+        /// </list>
+        /// </summary>
+        private static string FindFirstInvalidParam(ConfigNode node, bool isCC)
+        {
+            foreach (ConfigNode child in node.nodes)
+            {
+                if (!string.Equals(child.name, "PARAM", StringComparison.OrdinalIgnoreCase))
+                    continue;
+
+                var typeName = child.GetValue("name");
+
+                // Check 1: unknown parameter type (ContractSystem.GetParameterType is static).
+                if (!string.IsNullOrEmpty(typeName) && ContractSystem.GetParameterType(typeName) == null)
+                    return $"parameter type '{typeName}' is not installed on this client";
+
+                // Check 2: CC PARAM with body-context field but no body-target field.
+                if (isCC && !string.IsNullOrEmpty(typeName))
+                {
+                    var hasBodyContext = false;
+                    var hasBodyTarget = false;
+                    foreach (ConfigNode.Value v in child.values)
+                    {
+                        if (BodyContextKeys.Contains(v.name)) hasBodyContext = true;
+                        if (BodyTargetKeys.Contains(v.name)) hasBodyTarget = true;
+                    }
+
+                    if (hasBodyContext && !hasBodyTarget)
+                        return $"CC parameter '{typeName}' has body-context field (e.g. coverage/scanType) but is missing required body target (targetBody)";
+                }
+
+                // Recurse into nested PARAM nodes.
+                var nested = FindFirstInvalidParam(child, isCC);
+                if (nested != null) return nested;
+            }
+
+            return null;
+        }
+    }
+}

--- a/LmpClient/Harmony/OrbitDriver_UpdateOrbit.cs
+++ b/LmpClient/Harmony/OrbitDriver_UpdateOrbit.cs
@@ -25,7 +25,12 @@ namespace LmpClient.Harmony
             if (MainSystem.NetworkState < ClientState.Connected) return true;
             if (__instance.vessel == null) return true;
             if (FlightGlobals.ActiveVessel && __instance.vessel == FlightGlobals.ActiveVessel && __instance.vessel.packed) return true;
-            if (!__instance.vessel.IsImmortal() && __instance.vessel.packed) return true;
+            // For packed vessels that LMP is actively managing, use our custom update to suppress spurious
+            // on-rails SOI transitions. Stock UpdateOrbit detects SOI crossings from orbit parameters that
+            // LMP resets every frame via UpdateFromStateVectors, causing repeated transition log spam.
+            // The reference body for these vessels is controlled by Orbit[7] in position messages.
+            if (!__instance.vessel.IsImmortal() && __instance.vessel.packed &&
+                !VesselPositionSystem.Singleton.VesselHavePositionUpdatesQueued(__instance.vessel.id)) return true;
 
             UpdateOrbit(__instance, offset, ref ___ready, ref ___fdtLast, ref ___isHyperbolic);
 
@@ -37,12 +42,17 @@ namespace LmpClient.Harmony
             if (!ready) return;
             driver.lastMode = driver.updateMode;
 
+            var hasQueuedUpdates = VesselPositionSystem.Singleton.VesselHavePositionUpdatesQueued(driver.vessel.id);
+
             //Always call updateFromParameters so the vessel is positioned based on the orbital data
-            if ((VesselPositionSystem.Singleton.VesselHavePositionUpdatesQueued(driver.vessel.id) && driver.updateMode == OrbitDriver.UpdateMode.TRACK_Phys)
+            if ((hasQueuedUpdates && driver.updateMode == OrbitDriver.UpdateMode.TRACK_Phys)
                 || driver.updateMode == OrbitDriver.UpdateMode.UPDATE)
             {
                 driver.updateFromParameters();
-                if (driver.vessel)
+                // When LMP is actively syncing a vessel, the reference body is driven by the incoming
+                // position message (Orbit[7]). Calling CheckDominantBody here would race against that,
+                // spuriously switching the body and producing on-rails SOI transition spam in map view.
+                if (driver.vessel && !hasQueuedUpdates)
                 {
                     driver.CheckDominantBody(driver.referenceBody.position + driver.pos);
                 }

--- a/LmpClient/LmpClient.csproj
+++ b/LmpClient/LmpClient.csproj
@@ -168,6 +168,7 @@
     <Compile Include="Harmony\EVAConstructionModeEditor_AttachPart.cs" />
     <Compile Include="Harmony\EVAConstructionModeEditor_DropAttachablePart.cs" />
     <Compile Include="Harmony\ModuleDockingNode_DockToVessel.cs" />
+    <Compile Include="Harmony\ContractPreLoader_Filter.cs" />
     <Compile Include="Harmony\ContractSystem_LoadContract.cs" />
     <Compile Include="Harmony\ContractSystem_OnAwake.cs" />
     <Compile Include="Harmony\ContractSystem_OnLoad.cs" />

--- a/LmpClient/Systems/Scenario/ScenarioSystem.cs
+++ b/LmpClient/Systems/Scenario/ScenarioSystem.cs
@@ -344,6 +344,27 @@ namespace LmpClient.Systems.Scenario
                 if (string.IsNullOrEmpty(guid) || existingGuids.Contains(guid))
                     continue;
 
+                // KSPCF's ContractPreLoader.OnLoad calls Contract.Load(node) on each child
+                // outside the ContractSystem.LoadContract path that LMP's Harmony finalizer
+                // guards, so exceptions there are never suppressed.  Apply the same body-index
+                // validation here so contracts that would cause CC's ParseCelestialBodyValue
+                // to throw ArgumentException never reach that code path.
+                var typeName = contractNode.GetValue("type") ?? string.Empty;
+                var isCC = string.Equals(typeName, "ConfiguredContract", StringComparison.OrdinalIgnoreCase);
+                var invalidBody = FindInvalidBodyIndex(contractNode, isCC);
+                if (invalidBody != null)
+                {
+                    LunaLog.LogWarning($"[ContractPreLoader]: Skipping injection of contract {guid} ({typeName}) — {invalidBody}.");
+                    continue;
+                }
+
+                var missingBody = FindMissingBodyReference(contractNode, isCC);
+                if (missingBody != null)
+                {
+                    LunaLog.LogWarning($"[ContractPreLoader]: Skipping injection of contract {guid} ({typeName}) — {missingBody}.");
+                    continue;
+                }
+
                 // Add the full CONTRACT node (same name KSP uses in ContractSystem.OnSave).
                 // KSPCF's ContractPreLoader.OnLoad calls Contract.Load(node) on each child,
                 // which requires type, guid, state, and all parameters to succeed.
@@ -461,6 +482,7 @@ namespace LmpClient.Systems.Scenario
             {
                 var guid = contractNode.GetValue("guid");
                 var typeName = contractNode.GetValue("type") ?? "Unknown";
+                var isConfiguredContract = string.Equals(typeName, "ConfiguredContract", StringComparison.OrdinalIgnoreCase);
 
                 var missingPart = FindMissingPartName(contractNode);
                 if (missingPart != null)
@@ -471,12 +493,21 @@ namespace LmpClient.Systems.Scenario
                     continue;
                 }
 
-                var invalidBody = FindInvalidBodyIndex(contractNode);
+                var invalidBody = FindInvalidBodyIndex(contractNode, isConfiguredContract);
                 if (invalidBody != null)
                 {
-                    LunaLog.LogWarning($"[ShareContracts]: Dropping contract {guid} ({typeName}) from {sectionName} — references {invalidBody} which is out of range on this client. The server likely has a planet pack installed that this client does not.");
+                    LunaLog.LogWarning($"[ShareContracts]: Dropping contract {guid} ({typeName}) from {sectionName} — {invalidBody}.");
                     if (guid != null)
                         strippedOut[guid] = (typeName, invalidBody);
+                    continue;
+                }
+
+                var missingBody = FindMissingBodyReference(contractNode, isConfiguredContract);
+                if (missingBody != null)
+                {
+                    LunaLog.LogWarning($"[ShareContracts]: Dropping contract {guid} ({typeName}) from {sectionName} — {missingBody}.");
+                    if (guid != null)
+                        strippedOut[guid] = (typeName, missingBody);
                     continue;
                 }
 
@@ -524,15 +555,50 @@ namespace LmpClient.Systems.Scenario
             };
 
         /// <summary>
-        /// Recursively searches a contract ConfigNode for any value whose key is a recognised
-        /// celestial-body index field and whose integer value falls outside the range of
-        /// <see cref="FlightGlobals.Bodies"/> on this client.
+        /// ConfigNode value keys found exclusively (or almost exclusively) in CC contract
+        /// parameters that also require a body-target key (<see cref="BodyIndexKeys"/>).
+        /// If a CC PARAM node contains any of these keys but none of the body-target keys,
+        /// the node is missing a required field that CC's <c>ConfigNodeUtil.ParseValue</c>
+        /// would throw <see cref="System.ArgumentException"/> for when loading.
         ///
-        /// Returns a human-readable description such as "body index #6 (key 'destination')" on
-        /// mismatch, or null if all body references are valid.  String-format body names (e.g.
-        /// "Duna") are not checked because they are resolved by name and do not cause index errors.
+        /// Examples: <c>SCANsatCoverage</c> requires both <c>coverage</c>/<c>scanType</c>
+        /// AND <c>targetBody</c>; if <c>targetBody</c> was never saved (malformed server data),
+        /// CC shows an in-game popup and the contract cannot be displayed.
         /// </summary>
-        private static string FindInvalidBodyIndex(ConfigNode node)
+        private static readonly System.Collections.Generic.HashSet<string> BodyContextKeys =
+            new System.Collections.Generic.HashSet<string>(StringComparer.OrdinalIgnoreCase)
+            {
+                // SCANsat integration parameters
+                "coverage", "scanType", "scanMode",
+                // CC science / biome / situation parameters
+                "experiment", "biome", "situation",
+                // CC orbital / altitude parameters
+                "orbitType", "minOrbit", "maxOrbit",
+                "minAltitude", "maxAltitude",
+                "minPeriapsis", "maxPeriapsis",
+                "minApoapsis", "maxApoapsis",
+                "minEccentricity", "maxEccentricity",
+                "minInclination", "maxInclination",
+            };
+
+        /// <summary>
+        /// Recursively searches a contract ConfigNode for any value whose key is a recognised
+        /// celestial-body index field and whose integer value is invalid for this client.
+        ///
+        /// For ordinary (non-CC) contracts, only out-of-range indices are flagged because KSP
+        /// resolves body references by integer index.
+        ///
+        /// For ContractConfigurator contracts (<paramref name="isConfiguredContract"/> = true),
+        /// <em>any</em> integer value is invalid: CC's <c>ParseCelestialBodyValue</c> resolves
+        /// bodies by name and throws <see cref="System.ArgumentException"/> when given a numeric
+        /// string such as <c>"5"</c>, even if that index is in range for
+        /// <see cref="FlightGlobals.Bodies"/>.  Such values can appear when a contract was
+        /// serialised by an older CC build or by KSPCF's ContractPreLoader using the raw body
+        /// index rather than the body name.
+        ///
+        /// Returns a human-readable description on mismatch, or null if all body references are valid.
+        /// </summary>
+        private static string FindInvalidBodyIndex(ConfigNode node, bool isConfiguredContract = false)
         {
             // Guard: if Bodies hasn't been populated yet (shouldn't happen at load time, but be safe).
             if (FlightGlobals.Bodies == null || FlightGlobals.Bodies.Count == 0)
@@ -546,7 +612,11 @@ namespace LmpClient.Systems.Scenario
                 if (int.TryParse(v.value, out idx))
                 {
                     if (idx < 0 || idx >= FlightGlobals.Bodies.Count)
-                        return $"body index #{idx} (key '{v.name}')";
+                        return $"body index #{idx} (key '{v.name}') out of range";
+                    // CC contracts always store body names; any in-range integer is also invalid
+                    // because ParseCelestialBodyValue only accepts names, not numeric strings.
+                    if (isConfiguredContract)
+                        return $"body index #{idx} (key '{v.name}') — CC contract expects a body name, not an integer";
                 }
                 else if (double.TryParse(v.value,
                              System.Globalization.NumberStyles.Float,
@@ -558,14 +628,62 @@ namespace LmpClient.Systems.Scenario
                     // KSP occasionally serialises body indices as floats (e.g. "17" → "17.0").
                     idx = (int)dbl;
                     if (idx >= FlightGlobals.Bodies.Count)
-                        return $"body index #{idx} (key '{v.name}', stored as float)";
+                        return $"body index #{idx} (key '{v.name}', stored as float) out of range";
+                    if (isConfiguredContract)
+                        return $"body index #{idx} (key '{v.name}', stored as float) — CC contract expects a body name, not an integer";
                 }
             }
             foreach (ConfigNode childNode in node.nodes)
             {
-                var invalid = FindInvalidBodyIndex(childNode);
+                var invalid = FindInvalidBodyIndex(childNode, isConfiguredContract);
                 if (invalid != null) return invalid;
             }
+            return null;
+        }
+
+        /// <summary>
+        /// Searches the direct PARAM child nodes of a <strong>CC ConfiguredContract</strong>
+        /// node for parameters that declare body-context fields (e.g. <c>coverage</c>,
+        /// <c>scanType</c>, <c>situation</c>) without any corresponding body-target field
+        /// (e.g. <c>targetBody</c>).  Such nodes are malformed — CC's
+        /// <c>ConfigNodeUtil.ParseValue&lt;CelestialBody&gt;</c> will throw
+        /// <see cref="System.ArgumentException"/> and display an in-game popup when it
+        /// tries to load a required body field that is absent.
+        ///
+        /// Only meaningful for CC contracts; always returns <c>null</c> for non-CC contracts.
+        /// </summary>
+        /// <returns>
+        /// A human-readable description of the problem (e.g.
+        /// <c>"PARAM 'SCANsatCoverage' has body-context field but no body target"</c>),
+        /// or <c>null</c> if no issue is found.
+        /// </returns>
+        private static string FindMissingBodyReference(ConfigNode contractNode, bool isConfiguredContract)
+        {
+            if (!isConfiguredContract) return null;
+
+            foreach (ConfigNode child in contractNode.nodes)
+            {
+                if (!string.Equals(child.name, "PARAM", StringComparison.OrdinalIgnoreCase)) continue;
+
+                var hasBodyContextKey = false;
+                var hasBodyKey = false;
+                foreach (ConfigNode.Value v in child.values)
+                {
+                    if (BodyContextKeys.Contains(v.name)) hasBodyContextKey = true;
+                    if (BodyIndexKeys.Contains(v.name)) hasBodyKey = true;
+                }
+
+                if (hasBodyContextKey && !hasBodyKey)
+                {
+                    var paramName = child.GetValue("name") ?? "unknown";
+                    return $"CC PARAM '{paramName}' has body-context field but is missing a required body target (targetBody/body)";
+                }
+
+                // Recurse into nested PARAM nodes.
+                var nested = FindMissingBodyReference(child, isConfiguredContract: true);
+                if (nested != null) return nested;
+            }
+
             return null;
         }
 

--- a/LmpClient/Systems/ShareContracts/ShareContractsEvents.cs
+++ b/LmpClient/Systems/ShareContracts/ShareContractsEvents.cs
@@ -95,6 +95,13 @@ namespace LmpClient.Systems.ShareContracts
             // Tell the Harmony postfix that onContractsLoaded fired normally so it does not
             // fire it a second time.
             System.ContractsLoadedEventFired = true;
+
+            // Snapshot the server-offered Contract objects NOW, before StopIgnoringEvents() and
+            // before any other onContractsLoaded listener (e.g. ContractConfigurator) runs and
+            // potentially removes them.  The snapshot is passed to PostLoadContractCheck so it can
+            // detect and restore missing contracts in the first frame after load.
+            var serverOfferedSnapshot = SnapshotServerOfferedContracts();
+
             // Safe point to stop ignoring events: ContractSystem.OnLoad() has fully completed.
             // ContractOffered from new contract generation cannot fire until LockAcquire sets
             // generateContractIterations back to the default, which always happens after
@@ -105,15 +112,46 @@ namespace LmpClient.Systems.ShareContracts
             CreateUnavailableContractStubs();
             LogContractPreLoaderState();
             LogMissionControlTally();
-            HighLogic.fetch.StartCoroutine(PostLoadContractCheck());
+            HighLogic.fetch.StartCoroutine(PostLoadContractCheck(serverOfferedSnapshot));
+        }
+
+        /// <summary>
+        /// Takes a snapshot of every Contract object whose GUID is in the server's Offered set,
+        /// capturing them while they are definitely present (before any post-load listener can
+        /// remove them).  The snapshot is used by <see cref="PostLoadContractCheck"/> to detect
+        /// and restore contracts silently removed between <c>onContractsLoaded</c> and the first
+        /// Unity Update frame.
+        /// </summary>
+        private List<Contract> SnapshotServerOfferedContracts()
+        {
+            var cs = ContractSystem.Instance;
+            if (cs == null) return new List<Contract>();
+
+            var serverGuids = System.ServerOfferedContractGuids;
+            if (serverGuids == null || serverGuids.Count == 0) return new List<Contract>();
+
+            var snapshot = new List<Contract>();
+            foreach (var c in cs.Contracts)
+            {
+                if (c != null && serverGuids.Contains(c.ContractGuid.ToString()))
+                    snapshot.Add(c);
+            }
+
+            LunaLog.Log($"[ShareContracts]: Snapshotted {snapshot.Count} server-offered contract object(s) for post-load restoration guard.");
+            return snapshot;
         }
 
         /// <summary>
         /// Logs the Offered contract count once per frame for 5 frames after ContractsLoaded(),
         /// then at 1 s and 3 s, to pinpoint exactly when (and therefore which system) removes
         /// contracts that are present at the end of our onContractsLoaded handler.
+        ///
+        /// At frame +1 it also runs a restoration pass: any contract from
+        /// <paramref name="serverOfferedSnapshot"/> that is no longer present in
+        /// <c>ContractSystem.Instance.Contracts</c> is re-added with <c>IgnoreEvents</c>
+        /// temporarily enabled so the <c>ContractOffered</c> lock-guard cannot withdraw it again.
         /// </summary>
-        private static System.Collections.IEnumerator PostLoadContractCheck()
+        private System.Collections.IEnumerator PostLoadContractCheck(List<Contract> serverOfferedSnapshot)
         {
             var cs = ContractSystem.Instance;
             if (cs == null) yield break;
@@ -123,6 +161,15 @@ namespace LmpClient.Systems.ShareContracts
                 yield return null;
                 var offered = cs.Contracts.Count(c => c.ContractState == Contract.State.Offered);
                 LunaLog.Log($"[ShareContracts]: Post-load check frame +{i} — {offered} Offered contracts.");
+
+                if (i == 1 && serverOfferedSnapshot != null && serverOfferedSnapshot.Count > 0)
+                {
+                    RestoreMissingServerOfferedContracts(cs, serverOfferedSnapshot);
+                    // Re-count after restoration so subsequent frames reflect the corrected state.
+                    offered = cs.Contracts.Count(c => c.ContractState == Contract.State.Offered);
+                    LunaLog.Log($"[ShareContracts]: Post-load check frame +{i} after restoration — {offered} Offered contracts.");
+                }
+
                 if (offered == 0) yield break;
             }
 
@@ -136,6 +183,80 @@ namespace LmpClient.Systems.ShareContracts
             {
                 var offered = cs.Contracts.Count(c => c.ContractState == Contract.State.Offered);
                 LunaLog.Log($"[ShareContracts]: Post-load check +3 s — {offered} Offered contracts.");
+            }
+        }
+
+        /// <summary>
+        /// Restores server-offered contracts that were silently removed from
+        /// <c>ContractSystem.Instance.Contracts</c> between <c>onContractsLoaded</c> and the
+        /// first Unity Update frame.
+        ///
+        /// For each snapshotted contract that is no longer in <c>Contracts</c>:
+        /// <list type="bullet">
+        ///   <item>Searches <c>ContractsFinished</c> first — if found there the contract was
+        ///         legitimately completed/failed and no restoration is needed.</item>
+        ///   <item>Otherwise re-adds the original Contract object to <c>Contracts</c> with
+        ///         <c>IgnoreEvents = true</c> so the <c>ContractOffered</c> lock-guard cannot
+        ///         withdraw it immediately.</item>
+        /// </list>
+        /// </summary>
+        private void RestoreMissingServerOfferedContracts(ContractSystem cs, List<Contract> serverOfferedSnapshot)
+        {
+            // Build a set of GUIDs currently in Contracts (any state) for fast lookup.
+            var presentInContracts = new System.Collections.Generic.HashSet<string>(StringComparer.OrdinalIgnoreCase);
+            foreach (var c in cs.Contracts)
+            {
+                if (c != null) presentInContracts.Add(c.ContractGuid.ToString());
+            }
+
+            var restored = 0;
+            foreach (var contract in serverOfferedSnapshot)
+            {
+                var guid = contract.ContractGuid.ToString();
+
+                if (presentInContracts.Contains(guid))
+                    continue; // still present — nothing to do
+
+                // Check ContractsFinished: if the contract ended up there it completed/failed
+                // legitimately (e.g. ExplorationContract auto-completed because the milestone
+                // was already achieved in ProgressTracking). Log it and skip.
+                var inFinished = false;
+                foreach (var fc in cs.ContractsFinished)
+                {
+                    if (fc != null && fc.ContractGuid.ToString().Equals(guid, StringComparison.OrdinalIgnoreCase))
+                    {
+                        inFinished = true;
+                        LunaLog.Log($"[ShareContracts]: Contract {guid} ({contract.GetType().Name}) is in ContractsFinished " +
+                                    $"(state: {fc.ContractState}) — this is correct, not restoring.");
+                        break;
+                    }
+                }
+
+                if (inFinished) continue;
+
+                // The contract was removed from Contracts and is NOT in ContractsFinished —
+                // it was silently discarded (e.g. by a slot-limit enforcement mechanism or a
+                // WithdrawAndRemoveContract call from a ContractOffered race). Re-add it.
+                LunaLog.LogWarning($"[ShareContracts]: Contract {guid} ({contract.GetType().Name}, " +
+                                   $"state: {contract.ContractState}) was silently removed from " +
+                                   $"ContractSystem.Contracts after load. Restoring.");
+
+                System.StartIgnoringEvents();
+                try
+                {
+                    cs.Contracts.Add(contract);
+                    restored++;
+                }
+                finally
+                {
+                    System.StopIgnoringEvents();
+                }
+            }
+
+            if (restored > 0)
+            {
+                LunaLog.Log($"[ShareContracts]: Restored {restored} silently-removed server Offered contract(s).");
+                GameEvents.Contract.onContractsListChanged.Fire();
             }
         }
 
@@ -399,12 +520,14 @@ namespace LmpClient.Systems.ShareContracts
             // ContractSystem.OnLoad() (scenario restore path) via ContractSystem_OnLoad patch.
             if (System.IgnoreEvents) return;
 
+            var guidStr = contract.ContractGuid.ToString();
+
             // Protect every contract that was part of the server's Offered snapshot.
             // ContractPreLoader (KSPCF) subscribes to onContractsLoaded and re-fires onOffered
             // for contracts already in the system so it can register them in its persistent list.
             // If we intercepted those events we would withdraw valid server contracts regardless
             // of lock status. Contracts not in this set are locally generated and handled normally.
-            if (System.ServerOfferedContractGuids.Contains(contract.ContractGuid.ToString()))
+            if (System.ServerOfferedContractGuids.Contains(guidStr))
                 return;
 
             if (!LockSystem.LockQuery.ContractLockBelongsToPlayer(SettingsSystem.CurrentSettings.PlayerName))
@@ -412,6 +535,9 @@ namespace LmpClient.Systems.ShareContracts
                 //We don't have the contract lock, so discard any contract KSP generated locally.
                 //New generation is already suppressed via generateContractIterations = 0; this
                 //is a safety net for any edge case where KSP still fires the event.
+                LunaLog.LogWarning($"[ShareContracts]: ContractOffered — withdrawing locally-generated contract " +
+                                   $"{guidStr} ({contract.GetType().Name}) — not in server Offered snapshot " +
+                                   $"({System.ServerOfferedContractGuids.Count} GUIDs tracked), no contract lock.");
                 WithdrawAndRemoveContract(contract);
                 return;
             }


### PR DESCRIPTION
## Problem

Three related issues were identified and fixed in this PR.

### 1. Server-offered contract disappears after load
When connecting to a Career server, certain contracts (notably `ExplorationContract`s) would be received from the server and briefly appear in `ContractSystem.Contracts` at the end of `onContractsLoaded`, but then silently vanish before the first `Update` frame â€” not moved to `ContractsFinished`, just gone. The contract would not appear in Available, Active, or Archived in Mission Control.

### 2. ContractConfigurator [EXC] spam from injected server contracts
LMP injects server-offered contract nodes into `ContractPreLoader`'s scenario so KSPCF can preserve them across `GenerateContracts`. However, some of those contracts reference parameter types the client doesn't have installed, or store celestial body references as numeric indices (CC always expects body names). CC's `ContractPreLoader.OnLoad` calls `Contract.Load` directly â€” outside the `ContractSystem.LoadContract` path that LMP's Harmony finalizer guards â€” so exceptions there were never suppressed, producing `[EXC]` log spam.

### 3. Spurious SOI transition spam for LMP-managed packed vessels
`OrbitDriver.UpdateOrbit` was calling `CheckDominantBody` on every frame for packed vessels that LMP actively manages via position updates. Because LMP resets orbit parameters from incoming state vectors every frame, KSP's SOI detector was repeatedly detecting false transitions, flooding the log with on-rails SOI transition messages in map view.

---

## Changes

### Contract system

**`ContractPreLoader_Filter.cs`** (new)
A Harmony prefix applied imperatively to `ContractConfigurator.ContractPreLoader.OnLoad` that strips invalid `CONTRACT` nodes before CC iterates them. Detects two failure modes:
- Unknown parameter type â€” `ContractSystem.GetParameterType` returns null, causing a `NullReferenceException`
- Malformed CC PARAM â€” has body-context fields (`coverage`, `scanType`, `situation`, etc.) but no body-target field (`targetBody`), causing `ArgumentException` and an in-game popup

Applied imperatively (not via `[HarmonyPatch]` attributes) because `ContractPreLoader.OnLoad` is a virtual override; attribute-driven patches target the base class body and are never dispatched through for `ContractPreLoader` instances.

**`HarmonyPatcher.cs`**
Added `PatchContractPreLoader()` to register the above prefix at runtime via type lookup, with graceful no-op if ContractConfigurator is not installed.

**`ScenarioSystem.cs`**
- Added `BodyContextKeys` set for detecting CC PARAMs with body-context fields but no body-target
- Added `FindMissingBodyReference` to identify CC contracts with those malformed PARAMs
- Extended `FindInvalidBodyIndex` to also flag CC contracts storing body references as integers (CC's `ParseCelestialBodyValue` only accepts names, not numeric strings, even when in range)
- Applied both new checks in `InjectServerContractsIntoPreLoader` and `MigrateFinishedContractsIntoMain`

**`ShareContractsEvents.cs`**
- `ContractsLoaded()` now calls `SnapshotServerOfferedContracts()` to capture all server-offered `Contract` objects while they are guaranteed present, before `StopIgnoringEvents()` and before any other `onContractsLoaded` listener can remove them
- `PostLoadContractCheck` coroutine receives the snapshot and at frame +1 calls `RestoreMissingServerOfferedContracts`, which checks `ContractsFinished` first (legitimately completed contracts are not restored) and re-adds any silently-removed contracts with `IgnoreEvents` temporarily enabled to prevent the `ContractOffered` lock-guard from withdrawing them again
- Re-counts offered contracts after restoration so subsequent diagnostic frames reflect the corrected state
- Added `LogWarning` in `ContractOffered` recording GUID, type, and tracked-GUID set size whenever a contract is about to be withdrawn as locally-generated

### Orbit

**`OrbitDriver_UpdateOrbit.cs`**
Suppresses `CheckDominantBody` for packed vessels that have LMP position updates queued (`VesselHavePositionUpdatesQueued`). The reference body for those vessels is controlled by the incoming position message (`Orbit[7]`); letting KSP's SOI detector run against LMP-reset orbit parameters every frame produced continuous spurious on-rails SOI transition log spam in map view.
