### PR TITLE
option to freeze time whilst server is off

### DIFF
--- a/Server/Context/TimeContext.cs
+++ b/Server/Context/TimeContext.cs
@@ -5,5 +5,6 @@ namespace Server.Context
     public class TimeContext
     {
         public static DateTime StartTime;
+        public static DateTime EndTime;
     }
 }

--- a/Server/Settings/Definition/WarpSettingsDefinition.cs
+++ b/Server/Settings/Definition/WarpSettingsDefinition.cs
@@ -9,5 +9,7 @@ namespace Server.Settings.Definition
     {
         [XmlComment(Value = "Specify the warp Type. Values: None, Subspace")]
         public WarpMode WarpMode { get; set; } = WarpMode.Subspace;
+        [XmlComment(Value = "Tells the server to warp forward on startup to compensate for the time the server was down.")]
+        public bool WarpSyncOnStartup { get; set; } = true;
     }
 }

--- a/Server/Settings/Definition/WarpSettingsDefinition.cs
+++ b/Server/Settings/Definition/WarpSettingsDefinition.cs
@@ -9,7 +9,7 @@ namespace Server.Settings.Definition
     {
         [XmlComment(Value = "Specify the warp Type. Values: None, Subspace")]
         public WarpMode WarpMode { get; set; } = WarpMode.Subspace;
-        [XmlComment(Value = "Tells the server to warp forward on startup to compensate for the time the server was down.")]
-        public bool WarpSyncOnStartup { get; set; } = true;
+        [XmlComment(Value = "Tells the server to pause the time whilst off. If set to false the server will keep track of time and affect crafts")]
+        public bool PauseTimeWhileShutdown { get; set; } = false;
     }
 }

--- a/Server/System/TimeSystem.cs
+++ b/Server/System/TimeSystem.cs
@@ -54,6 +54,7 @@ namespace Server.System
                     LunaLog.Debug("Creating new time file, replacement of start time file");
                     TimeContext.StartTime = GetStoredStartTimeFromFile();
                     TimeContext.EndTime = LunaNetworkTime.UtcNow;
+                    File.Delete(OldStartTimeFile); // delete it since we will be using the new timefile in the future
                 }
                 else
                 {

--- a/Server/System/TimeSystem.cs
+++ b/Server/System/TimeSystem.cs
@@ -57,7 +57,7 @@ namespace Server.System
                 }
                 else
                 {
-                    LunaLog.Debug("Creating new start time file");
+                    LunaLog.Debug("Creating new time file");
                     TimeContext.StartTime = LunaNetworkTime.UtcNow;
                     TimeContext.EndTime = LunaNetworkTime.UtcNow;
                 }

--- a/Server/System/TimeSystem.cs
+++ b/Server/System/TimeSystem.cs
@@ -5,58 +5,112 @@ using System;
 using System.Globalization;
 using System.IO;
 using System.Linq;
