### PR TITLE
Clean up GeoIP2 geolocalization provider

### DIFF
--- a/LmpMasterServer/Geolocalization/GeoIp2.cs
+++ b/LmpMasterServer/Geolocalization/GeoIp2.cs
@@ -1,0 +1,43 @@
+﻿using MaxMind.GeoIP2;
+using LmpMasterServer.Log;
+using System;
+using System.Net;
+using System.Threading.Tasks;
+
+namespace LmpMasterServer.Geolocalization
+{
+    internal class GeoIp2 : IGeolocalization
+    {
+
+        private static WebServiceClient client;
+
+        static GeoIp2()
+        {
+            var licenseKey = Environment.GetEnvironmentVariable("LMP_GEOIP2_LICENSE_KEY");
+            if (string.IsNullOrEmpty(licenseKey))
+                return;
+
+            if (!int.TryParse(Environment.GetEnvironmentVariable("LMP_GEOIP2_ACCOUNT_ID"), out var accountId))
+                return;
+
+            var clientOptions = (Microsoft.Extensions.Options.IOptions<WebServiceClientOptions>)new WebServiceClientOptions() { AccountId = accountId, LicenseKey = licenseKey };
+            client = new WebServiceClient(GeolocationHttpClient.GetClient(), clientOptions);
+            LunaLog.Debug($"GeoIP2 client setup successful, using account ID {accountId}");
+        }
+
+        public static async Task<string> GetCountryAsync(IPEndPoint externalEndpoint)
+        {
+            if (client == null)
+                return null;
+            try
+            {
+                var country = await client.CountryAsync(externalEndpoint.Address);
+                return country.Country.IsoCode;
+            }
+            catch (Exception)
+            {
+                return null;
+            }
+        }
+    }
+}

--- a/LmpMasterServer/Geolocalization/IpLocate.cs
+++ b/LmpMasterServer/Geolocalization/IpLocate.cs
@@ -1,5 +1,4 @@
-﻿using MaxMind.GeoIP2;
-using System;
+﻿using System;
 using System.Net;
 using System.Text.Json.Nodes;
 using System.Threading.Tasks;
@@ -16,25 +15,6 @@ namespace LmpMasterServer.Geolocalization
                 var output = JsonNode.Parse(
                     await client.GetStringAsync($"https://www.iplocate.io/api/lookup/{externalEndpoint.Address}"));
                 return output?["country_code"]?.GetValue<string>();
