### PR TITLE
fix: vessel coupling system for synchronized docking

### DIFF
--- a/LmpClient/Systems/VesselCoupleSys/VesselCouple.cs
+++ b/LmpClient/Systems/VesselCoupleSys/VesselCouple.cs
@@ -1,4 +1,4 @@
-﻿using HarmonyLib;
+using HarmonyLib;
 using LmpClient.Extensions;
 using LmpClient.Systems.VesselRemoveSys;
 using LmpClient.VesselUtilities;
@@ -40,10 +40,22 @@ namespace LmpClient.Systems.VesselCoupleSys
             _activeVesselIsDominantVessel = FlightGlobals.ActiveVessel && FlightGlobals.ActiveVessel.id == VesselId;
 
             var coupleResult = ProcessCoupleInternal(VesselId, CoupledVesselId, PartFlightId, CoupledPartFlightId, Trigger);
-            AfterCouplingEvent();
 
-            if (!coupleResult)
-                VesselRemoveSystem.Singleton.KillVessel(CoupledVesselId, false, "Killing coupled vessel during a undetected coupling");
+            // FIX: Only call AfterCouplingEvent if coupling succeeded
+            if (coupleResult)
+            {
+                AfterCouplingEvent();
+            }
+            else
+            {
+                // Reset static state to prevent stale data
+                _dominantVessel = null;
+                _weakVessel = null;
+                
+                VesselRemoveSystem.Singleton.KillVessel(CoupledVesselId, false,
+                "Killing coupled vessel during a undetected coupling");
+
+            }
 
             return coupleResult;
         }
@@ -145,8 +157,11 @@ namespace LmpClient.Systems.VesselCoupleSys
 
             if (_activeVesselIsDominantVessel)
             {
-                _dominantVessel.MakeActive();
-                FlightInputHandler.SetNeutralControls();
+                if (_dominantVessel)
+                {
+                    _dominantVessel.MakeActive();
+                    FlightInputHandler.SetNeutralControls();
+                }
             }
         }
     }

--- a/LmpClient/Systems/VesselCoupleSys/VesselCoupleEvents.cs
+++ b/LmpClient/Systems/VesselCoupleSys/VesselCoupleEvents.cs
@@ -1,4 +1,4 @@
-﻿using LmpClient.Base;
+using LmpClient.Base;
 using LmpClient.Systems.Lock;
 using LmpClient.Systems.SettingsSys;
 using LmpClient.Systems.VesselRemoveSys;
@@ -39,20 +39,19 @@ namespace LmpClient.Systems.VesselCoupleSys
 
             System.MessageSender.SendVesselCouple(partFrom.vessel, partTo.flightID, removedVesselId, partFrom.flightID, trigger);
 
-            var ownFinalVessel = LockSystem.LockQuery.UpdateLockBelongsToPlayer(partFrom.vessel.id, SettingsSystem.CurrentSettings.PlayerName);
-            if (ownFinalVessel)
+            // FIX: Force acquire all locks for the combined vessel
+            // The player who initiated the docking should control the combined vessel
+            LockSystem.Singleton.AcquireControlLock(partFrom.vessel.id, true);
+            LockSystem.Singleton.AcquireUpdateLock(partFrom.vessel.id, true);
+            LockSystem.Singleton.AcquireUnloadedUpdateLock(partFrom.vessel.id, true);
+            
+            foreach (var kerbal in partFrom.vessel.GetVesselCrew())
             {
-                foreach (var kerbal in partFrom.vessel.GetVesselCrew())
-                {
-                    LockSystem.Singleton.AcquireKerbalLock(kerbal.name, true);
-                }
+                LockSystem.Singleton.AcquireKerbalLock(kerbal.name, true);
+            }
+            
 
-                JumpIfVesselOwnerIsInFuture(removedVesselId);
-            }
-            else
-            {
-                JumpIfVesselOwnerIsInFuture(partFrom.vessel.id);
-            }
+            JumpIfVesselOwnerIsInFuture(removedVesselId);
 
             VesselRemoveSystem.Singleton.MessageSender.SendVesselRemove(removedVesselId, false);
             VesselRemoveSystem.Singleton.DelayedKillVessel(removedVesselId, false, "Killing coupled vessel during a detected coupling", 500);

--- a/LmpClient/Systems/VesselProtoSys/VesselProtoEvents.cs
+++ b/LmpClient/Systems/VesselProtoSys/VesselProtoEvents.cs
@@ -1,4 +1,4 @@
-﻿using LmpClient.Base;
+using LmpClient.Base;
 using LmpClient.Systems.Lock;
 using LmpClient.Systems.SettingsSys;
 using LmpClient.Systems.ShareScienceSubject;
@@ -123,7 +123,7 @@ namespace LmpClient.Systems.VesselProtoSys
             if (!LockSystem.LockQuery.UpdateLockBelongsToPlayer(partFrom.vessel.id, SettingsSystem.CurrentSettings.PlayerName) &&
                 !LockSystem.LockQuery.UpdateLockBelongsToPlayer(removedVesselId, SettingsSystem.CurrentSettings.PlayerName)) return;
 
-            System.MessageSender.SendVesselMessage(partFrom.vessel);
+            System.MessageSender.SendVesselMessage(partFrom.vessel, forceReload: true);
         }
 
         /// <summary>


### PR DESCRIPTION
<!-- Thank you for contributing to LMP!

If you are adding a dedicated server, please read https://github.com/LunaMultiplayer/LunaMultiplayer/wiki/Dedicated-server first,
especially:
* Your server doesn't need to be listed as "dedicated server" to show up in the server browser.
* Dedicated servers should have either a static IP address or working DynDNS
* Port forwarding should be set up statically, or at least UPnP needs to work reliably
* Dedicated servers should not be password protected
* Dedicated servers need to be available 24/7

Please confirm that you have read and verified all of the above.
-->
### Fixes included in this PR:

- **Fixed `NullReferenceException` crashes during failed docking:** Prevents the game from hard-crashing or breaking the client's camera if a coupling/docking event fails to execute due to glitchy parts or missing vessels.
- **Fixed loss of vessel control after docking:** Ensures that the player who actively initiates a docking maneuver (e.g., docking to a space station) immediately gains all controls of the resulting combined vessel, preventing them from being locked out of their own ship.
- **Fixed visual desyncs and physics bugs for spectators:** Resolves issues where other players observing a docking event would see parts floating in space or ships exploding, by forcing their clients to completely rebuild the newly docked vessel.

### Changes proposed in this PR:

- **`VesselCouple.cs`**: Wrapped `AfterCouplingEvent()` in a `if (coupleResult)` check to ensure it only fires on successful docking. Added explicit null cleanup for `_dominantVessel` and `_weakVessel` when docking fails to prevent stale data corruption, and added a null-check safeguard before calling `.MakeActive()`.
- **`VesselCoupleEvents.cs`**: Removed the conditional check for prior lock ownership. The code now forcefully acquires the `ControlLock`, `UpdateLock`, and `UnloadedUpdateLock` on the combined vessel for the player triggering the docking event.
- **`VesselProtoEvents.cs`**: Updated `System.MessageSender.SendVesselMessage(partFrom.vessel)` to include `forceReload: true` inside `PartCoupled()`, explicitly commanding other connected clients to rebuild the vessel model from scratch rather than attempting a standard interpolation update.
