### PR TITLE
Fix: docking local diffs need the same repair as remote docking diffs

### DIFF
--- a/LmpClient/Harmony/ModuleDockingNode_Undock.cs
+++ b/LmpClient/Harmony/ModuleDockingNode_Undock.cs
@@ -1,0 +1,30 @@
+using HarmonyLib;
+using LmpClient.VesselUtilities;
+
+// ReSharper disable All
+
+namespace LmpClient.Harmony
+{
+    /// <summary>
+    /// Guard local docking-node undock actions when FSM is in a bad state.
+    /// </summary>
+    [HarmonyPatch(typeof(ModuleDockingNode))]
+    [HarmonyPatch("Undock")]
+    public class ModuleDockingNode_Undock
+    {
+        [HarmonyPrefix]
+        private static bool PrefixUndock(ModuleDockingNode __instance)
+        {
+            if (!DockingPortUtil.EnsureRecoverableForUndock(__instance,
+                    "ModuleDockingNode.Undock", out var failureReason))
+            {
+                LunaLog.LogWarning($"[LMP]: Blocking ModuleDockingNode.Undock. {failureReason}. " +
+                    $"Part: {__instance.part?.partName}, Vessel: {__instance.vessel?.id}, " +
+                    $"PartFlightId: {__instance.part?.flightID}");
+                return false;
+            }
+
+            return true;
+        }
+    }
+}

--- a/LmpClient/Harmony/ModuleDockingNode_UndockSameVessel.cs
+++ b/LmpClient/Harmony/ModuleDockingNode_UndockSameVessel.cs
@@ -1,0 +1,30 @@
+using HarmonyLib;
+using LmpClient.VesselUtilities;
+
+// ReSharper disable All
+
+namespace LmpClient.Harmony
+{
+    /// <summary>
+    /// Guard same-vessel undock actions when FSM is in a bad state.
+    /// </summary>
+    [HarmonyPatch(typeof(ModuleDockingNode))]
+    [HarmonyPatch("UndockSameVessel")]
+    public class ModuleDockingNode_UndockSameVessel
+    {
+        [HarmonyPrefix]
+        private static bool PrefixUndockSameVessel(ModuleDockingNode __instance)
+        {
+            if (!DockingPortUtil.EnsureRecoverableForUndock(__instance,
+                    "ModuleDockingNode.UndockSameVessel", out var failureReason))
+            {
+                LunaLog.LogWarning($"[LMP]: Blocking ModuleDockingNode.UndockSameVessel. {failureReason}. " +
+                    $"Part: {__instance.part?.partName}, Vessel: {__instance.vessel?.id}, " +
+                    $"PartFlightId: {__instance.part?.flightID}");
+                return false;
+            }
+
+            return true;
+        }
+    }
+}

--- a/LmpClient/Harmony/Part_Undock.cs
+++ b/LmpClient/Harmony/Part_Undock.cs
@@ -1,5 +1,7 @@
 ﻿using HarmonyLib;
+using System.Linq;
 using LmpClient.Events;
+using LmpClient.VesselUtilities;
 
 // ReSharper disable All
 
@@ -13,15 +15,29 @@ namespace LmpClient.Harmony
     public class Part_Undock
     {
         [HarmonyPrefix]
-        private static void PrefixUndock(Part __instance, DockedVesselInfo newVesselInfo, ref Vessel __state)
+        private static bool PrefixUndock(Part __instance, DockedVesselInfo newVesselInfo, ref Vessel __state)
         {
+            var dockingNode = __instance.FindModulesImplementing<ModuleDockingNode>().FirstOrDefault();
+            if (dockingNode != null && !DockingPortUtil.EnsureRecoverableForUndock(dockingNode,
+                    "Part.Undock", out var failureReason))
+            {
+                LunaLog.LogWarning($"[LMP]: Blocking undock from Part.Undock. {failureReason}. " +
+                    $"Part: {__instance.partName}, Vessel: {__instance.vessel?.id}, PartFlightId: {__instance.flightID}");
+                __state = null;
+                return false;
+            }
+
             __state = __instance.vessel;
             PartEvent.onPartUndocking.Fire(__instance, newVesselInfo);
+            return true;
         }
 
         [HarmonyPostfix]
         private static void PostfixUndock(Part __instance, DockedVesselInfo newVesselInfo, ref Vessel __state)
         {
+            if (__state == null)
+                return;
+
             PartEvent.onPartUndocked.Fire(__instance, newVesselInfo, __state);
         }
     }

--- a/LmpClient/LmpClient.csproj
+++ b/LmpClient/LmpClient.csproj
@@ -168,6 +168,8 @@
     <Compile Include="Harmony\EVAConstructionModeEditor_AttachPart.cs" />
     <Compile Include="Harmony\EVAConstructionModeEditor_DropAttachablePart.cs" />
     <Compile Include="Harmony\ModuleDockingNode_DockToVessel.cs" />
+    <Compile Include="Harmony\ModuleDockingNode_Undock.cs" />
+    <Compile Include="Harmony\ModuleDockingNode_UndockSameVessel.cs" />
     <Compile Include="Harmony\ContractPreLoader_Filter.cs" />
     <Compile Include="Harmony\ContractSystem_LoadContract.cs" />
     <Compile Include="Harmony\ContractSystem_OnAwake.cs" />

