### PR TITLE
Fix: Ignore ScenarioNewGameIntro during scenario receive sync

### DIFF
--- a/LmpClient/Harmony/ScenarioNewGameIntro_OnLoad.cs
+++ b/LmpClient/Harmony/ScenarioNewGameIntro_OnLoad.cs
@@ -1,0 +1,27 @@
+using HarmonyLib;
+
+// ReSharper disable All
+
+namespace LmpClient.Harmony
+{
+    /// <summary>
+    /// LMP rebuilds game state on connect and does not receive ScenarioNewGameIntro
+    /// from server sync. This can leave intro flags false and retrigger first-run
+    /// tutorial popups on multiplayer load.
+    ///
+    /// Force all tutorial completion flags to true and skip stock OnLoad.
+    /// </summary>
+    [HarmonyPatch(typeof(ScenarioNewGameIntro))]
+    [HarmonyPatch("OnLoad")]
+    public class ScenarioNewGameIntro_OnLoad
+    {
+        [HarmonyPrefix]
+        private static bool PrefixOnLoad(ScenarioNewGameIntro __instance)
+        {
+            __instance.kscComplete = true;
+            __instance.editorComplete = true;
+            __instance.tsComplete = true;
+            return false;
+        }
+    }
+}

--- a/LmpClient/LmpClient.csproj
+++ b/LmpClient/LmpClient.csproj
@@ -196,6 +196,7 @@
     <Compile Include="Harmony\ScenarioDiscoverableObjects_SpawnAsteroid.cs" />
     <Compile Include="Harmony\ScenarioDiscoverableObjects_SpawnComet.cs" />
     <Compile Include="Harmony\ScenarioDiscoverableObjects_UpdateSpaceObjects.cs" />
+    <Compile Include="Harmony\ScenarioNewGameIntro_OnLoad.cs" />
     <Compile Include="Harmony\ShipConstruction_AssembleForLaunch.cs" />
     <Compile Include="Harmony\SpaceTracking_StopTrackingObject.cs" />
     <Compile Include="Harmony\SpaceTracking_StartTrackingObject.cs" />

--- a/LmpCommon/IgnoredScenarios.cs
+++ b/LmpCommon/IgnoredScenarios.cs
@@ -6,6 +6,7 @@ namespace LmpCommon
     {
         public static List<string> IgnoreReceive { get; } = new List<string>
         {
+            "ScenarioNewGameIntro", //Don't receive this - it resets the "new game" flag and triggers first-run popups (e.g. ClickThroughBlocker)
             "ScenarioDiscoverableObjects", //Asteroids have their own system
             "ScenarioCustomWaypoints", //Don't sync this
         };


### PR DESCRIPTION
This is a very small sync-policy tweak that adds ScenarioNewGameIntro to the receive ignore list. The intent is to avoid replaying first-run intro scenario state through multiplayer sync.

I kept this separate on purpose since it is a policy decision and easier to discuss on its own than bundled into larger gameplay or settings changes. Pending review.
