### PR TITLE
Improve server commands

### DIFF
--- a/Server/Command/Command/BanPlayerCommand.cs
+++ b/Server/Command/Command/BanPlayerCommand.cs
@@ -38,7 +38,7 @@ namespace Server.Command.Command
             }
             else
             {
-                LunaLog.Normal("Undefined function. Usage: /ban [username] [reason]");
+                LunaLog.Error("Syntax error. Usage: /ban [username] [reason]");
             }
 
             return false;

--- a/Server/Command/Command/ClearVesselsCommand.cs
+++ b/Server/Command/Command/ClearVesselsCommand.cs
@@ -28,7 +28,7 @@ namespace Server.Command.Command
                                  $"You can use * on a search param to accept all possible values.{Environment.NewLine}" +
                                  $"Using * for all params like in the following example{Environment.NewLine}" +
                                  $"will clear every vessel from universe.{Environment.NewLine}" +
-                                 $"/clearvessels * * * * *{Environment.NewLine}" +
+                                 $"/clearvessels * * * *{Environment.NewLine}" +
                                  $"vesselType can be ship, plane, debris, spaceobject etc.{Environment.NewLine}" +
                                  $"vesselSituation can be orbiting, flying, landed.{Environment.NewLine}" +
                                  $"vesselSplashed can be true or false.{Environment.NewLine}" +

--- a/Server/Command/Command/VesselCommand.cs
+++ b/Server/Command/Command/VesselCommand.cs
@@ -14,7 +14,7 @@ namespace Server.Command.Command
             var args = commandArgs.Split(' ', StringSplitOptions.RemoveEmptyEntries);
             if (args.Length < 2 || args[0].ToLower() != "info")
             {
-                LunaLog.Normal("Usage: /vessel info [name/guid]");
+                LunaLog.Error("Syntax error. Usage: /vessel info [name/guid]");
                 return false;
             }
 

--- a/Server/Command/Common/CommandSystemHelperMethods.cs
+++ b/Server/Command/Common/CommandSystemHelperMethods.cs
@@ -1,4 +1,7 @@
-﻿namespace Server.Command.Common
+﻿using System.Text.RegularExpressions;
+using System.Linq;
+
+namespace Server.Command.Common
 {
     public class CommandSystemHelperMethods
     {
@@ -15,7 +18,11 @@
         public static void SplitCommandParamArray(string command, out string[] parameters)
         {
             parameters = null;
-            var paramArray = command.Split(' ');
+            var paramArray = Regex.Matches(command, "\"[^\"]+\"|[^ \"]+")
+            .Cast<Match>()
+            .Select(m => m.Value.Trim('"'))
+            .ToArray();
+
             if (paramArray.Length > 0)
                 if (!string.IsNullOrEmpty(paramArray[0]))
                     parameters = paramArray;

--- a/Server/Command/Common/CommandSystemHelperMethods.cs
+++ b/Server/Command/Common/CommandSystemHelperMethods.cs
@@ -5,16 +5,6 @@ namespace Server.Command.Common
 {
     public class CommandSystemHelperMethods
     {
-        public static void SplitCommand(string command, out string param1, out string param2)
-        {
-            param2 = "";
-            var splittedCommand = command.Split(new[] { ' ' }, 2);
-            param1 = splittedCommand[0];
-
-            if (splittedCommand.Length > 1)
-                param2 = splittedCommand[1];
-        }
-
         public static void SplitCommandParamArray(string command, out string[] parameters)
         {
             parameters = null;
@@ -26,6 +16,18 @@ namespace Server.Command.Common
             if (paramArray.Length > 0)
                 if (!string.IsNullOrEmpty(paramArray[0]))
                     parameters = paramArray;
+        }
+
+        public static void SplitCommand(string command, out string param1, out string param2)
+        {
+            SplitCommandParamArray(command, out var parameters);
+            param1 = "";
+            if (parameters != null && parameters.Length > 0)
+                param1 = parameters[0];
+
+            param2 = "";
+            if (parameters != null && parameters.Length > 1)
+                param2 = parameters[1];
         }
     }
 }


### PR DESCRIPTION
### Fixes included in this PR:
327fcc55cb7397c3ab71d646cfbbf41d60c411c4 - Fixes an incorrect example. It used to say "/clearvessels \* \* \* \* \*" whilst there were only 4 parameters to set this is now correct to only display 4 '*'.

### Changes proposed in this PR:
c4561480387120772577831d591d7b7c9e194549 - Makes all Syntax errors log as errors and display "Syntax error"
ee3e7f9f7c37d1cd82b37d4c3baffb14c4172600 - Allows for "" to be used in parameters which allows for full vessel names in the "clearvessels" command. This solves #540 
ee1d6395036ac4919f2f588c0652b906bb6cea4c - Makes both types of splits use the same splitting code and thereby avoids code being repeated in the two diffrent but similar functions
