### PR TITLE
Feature: add AllowVesselTermination setting and tracking-station guards

### DIFF
--- a/LmpClient/Harmony/SpaceTracking_DeleteVessel.cs
+++ b/LmpClient/Harmony/SpaceTracking_DeleteVessel.cs
@@ -1,0 +1,62 @@
+using HarmonyLib;
+using KSP.UI.Screens;
+using LmpClient.Base;
+using LmpClient.Localization;
+using LmpClient.Systems.SettingsSys;
+using LmpCommon.Enums;
+
+// ReSharper disable All
+
+namespace LmpClient.Harmony
+{
+    /// <summary>
+    /// Blocks the Tracking Station "Terminate" button when AllowVesselTermination is false on the server.
+    /// Physical destruction (crashes, explosions) is unaffected — only the UI button path is intercepted.
+    /// </summary>
+    [HarmonyPatch(typeof(SpaceTracking))]
+    [HarmonyPatch("BtnOnClick_DeleteSelectedVessel")]
+    public class SpaceTracking_DeleteSelectedVessel
+    {
+        [HarmonyPrefix]
+        private static bool PrefixDeleteSelectedVessel()
+        {
+            if (MainSystem.NetworkState < ClientState.Connected) return true;
+
+            if (!SettingsSystem.ServerSettings.AllowVesselTermination)
+            {
+                LunaScreenMsg.PostScreenMessage(LocalizationContainer.ScreenText.TerminationDisabledByServer, 5f, ScreenMessageStyle.UPPER_CENTER);
+                return false;
+            }
+
+            return true;
+        }
+    }
+
+    /// <summary>
+    /// Blocks the Tracking Station "Recover" button when AllowVesselTermination is false on the server,
+    /// unless the vessel is recoverable (landed or splashed on the home body). Recoverable vessels are
+    /// allowed through so players can still recover missions that have safely returned home.
+    /// </summary>
+    [HarmonyPatch(typeof(SpaceTracking))]
+    [HarmonyPatch("BtnOnclick_RecoverSelectedVessel")]
+    public class SpaceTracking_RecoverSelectedVessel
+    {
+        [HarmonyPrefix]
+        private static bool PrefixRecoverSelectedVessel(SpaceTracking __instance)
+        {
+            if (MainSystem.NetworkState < ClientState.Connected) return true;
+
+            if (!SettingsSystem.ServerSettings.AllowVesselTermination)
+            {
+                // Allow recovery of vessels that are landed/splashed on the home body
+                if (__instance.SelectedVessel != null && __instance.SelectedVessel.IsRecoverable)
+                    return true;
+
+                LunaScreenMsg.PostScreenMessage(LocalizationContainer.ScreenText.TerminationDisabledByServer, 5f, ScreenMessageStyle.UPPER_CENTER);
+                return false;
+            }
+
+            return true;
+        }
+    }
+}

--- a/LmpClient/LmpClient.csproj
+++ b/LmpClient/LmpClient.csproj
@@ -227,6 +227,7 @@
     <Compile Include="Harmony\QuickSaveLoad_QuickLoad.cs" />
     <Compile Include="Harmony\ProtoCrewMember_Die.cs" />
     <Compile Include="Harmony\ShipConstruction_FindVesselsLandedAt.cs" />
+    <Compile Include="Harmony\SpaceTracking_DeleteVessel.cs" />
     <Compile Include="Harmony\SpaceTracking_FlyVessel.cs" />
     <Compile Include="Harmony\SpaceTracking_SetVessel.cs" />
     <Compile Include="Harmony\Strategy_CanBeActivated.cs" />

--- a/LmpClient/Localization/Structures/ScreenText.cs
+++ b/LmpClient/Localization/Structures/ScreenText.cs
@@ -11,6 +11,7 @@
         public string CheckParts { get; set; } = "If you use mod or DLC parts that other players don't have you won't be seen by them!";
         public string CannotRecover { get; set; } = "Cannot recover vessel, the vessel is not yours.";
         public string CannotTerminate { get; set; } = "Cannot terminate vessel, the vessel is not yours.";
+        public string TerminationDisabledByServer { get; set; } = "Vessel termination is disabled on this server. Vessels cannot be deleted from the Tracking Station.";
         public string SpectatingRemoved { get; set; } = "The vessel you were spectating was removed";
         public string WarpDisabled { get; set; } = "Cannot warp, warping is disabled on this server";
         public string WaitingSubspace { get; set; } = "Cannot warp, waiting subspace id from the server";

--- a/LmpClient/Systems/SettingsSys/SettingsMessageHandler.cs
+++ b/LmpClient/Systems/SettingsSys/SettingsMessageHandler.cs
@@ -35,6 +35,7 @@ namespace LmpClient.Systems.SettingsSys
             SettingsSystem.ServerSettings.MaxScreenshotHeight = msgData.MaxScreenshotHeight;
             SettingsSystem.ServerSettings.MinCraftLibraryRequestIntervalMs = msgData.MinScreenshotIntervalMs;
             SettingsSystem.ServerSettings.PrintMotdInChat = msgData.PrintMotdInChat;