+using Server.Settings;
+using Server.Settings.Structures;
 
 namespace Server.System
 {
     public static class TimeSystem
     {
-        private static string StartTimeFile { get; } = Path.Combine(ServerContext.UniverseDirectory, "StartTime.txt");
+        private static string TimeFile { get; } = Path.Combine(ServerContext.UniverseDirectory, "Time.txt");
+        private static string OldStartTimeFile { get; } = Path.Combine(ServerContext.UniverseDirectory, "StartTime.txt");
 
         public static void Reset()
         {
-            LoadSavedStartTime();
+            LoadSavedTimes();
+
+            if (!WarpSettings.SettingsStore.WarpSyncOnStartup)
+            {
+                var timeDiffrence = TimeContext.StartTime - TimeContext.EndTime;
+                TimeContext.StartTime += timeDiffrence;
+            }
         }
 
         public static void BackupStartTime()
         {
             var content = $"#Incorrectly editing this file will cause weirdness. If there is any errors, the universe time will be reset.{Environment.NewLine}";
             content += $"#This file can only be edited if the server is stopped.{Environment.NewLine}";
-            content += $"#It must always contain ONLY 1 line which will have the date and time when the server started in UTC{Environment.NewLine}";
+            content += $"#It must always contain 2 lines which will have the date and time when the server started and last stopped in UTC{Environment.NewLine}";
 
-            content += $"{TimeContext.StartTime:s}";
+            content += $"StartTime:{TimeContext.StartTime:s}{Environment.NewLine}";
+            content += $"EndTime:{LunaNetworkTime.UtcNow:s}";
 
-            FileHandler.WriteToFile(StartTimeFile, content);
+            FileHandler.WriteToFile(TimeFile, content);
         }
 
         #region Private methods
 
-        private static void LoadSavedStartTime()
+        private static void LoadSavedTimes()
         {
-            if (FileHandler.FileExists(StartTimeFile))
+            if (FileHandler.FileExists(TimeFile))
             {
                 TimeContext.StartTime = GetStoredStartTimeFromFile();
+                TimeContext.EndTime = GetStoredEndTimeFromFile();
             }
             else
             {
-                LunaLog.Debug("Creating new start time file");
-                TimeContext.StartTime = LunaNetworkTime.UtcNow;
+                if (FileHandler.FileExists(OldStartTimeFile))
+                {
+                    LunaLog.Debug("Creating new time file, replacement of start time file");
+                    TimeContext.StartTime = GetStoredStartTimeFromFile();
+                    TimeContext.EndTime = LunaNetworkTime.UtcNow;
+                }
+                else
+                {
+                    LunaLog.Debug("Creating new start time file");
+                    TimeContext.StartTime = LunaNetworkTime.UtcNow;
+                    TimeContext.EndTime = LunaNetworkTime.UtcNow;
+                }
             }
         }
 
         private static DateTime GetStoredStartTimeFromFile()
         {
-            var startTimeLine = FileHandler.ReadFileLines(StartTimeFile)
-                .Select(l => l.Trim()).Where(l => !string.IsNullOrEmpty(l) && !l.StartsWith("#")).SingleOrDefault();
+            var startTimeLine = FileHandler.ReadFileLines(TimeFile)
+                .Select(l => l.Trim())
+                .FirstOrDefault(l => l.StartsWith("StartTime:"));
+
+            if (startTimeLine != null)
+            {
+                startTimeLine = startTimeLine
+                    .Substring("StartTime:".Length)
+                    .Trim();
+            }
+            else
+            { // fallback to old system
+                startTimeLine = FileHandler.ReadFileLines(OldStartTimeFile)
+                    .Select(l => l.Trim()).Where(l => !string.IsNullOrEmpty(l) && !l.StartsWith("#")).SingleOrDefault();
+            }
 
             if (startTimeLine == null || !DateTime.TryParseExact(startTimeLine, "s", CultureInfo.InvariantCulture,
                 DateTimeStyles.None, out var startTime))
             {
-                LunaLog.Error("Incorrect StartTime.txt file!");
+                LunaLog.Error("Incorrect Time.txt file!");
                 return LunaNetworkTime.UtcNow;
             }
 
             return startTime;
         }
+
+        private static DateTime GetStoredEndTimeFromFile()
+        {
+            var endTimeLine = FileHandler.ReadFileLines(TimeFile)
+                .Select(l => l.Trim())
+                .FirstOrDefault(l => l.StartsWith("EndTime:"));
+
+            if (endTimeLine != null)
+                endTimeLine = endTimeLine.Substring("EndTime:".Length);
+
+            if (endTimeLine == null || !DateTime.TryParseExact(endTimeLine, "s", CultureInfo.InvariantCulture,
+                DateTimeStyles.None, out var endTime))
+            {
+                LunaLog.Error("Incorrect Time.txt file!");
+                return LunaNetworkTime.UtcNow;
+            }
+
+            return endTime;
+        }
+
 
         #endregion
 

--- a/Server/System/TimeSystem.cs
+++ b/Server/System/TimeSystem.cs
@@ -19,7 +19,7 @@ namespace Server.System
         {
             LoadSavedTimes();
 
-            if (!WarpSettings.SettingsStore.WarpSyncOnStartup)
+            if (WarpSettings.SettingsStore.PauseTimeWhileShutdown)
             {
                 var timeDiffrence = TimeContext.StartTime - TimeContext.EndTime;
                 TimeContext.StartTime += timeDiffrence;

--- a/Server/Web/Structures/Settings/ServerWarpSettings.cs
+++ b/Server/Web/Structures/Settings/ServerWarpSettings.cs
@@ -5,5 +5,6 @@ namespace Server.Web.Structures.Settings
     public class ServerWarpSettings
     {
         public string WarpMode => WarpSettings.SettingsStore.WarpMode.ToString();
+        public string WarpSyncOnStartup => WarpSettings.SettingsStore.WarpSyncOnStartup.ToString();
     }
 }

--- a/Server/Web/Structures/Settings/ServerWarpSettings.cs
+++ b/Server/Web/Structures/Settings/ServerWarpSettings.cs
@@ -5,6 +5,6 @@ namespace Server.Web.Structures.Settings
     public class ServerWarpSettings
     {
         public string WarpMode => WarpSettings.SettingsStore.WarpMode.ToString();
-        public string WarpSyncOnStartup => WarpSettings.SettingsStore.WarpSyncOnStartup.ToString();
+        public string PauseTimeWhileShutdown => WarpSettings.SettingsStore.PauseTimeWhileShutdown.ToString();
     }
 }


### PR DESCRIPTION
<!-- Thank you for contributing to LMP!

If you are adding a dedicated server, please read https://github.com/LunaMultiplayer/LunaMultiplayer/wiki/Dedicated-server first,
especially:
* Your server doesn't need to be listed as "dedicated server" to show up in the server browser.
* Dedicated servers should have either a static IP address or working DynDNS
* Port forwarding should be set up statically, or at least UPnP needs to work reliably
* Dedicated servers should not be password protected
* Dedicated servers need to be available 24/7

Please confirm that you have read and verified all of the above.
-->
### Fixes included in this PR:
Fixes #543 

### Changes proposed in this PR:
Adding a warp option for the server to determine if it should jump ahead or stay at the time it was at shutdown.
Saving EndTime in a new Time.txt file that replaces StartTime.txt.

The TimeContext system is a black box to me and I was wondering if anyone knew a better way of implementing this. I just implemented the solution the same way the current workaround mentioned in #543 did.
I was also wondering if the old startTime file should be deleted upon creation of the new one.