### PR TITLE
Add --data-directory and -d

### DIFF
--- a/Server/Command/Command/BanPlayerCommand.cs
+++ b/Server/Command/Command/BanPlayerCommand.cs
@@ -1,6 +1,7 @@
 ﻿using Server.Client;
 using Server.Command.Command.Base;
 using Server.Command.Common;
+using Server.Context;
 using Server.Log;
 using Server.Server;
 using Server.System;
@@ -46,7 +47,7 @@ namespace Server.Command.Command
 
         public static IEnumerable<string> GetBannedPlayers()
         {
-            return FileHandler.ReadFileLines(Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "LMPPlayerBans.txt"));
+            return FileHandler.ReadFileLines(Path.Combine(ServerContext.DataDirectory, "LMPPlayerBans.txt"));
         }
     }
 }

--- a/Server/Command/Command/Base/HandledCommand.cs
+++ b/Server/Command/Command/Base/HandledCommand.cs
@@ -1,4 +1,5 @@
-﻿using Server.Log;
+﻿using Server.Context;
+using Server.Log;
 using Server.System;
 using System;
 using System.Collections.Generic;
@@ -18,7 +19,7 @@ namespace Server.Command.Command.Base
 
         protected virtual List<string> Items { get; set; } = new List<string>();
 
-        protected string FullPath => Path.Combine(AppDomain.CurrentDomain.BaseDirectory, FileName);
+        protected string FullPath => Path.Combine(ServerContext.DataDirectory, FileName);
 
         #region Protected methods
 

--- a/Server/Context/ServerContext.cs
+++ b/Server/Context/ServerContext.cs
@@ -25,10 +25,11 @@ namespace Server.Context
         public static bool UsePassword => !string.IsNullOrEmpty(GeneralSettings.SettingsStore.Password);
 
         public static Stopwatch ServerClock = new Stopwatch();
-        public static string UniverseDirectory = Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "Universe");
-        public static string ConfigDirectory = Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "Config");
-        public static string ModFilePath = Path.Combine(ConfigDirectory, "LMPModControl.xml");
-        public static string OldModFilePath = Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "LMPModControl.xml");
+        public static string DataDirectory = AppDomain.CurrentDomain.BaseDirectory;
+        public static string UniverseDirectory => Path.Combine(DataDirectory, "Universe");
+        public static string ConfigDirectory => Path.Combine(DataDirectory, "Config");
+        public static string ModFilePath => Path.Combine(ConfigDirectory, "LMPModControl.xml");
+        public static string OldModFilePath => Path.Combine(DataDirectory, "LMPModControl.xml");
 
         // Configuration object
         public static NetPeerConfiguration Config { get; } = new NetPeerConfiguration("LMP")

--- a/Server/Log/LunaLog.cs
+++ b/Server/Log/LunaLog.cs
@@ -1,5 +1,6 @@
 ﻿using LmpCommon;
 using LmpCommon.Enums;
+using Server.Context;
 using Server.Settings.Structures;
 using Server.System;
 using System;
@@ -17,7 +18,7 @@ namespace Server.Log
                 FileHandler.FolderCreate(LogFolder);
         }
 
-        public static string LogFolder = Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "logs");
+        public static string LogFolder = Path.Combine(ServerContext.DataDirectory, "logs");
 
         public static string LogFilename = Path.Combine(LogFolder, $"lmpserver_{DateTime.Now:yyyy-MM-dd_HH-mm-ss}.log");
 