+            SettingsSystem.ServerSettings.AllowVesselTermination = msgData.AllowVesselTermination;
 
             SettingsSystem.ServerSettings.ServerParameters =
                 GameParameters.GetDefaultParameters(

--- a/LmpClient/Systems/SettingsSys/SettingsServerStructure.cs
+++ b/LmpClient/Systems/SettingsSys/SettingsServerStructure.cs
@@ -27,5 +27,6 @@ namespace LmpClient.Systems.SettingsSys
         public int MaxScreenshotHeight { get; set; }
         public int MinCraftLibraryRequestIntervalMs { get; set; }
         public bool PrintMotdInChat { get; set; }
+        public bool AllowVesselTermination { get; set; } = true;
     }
 }

--- a/LmpCommon/Message/Data/Settings/SetingsReplyMsgData.cs
+++ b/LmpCommon/Message/Data/Settings/SetingsReplyMsgData.cs
@@ -69,6 +69,7 @@ namespace LmpCommon.Message.Data.Settings
         public int MaxScreenshotHeight;
         public int MinCraftLibraryRequestIntervalMs;
         public bool PrintMotdInChat;
+        public bool AllowVesselTermination;
 
         public override string ClassName { get; } = nameof(SettingsReplyMsgData);
 
@@ -134,6 +135,7 @@ namespace LmpCommon.Message.Data.Settings
             lidgrenMsg.Write(MaxScreenshotHeight);
             lidgrenMsg.Write(MinCraftLibraryRequestIntervalMs);
             lidgrenMsg.Write(PrintMotdInChat);
+            lidgrenMsg.Write(AllowVesselTermination);
         }
 
         internal override void InternalDeserialize(NetIncomingMessage lidgrenMsg)
@@ -198,12 +200,13 @@ namespace LmpCommon.Message.Data.Settings
             MaxScreenshotHeight = lidgrenMsg.ReadInt32();
             MinCraftLibraryRequestIntervalMs = lidgrenMsg.ReadInt32();
             PrintMotdInChat = lidgrenMsg.ReadBoolean();
+            AllowVesselTermination = lidgrenMsg.ReadBoolean();
         }
 
         internal override int InternalGetMessageSize()
         {
             return base.InternalGetMessageSize() + sizeof(WarpMode) + sizeof(GameMode) + sizeof(TerrainQuality) + sizeof(GameDifficulty) +
-                sizeof(bool) * 24 + sizeof(int) * 9 + sizeof(float) * 19 + ConsoleIdentifier.GetByteCount();
+                sizeof(bool) * 25 + sizeof(int) * 9 + sizeof(float) * 19 + ConsoleIdentifier.GetByteCount();
         }
     }
 }

--- a/Server/Message/SettingsMsgReader.cs
+++ b/Server/Message/SettingsMsgReader.cs
@@ -37,6 +37,7 @@ namespace Server.Message
             msgData.MaxScreenshotHeight = ScreenshotSettings.SettingsStore.MaxScreenshotHeight;
             msgData.MinCraftLibraryRequestIntervalMs = CraftSettings.SettingsStore.MinCraftLibraryRequestIntervalMs;
             msgData.PrintMotdInChat = GeneralSettings.SettingsStore.PrintMotdInChat;
+            msgData.AllowVesselTermination = GeneralSettings.SettingsStore.AllowVesselTermination;
 
             if (GeneralSettings.SettingsStore.GameDifficulty == GameDifficulty.Custom && GameplaySettings.SettingsStore != null)
             {

--- a/Server/Settings/Definition/GeneralSettingsDefinition.cs
+++ b/Server/Settings/Definition/GeneralSettingsDefinition.cs
@@ -34,6 +34,9 @@ namespace Server.Settings.Definition
         [XmlComment(Value = "Writes the server's MOTD (message of the day) in the chat of the user who joins")]
         public bool PrintMotdInChat { get; set; } = false;
 
+        [XmlComment(Value = "Allow players to terminate/delete vessels from the Tracking Station. Set to false to prevent accidental or deliberate deletion of persistent vessels.")]
+        public bool AllowVesselTermination { get; set; } = true;
+
         [XmlComment(Value = "Maximum amount of players that can join the server.")]
         public int MaxPlayers { get; set; } = 20;
 


### PR DESCRIPTION
This adds a server-side toggle to control whether players can terminate or recover vessels from the Tracking Station. The client now receives that setting in the normal settings payload, and the Tracking Station delete/recover button paths are guarded when the setting is off. Recovery is still allowed for recoverable vessels, so normal landed or splashed return-to-home-body recovery can continue as expected.

I split this out so the behavior change is focused and easy to review: one feature flag, one settings wire-up, and one user-facing guard path.

Intended to be merged and checked more by public exposure.