-            }
-            catch (Exception)
-            {
-                return null;
-            }
-        }
-
-        public static async Task<string> GetCountryAsyncGeoIp2(IPEndPoint externalEndpoint)
-        {
-            try
-            {
-                var licenseKey = Environment.GetEnvironmentVariable("license_key");
-
-                if (!int.TryParse(Environment.GetEnvironmentVariable("account_id"), out var accountId) || string.IsNullOrEmpty(licenseKey))
-                    return null;
-
-                var client = new WebServiceClient(accountId, licenseKey);
-                var country = await client.CountryAsync(externalEndpoint.Address);
-                return country.Country.IsoCode;
             }
             catch (Exception)
             {

--- a/LmpMasterServer/Lidgren/MasterServer.cs
+++ b/LmpMasterServer/Lidgren/MasterServer.cs
@@ -323,17 +323,12 @@ namespace LmpMasterServer.Lidgren
                         (var id, var endpoint) = item;
                         if (ServerDictionary.TryGetValue(id, out var server))
                         {
-                            try 
+                            try
                             {
-                                if (await server.SetCountryFromEndpointAsync(endpoint))
+                                if (await server.SetCountryFromEndpointAsync(endpoint)) // Returns whether it made an external request
                                     await Task.Delay(Server.MinCountryCodeRefreshInterval);
-                                else
-                                    Server.CountryCodeRefreshQueue.Enqueue(item);
                             }
-                            catch
-                            {
-                                Server.CountryCodeRefreshQueue.Enqueue(item);
-                            }
+                            catch { } // No need to requeue as that will be triggered on the next server update if the country code is still missing
                         }
                     } else {
                         await Task.Delay(CountryCodeRefreshInterval);

--- a/LmpMasterServer/Structure/Server.cs
+++ b/LmpMasterServer/Structure/Server.cs
@@ -54,10 +54,6 @@ namespace LmpMasterServer.Structure
             ServerVersion = msg.ServerVersion;
             ServerName = msg.ServerName.Length > 30 ? msg.ServerName.Substring(0, 30) : msg.ServerName;
             Description = msg.Description.Length > 200 ? msg.Description.Substring(0, 200) : msg.Description;
-
-            if (!string.IsNullOrEmpty(msg.CountryCode) && CountryCodes.Contains(msg.CountryCode.ToUpper()))
-                Country = msg.CountryCode.ToUpper();
-
             Website = msg.Website.Length > 60 ? msg.Website.Substring(0, 60) : msg.Website;
             WebsiteText = msg.WebsiteText.Length > 15 ? msg.WebsiteText.Substring(0, 15) : msg.WebsiteText;
             RainbowEffect = msg.RainbowEffect;
@@ -70,8 +66,23 @@ namespace LmpMasterServer.Structure
             WarpMode = msg.WarpMode;
             TerrainQuality = msg.TerrainQuality;
 
-            if (string.IsNullOrEmpty(Country) && !CountryCodeRefreshQueue.Contains((Id, ExternalEndpoint)))
-                CountryCodeRefreshQueue.Enqueue((Id, ExternalEndpoint));
+            if (!string.IsNullOrEmpty(msg.CountryCode) && CountryCodes.Contains(msg.CountryCode.ToUpper()))
+            {
+                // Always override with the message value if it's valid
+                Country = msg.CountryCode.ToUpper();
+            }
+            else if (string.IsNullOrEmpty(Country))
+            {
+                // Only if not yet set, try to fetch from cache or queue for refresh.
+                if (AddressCountries.TryGet(externalEndpoint.Address, out var countryCode))
+                {
+                    Country = countryCode;
+                }
+                else if (!CountryCodeRefreshQueue.Contains((Id, ExternalEndpoint)))
+                {
+                    CountryCodeRefreshQueue.Enqueue((Id, ExternalEndpoint));
+                }
+            }
 
             if (!Website.Contains("://"))
             {
@@ -119,12 +130,12 @@ namespace LmpMasterServer.Structure
                 else
                 {
                     LunaLog.Normal($"COUNTRY CODE LOOKUP for {externalEndpoint}");
-                    Country = await IpApi.GetCountryAsync(externalEndpoint);
+                    Country = await GeoIp2.GetCountryAsync(externalEndpoint);
                     if (string.IsNullOrEmpty(Country))
-                        Country = await IpLocate.GetCountryAsync(externalEndpoint);
+                        Country = await IpApi.GetCountryAsync(externalEndpoint);
 
                     if (string.IsNullOrEmpty(Country))
-                        Country = await IpLocate.GetCountryAsyncGeoIp2(externalEndpoint);
+                        Country = await IpLocate.GetCountryAsync(externalEndpoint);
 
                     if (string.IsNullOrEmpty(Country))
                         LunaLog.Debug($"SetCountryFromEndpoint failed for {externalEndpoint}: No lookup successful");


### PR DESCRIPTION
This does some clean up and additional enhancements based on [Stronger retry for Ip location and added GeoIp2](https://github.com/LunaMultiplayer/LunaMultiplayer/commit/dbab939deea354bdd79b3b511fe9a2efffb81d56) for the master servers, by

- moving the new GeoIP2 provider out into a new `IGeolocalization` implementation
- renaming the environment variables to something LMP specific: `LMP_GEOIP2_LICENSE_KEY` and `LMP_GEOIP2_ACCOUNT_ID`
- making it handle missing env vars more gracefully
- making the `MaxMind.GeoIP2.WebServiceClient` persistent, creating it initially in a static constructor
- prioritizing the GeoIP2 lookup (if the user configured an API key etc, we also want to use it)
- adding a "cache lookup" from the `AddressCountries` dict as a fast path in `Server.Update()` so that for servers that re-appeared or share a public IP, we immediately set the country instead of scheduling it at the end of the queue where it might have to sit for a few hours