--- a/LmpClient/Systems/VesselUndockSys/VesselUndock.cs
+++ b/LmpClient/Systems/VesselUndockSys/VesselUndock.cs
@@ -40,27 +40,10 @@ namespace LmpClient.Systems.VesselUndockSys
                     var dockingNode = protoPart.partRef.FindModulesImplementing<ModuleDockingNode>().FirstOrDefault();
                     if (dockingNode != null)
                     {
-                        if (DockingPortUtil.IsInDockedState(dockingNode))
+                        if (!DockingPortUtil.EnsureRecoverableForUndock(dockingNode,
+                                "VesselUndock.ProcessUndock", out var failureReason))
                         {
-                            // Port is in a valid docked state — proceed normally
-                        }
-                        else if (DockingPortUtil.IsInRecoverableTransientState(dockingNode))
-                        {
-                            // Port is stuck in a transient state (e.g., Disengage). Attempt FSM recovery
-                            // before undocking, using the same technique as DockRotate: fsm.StartFSM(state)
-                            var targetState = DockingPortUtil.InferDockedStateForUndock(dockingNode);
-                            if (!DockingPortUtil.TryRecoverToDockedState(dockingNode, targetState))
-                            {
-                                LunaLog.LogWarning($"[LMP]: Cannot recover docking port for undock. " +
-                                    $"Part: {protoPart.partRef.partName}, Vessel: {VesselId}, PartFlightId: {PartFlightId}");
-                                return;
-                            }
-                        }
-                        else
-                        {
-                            // Port is in Ready, Disabled, or unknown state — not docked, skip
-                            LunaLog.LogWarning($"[LMP]: Skipping undock — docking port FSM is in state " +
-                                $"'{dockingNode.fsm?.currentStateName}', not a docked or recoverable state. " +
+                            LunaLog.LogWarning($"[LMP]: Skipping remote undock. {failureReason}. " +
                                 $"Part: {protoPart.partRef.partName}, Vessel: {VesselId}, PartFlightId: {PartFlightId}");
                             return;
                         }

--- a/LmpClient/VesselUtilities/DockingPortUtil.cs
+++ b/LmpClient/VesselUtilities/DockingPortUtil.cs
@@ -262,6 +262,61 @@ namespace LmpClient.VesselUtilities
         }
 
         /// <summary>
+        /// Ensure the docking node is in a state where an undock call is valid.
+        /// If the node is stuck in a recoverable transient state, this method
+        /// attempts to recover it to a docked state before undock proceeds.
+        /// </summary>
+        public static bool EnsureRecoverableForUndock(ModuleDockingNode node, string context, out string failureReason)
+        {
+            failureReason = null;
+
+            if (node?.fsm == null)
+            {
+                failureReason = "docking node or FSM is null";
+                return false;
+            }
+
+            if (IsInDockedState(node))
+                return true;
+
+            if (IsInRecoverableTransientState(node))
+            {
+                var targetState = InferDockedStateForUndock(node);
+                if (TryRecoverToDockedState(node, targetState))
+                    return true;
+
+                failureReason =
+                    $"failed transient recovery in {context}: '{node.fsm.currentStateName}' -> '{targetState}'";
+                return false;
+            }
+
+            // Fallback: when FSM reports an unexpected state, try to rehydrate the docking pair
+            // from part-tree / dockedPartUId data before hard-blocking undock.
+            var partner = FindPartnerFromPartTree(node);
+            if (partner == null && node.dockedPartUId != 0)
+                partner = FindPartnerByUId(node.dockedPartUId, node.vessel) ?? FindPartnerByUId(node.dockedPartUId);
+
+            if (partner?.fsm != null)
+            {
+                string nodeState, partnerState;
+                InferDockerDockeeRoles(node, partner, out nodeState, out partnerState);
+                RecoverDockedPair(node, partner, nodeState, partnerState,
+                    $"fallback pre-undock recovery from fsm='{node.fsm.currentStateName}'", node.vessel);
+
+                if (IsInDockedState(node))
+                    return true;
+            }
+
+            var inferredState = InferDockedStateForUndock(node);
+            if (TryRecoverToDockedState(node, inferredState))
+                return true;
+
+            failureReason =
+                $"unsupported undock state in {context}: '{node.fsm.currentStateName}'";
+            return false;
+        }
+
+        /// <summary>
         /// Attempt to recover a docking port for the remote-undock path (VesselUndock.cs).
         /// Sets up otherNode before forcing FSM to avoid NullRef.
         /// </summary>


### PR DESCRIPTION
This PR keeps the docking behavior fixes in one place from my earlier FSM work too.

I added undock guarding to the local undock paths, not just the remote undock flow. If a docking node is in a bad FSM state, we now try to recover it before allowing undock to continue.

I also added a fallback recovery path for cases where the normal docked or transient checks do not match cleanly. The code now tries to rebuild partner context from part tree and dockedPartUId before giving up. This is meant to cover weird real world cases like a docking port mounted in unusual orientation where the undock button is present but undock fails to fire.

Also restored VesselLoader safety behavior so this PR stays focused on docking.