### PR TITLE
Limit timewarp to 1x on WarpMode.None

### DIFF
--- a/LmpClient/Systems/Warp/WarpEvents.cs
+++ b/LmpClient/Systems/Warp/WarpEvents.cs
@@ -1,5 +1,8 @@
 ﻿using LmpClient.Base;
 using LmpClient.VesselUtilities;
+using UnityEngine;
+using LmpClient.Systems.SettingsSys;
+using LmpCommon.Enums;
 
 namespace LmpClient.Systems.Warp
 {
@@ -34,6 +37,12 @@ namespace LmpClient.Systems.Warp
                 System.CurrentSubspace = System.LatestSubspace;
                 System.SyncedToLastSubspace = true;
                 System.ProcessNewSubspace();
+            }
+
+            if (SettingsSystem.ServerSettings.WarpMode == WarpMode.None)
+            {
+                TimeWarp.fetch.physicsWarpRates = new float[] { 1f };
+                TimeWarp.fetch.warpRates = new float[] { 1f };
             }
         }
     }


### PR DESCRIPTION
<!-- Thank you for contributing to LMP!

If you are adding a dedicated server, please read https://github.com/LunaMultiplayer/LunaMultiplayer/wiki/Dedicated-server first,
especially:
* Your server doesn't need to be listed as "dedicated server" to show up in the server browser.
* Dedicated servers should have either a static IP address or working DynDNS
* Port forwarding should be set up statically, or at least UPnP needs to work reliably
* Dedicated servers should not be password protected
* Dedicated servers need to be available 24/7

Please confirm that you have read and verified all of the above.
-->
### Fixes included in this PR:
Removes the possibility to timewarp in none warp servers by using the timewarp keybinds #454

### Changes proposed in this PR:
Limit timewarp option to x1 everytime GameScenes are switched (if server does not allow timewarp), not doing it everytime leads to it being reset when switching GameScenes. This does unfortunately not display a "timewarp is disabled" message in the places where it wouldn't before.