### PR TITLE
R&D disconnect fix

### DIFF
--- a/LmpClient/Systems/ShareTechnology/ShareTechnologyMessageHandler.cs
+++ b/LmpClient/Systems/ShareTechnology/ShareTechnologyMessageHandler.cs
@@ -37,13 +37,6 @@ namespace LmpClient.Systems.ShareTechnology
             //Unlock the technology
             ResearchAndDevelopment.Instance.UnlockProtoTechNode(node);
 
-            //Refresh RD nodes in case we are in the RD screen
-            if (RDController.Instance && RDController.Instance.partList)
-            {
-                RDController.Instance.partList.Refresh();
-                RDController.Instance.UpdatePanel();
-            }
-
             //Refresh the tech tree
             ResearchAndDevelopment.RefreshTechTreeUI();
 


### PR DESCRIPTION
<!-- Thank you for contributing to LMP!

If you are adding a dedicated server, please read https://github.com/LunaMultiplayer/LunaMultiplayer/wiki/Dedicated-server first,
especially:
* Your server doesn't need to be listed as "dedicated server" to show up in the server browser.
* Dedicated servers should have either a static IP address or working DynDNS
* Port forwarding should be set up statically, or at least UPnP needs to work reliably
* Dedicated servers should not be password protected
* Dedicated servers need to be available 24/7

Please confirm that you have read and verified all of the above.
-->
### Fixes included in this PR:
Fixes disconnect that would happen sometimes when two players are in the R&D and the other player researches nodes. (https://discord.com/channels/378456662392045571/1493699734517583872)

### Changes proposed in this PR:
Remove special logic for updating nodes when being in the RD screen. This does not at all affect the functionality and it still syncs nodes in my testing.
This seems too good to be true so please find the problem with this and have a crashout at me.