--- a/Server/MainServer.cs
+++ b/Server/MainServer.cs
@@ -23,6 +23,7 @@ using System.Reflection;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
+using System.CommandLine;
 
 namespace Server
 {
@@ -40,11 +41,34 @@ namespace Server
 
         private static bool IsRestart = false;
 
-        public static async Task Main()
+        public static async Task Main(string[] args)
         {
             //Verify the .NET runtime before anything else so we can give users a clear,
             //actionable message instead of failing later with a confusing error.
             DotNetRuntimeChecker.EnsureCorrectRuntimeOrExit();
+
+            Option<DirectoryInfo> dataDirectoryOption = new("--data-directory", ["-d"])
+            {
+                Description = "The location to store the server runtime data",
+                DefaultValueFactory = parseResult => new DirectoryInfo(AppDomain.CurrentDomain.BaseDirectory)
+            };
+
+            dataDirectoryOption.AcceptExistingOnly();
+
+            RootCommand rootCommand = new("Luna Multiplayer Server");
+            rootCommand.Options.Add(dataDirectoryOption);
+
+            var parseResult = rootCommand.Parse(args);
+            if (parseResult.Errors.Count != 0)
+            {
+                foreach (var parseError in parseResult.Errors)
+                {
+                    await Console.Error.WriteLineAsync(parseError.Message);
+                }
+                Environment.Exit(1);
+            }
+
+            ServerContext.DataDirectory = parseResult.GetValue(dataDirectoryOption).FullName;
 
             try
             {
@@ -87,6 +111,7 @@ namespace Server
                 ServerContext.Day = LunaNetworkTime.Now.Day;
 
                 LunaLog.Normal($"Luna Server version: {LmpVersioning.CurrentVersion} ({AppContext.BaseDirectory})");
+                LunaLog.Normal($"Server Data Directory: {ServerContext.DataDirectory}");
 
                 Universe.CheckUniverse();
                 LoadSettingsAndGroups();

--- a/Server/MainServer.cs
+++ b/Server/MainServer.cs
@@ -41,7 +41,7 @@ namespace Server
 
         private static bool IsRestart = false;
 
-        public static async Task Main(string[] args)
+        public static Task Main(string[] args)
         {
             //Verify the .NET runtime before anything else so we can give users a clear,
             //actionable message instead of failing later with a confusing error.
@@ -58,18 +58,17 @@ namespace Server
             RootCommand rootCommand = new("Luna Multiplayer Server");
             rootCommand.Options.Add(dataDirectoryOption);
 
-            var parseResult = rootCommand.Parse(args);
-            if (parseResult.Errors.Count != 0)
+            rootCommand.SetAction((parseResult, cancellationToken) =>
             {
-                foreach (var parseError in parseResult.Errors)
-                {
-                    await Console.Error.WriteLineAsync(parseError.Message);
-                }
-                Environment.Exit(1);
-            }
+                ServerContext.DataDirectory = parseResult.GetValue(dataDirectoryOption).FullName;
+                return RunServer(cancellationToken);
+            });
 
-            ServerContext.DataDirectory = parseResult.GetValue(dataDirectoryOption).FullName;
+            return rootCommand.Parse(args).InvokeAsync(new InvocationConfiguration {ProcessTerminationTimeout = null}, CancellationTokenSrc.Token);
+        }
 
+        private static async Task RunServer(CancellationToken cancellationToken)
+        {
             try
             {
                 // Force culture to en-US to avoid 'System.Net.Sockets.resources' assembly load error.
@@ -131,24 +130,23 @@ namespace Server
                 WebServer.StartWebServer();
 
                 //Do not add the command handler thread to the TaskContainer as it's a blocking task
-                _ = LongRunTaskFactory.StartNew(CommandHandler.ThreadMainAsync, CancellationTokenSrc.Token);
+                _ = LongRunTaskFactory.StartNew(CommandHandler.ThreadMainAsync, cancellationToken);
 
-                TaskContainer.Add(LongRunTaskFactory.StartNew(WebServer.RefreshWebServerInformationAsync, CancellationTokenSrc.Token));
+                TaskContainer.Add(LongRunTaskFactory.StartNew(WebServer.RefreshWebServerInformationAsync, cancellationToken));
 
-                TaskContainer.Add(LongRunTaskFactory.StartNew(LmpPortMapper.RefreshUpnpPortAsync, CancellationTokenSrc.Token));
-                TaskContainer.Add(LongRunTaskFactory.StartNew(LogThread.RunLogThreadAsync, CancellationTokenSrc.Token));
-                TaskContainer.Add(LongRunTaskFactory.StartNew(ClientMainThread.ThreadMainAsync, CancellationTokenSrc.Token));
+                TaskContainer.Add(LongRunTaskFactory.StartNew(LmpPortMapper.RefreshUpnpPortAsync, cancellationToken));
+                TaskContainer.Add(LongRunTaskFactory.StartNew(LogThread.RunLogThreadAsync, cancellationToken));
+                TaskContainer.Add(LongRunTaskFactory.StartNew(ClientMainThread.ThreadMainAsync, cancellationToken));
 
-                TaskContainer.Add(LongRunTaskFactory.StartNew(() => BackupSystem.PerformBackupsAsync(CancellationTokenSrc.Token), CancellationTokenSrc.Token));
-                TaskContainer.Add(LongRunTaskFactory.StartNew(LidgrenServer.StartReceivingMessagesAsync, CancellationTokenSrc.Token));
-                TaskContainer.Add(LongRunTaskFactory.StartNew(LidgrenMasterServer.RegisterWithMasterServerAsync, CancellationTokenSrc.Token));
-                TaskContainer.Add(LongRunTaskFactory.StartNew(LidgrenMasterServer.CheckNATTypeAsync, CancellationTokenSrc.Token));
+                TaskContainer.Add(LongRunTaskFactory.StartNew(() => BackupSystem.PerformBackupsAsync(cancellationToken), cancellationToken));
+                TaskContainer.Add(LongRunTaskFactory.StartNew(LidgrenServer.StartReceivingMessagesAsync, cancellationToken));
+                TaskContainer.Add(LongRunTaskFactory.StartNew(LidgrenMasterServer.RegisterWithMasterServerAsync, cancellationToken));
+                TaskContainer.Add(LongRunTaskFactory.StartNew(LidgrenMasterServer.CheckNATTypeAsync, cancellationToken));
 
-                TaskContainer.Add(LongRunTaskFactory.StartNew(VersionChecker.RefreshLatestVersionAsync, CancellationTokenSrc.Token));
-                TaskContainer.Add(LongRunTaskFactory.StartNew(VersionChecker.DisplayNewVersionMsgAsync, CancellationTokenSrc.Token));
+                TaskContainer.Add(LongRunTaskFactory.StartNew(VersionChecker.RefreshLatestVersionAsync, cancellationToken));
+                TaskContainer.Add(LongRunTaskFactory.StartNew(VersionChecker.DisplayNewVersionMsgAsync, cancellationToken));
 
-                TaskContainer.Add(LongRunTaskFactory.StartNew(() => GcSystem.PerformGarbageCollectionAsync(CancellationTokenSrc.Token), CancellationTokenSrc.Token));
-
+                TaskContainer.Add(LongRunTaskFactory.StartNew(() => GcSystem.PerformGarbageCollectionAsync(cancellationToken), cancellationToken));
                 while (ServerContext.ServerStarting)
                     Thread.Sleep(500);
 

--- a/Server/Plugin/LmpPluginHandler.cs
+++ b/Server/Plugin/LmpPluginHandler.cs
@@ -5,6 +5,7 @@ using System.Linq;
 using System.Reflection;
 using LmpCommon.Message.Interface;
 using Server.Client;
+using Server.Context;
 using Server.Log;
 using Server.System;
 
@@ -35,7 +36,7 @@ namespace Server.Plugin
 
         public static void LoadPlugins()
         {
-            var pluginDirectory = Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "Plugins");
+            var pluginDirectory = Path.Combine(ServerContext.DataDirectory, "Plugins");
             if (!FileHandler.FolderExists(pluginDirectory))
                 FileHandler.FolderCreate(pluginDirectory);
             LunaLog.Debug("Loading plugins...");

--- a/Server/Server.csproj
+++ b/Server/Server.csproj
@@ -19,6 +19,7 @@
     <PackageReference Include="LunaConfigNode" Version="1.9.1" />
     <PackageReference Include="Microsoft.VisualStudio.Threading" Version="17.8.14" />
     <PackageReference Include="Mono.Nat" Version="3.0.4" />
+    <PackageReference Include="System.CommandLine" Version="2.0.7" />
     <PackageReference Include="System.Drawing.Common" Version="8.0.0" />
   </ItemGroup>
 

--- a/ServerTest/VesselStoreSystemTest.cs
+++ b/ServerTest/VesselStoreSystemTest.cs
@@ -17,7 +17,7 @@ namespace ServerTest
         public void Setup()
         {
             // Set up a mock universe directory
-            ServerContext.UniverseDirectory = Path.Combine(Path.GetTempPath(), "LMPTestUniverse_" + Guid.NewGuid());
+            ServerContext.DataDirectory = Path.Combine(Path.GetTempPath(), "LMPTestData_" + Guid.NewGuid());
             if (!Directory.Exists(ServerContext.UniverseDirectory))
                 Directory.CreateDirectory(ServerContext.UniverseDirectory);
             
@@ -31,8 +31,8 @@ namespace ServerTest
         [TestCleanup]
         public void Cleanup()
         {
-            if (Directory.Exists(ServerContext.UniverseDirectory))
-                Directory.Delete(ServerContext.UniverseDirectory, true);
+            if (Directory.Exists(ServerContext.DataDirectory))
+                Directory.Delete(ServerContext.DataDirectory, true);
         }
 
         private string GetValidVesselData(Guid id)


### PR DESCRIPTION
This adds the command line argument --data-directory [folder], with an alias of -d [folder] to the server.
These can be used to tell the server where to store runtime data, specifically, Config, logs, plugins, and Universe. When not specified, it will default to AppDomain.CurrentDomain.BaseDirectory. This default insures backwards compatibility.

Use of these options should make it easier for server owners to update, since it can clearly separate the state you'd want to keep from the server files themselves.

The argument parsing uses System.CommandLine, added as a dependency. This can be easily used in the future for more options if needed.

Thank you!