### PR TITLE
fix: VesselMsgReader truncation in Synchronization

### DIFF
--- a/Server/Message/VesselMsgReader.cs
+++ b/Server/Message/VesselMsgReader.cs
@@ -1,4 +1,4 @@
-﻿using ByteSizeLib;
+using ByteSizeLib;
 using LmpCommon.Message.Data.Vessel;
 using LmpCommon.Message.Interface;
 using LmpCommon.Message.Server;
@@ -141,8 +141,9 @@ namespace Server.Message
                 if (vesselData.Length > 0)
                 {
                     var protoMsg = ServerContext.ServerMessageFactory.CreateNewMessageData<VesselProtoMsgData>();
-                    protoMsg.Data = Encoding.UTF8.GetBytes(vesselData);
-                    protoMsg.NumBytes = vesselData.Length;
+                    var vesselBytes = Encoding.UTF8.GetBytes(vesselData);
+                    protoMsg.Data = vesselBytes;
+                    protoMsg.NumBytes = vesselBytes.Length;
                     protoMsg.VesselId = vesselId;
 
                     MessageQueuer.SendToClient<VesselSrvMsg>(client, protoMsg);


### PR DESCRIPTION
<!-- Thank you for contributing to LMP!

If you are adding a dedicated server, please read https://github.com/LunaMultiplayer/LunaMultiplayer/wiki/Dedicated-server first,
especially:
* Your server doesn't need to be listed as "dedicated server" to show up in the server browser.
* Dedicated servers should have either a static IP address or working DynDNS
* Port forwarding should be set up statically, or at least UPnP needs to work reliably
* Dedicated servers should not be password protected
* Dedicated servers need to be available 24/7

Please confirm that you have read and verified all of the above.
-->
### Fixes included in this PR:
This PR fixes a bug in the server's vessel synchronization logic where vessel data was being truncated when containing non-ASCII (multi-byte UTF-8) characters, which also includes Korean, Russian, Chinese and more characters.

In `VesselMsgReader.cs`, the code was converting the vessel string to a byte array but assigning the string's character length to the `NumBytes` field:

```csharp
protoMsg.Data = Encoding.UTF8.GetBytes(vesselData);
protoMsg.NumBytes = vesselData.Length; // BUG: Should be byte array length
```
In UTF-8, characters like §, ö, or any Unicode symbol use 2+ bytes. If a vessel name or data contained these, `vesselData.Length` would be smaller than the actual byte array, causing the message to be cut off (truncated) at the end. This typically results in invalid ConfigNodes (missing closing braces) on the client side, with `NullReferenceException` error shows up.

### Changes proposed in this PR:

The NumBytes is now correctly set to the length of the generated byte array:

```csharp
var vesselBytes = Encoding.UTF8.GetBytes(vesselData);
protoMsg.Data = vesselBytes;
protoMsg.NumBytes = vesselBytes.Length;
```