### PR TITLE
Add Valkey as optional persistent IP geolocation cache for masterservers

### DIFF
--- a/LmpMasterServer/Geolocalization/GeoIp2.cs
+++ b/LmpMasterServer/Geolocalization/GeoIp2.cs
@@ -1,0 +1,43 @@
+﻿using MaxMind.GeoIP2;
+using LmpMasterServer.Log;
+using System;
+using System.Net;
+using System.Threading.Tasks;
+
+namespace LmpMasterServer.Geolocalization
+{
+    internal class GeoIp2 : IGeolocalization
+    {
+
+        private static WebServiceClient client;
+
+        static GeoIp2()
+        {
+            var licenseKey = Environment.GetEnvironmentVariable("LMP_GEOIP2_LICENSE_KEY");
+            if (string.IsNullOrEmpty(licenseKey))
+                return;
+
+            if (!int.TryParse(Environment.GetEnvironmentVariable("LMP_GEOIP2_ACCOUNT_ID"), out var accountId))
+                return;
+
+            var clientOptions = (Microsoft.Extensions.Options.IOptions<WebServiceClientOptions>)new WebServiceClientOptions() { AccountId = accountId, LicenseKey = licenseKey };
+            client = new WebServiceClient(GeolocationHttpClient.GetClient(), clientOptions);
+            LunaLog.Debug($"GeoIP2 client setup successful, using account ID {accountId}");
+        }
+
+        public static async Task<string> GetCountryAsync(IPEndPoint externalEndpoint)
+        {
+            if (client == null)
+                return null;
+            try
+            {
+                var country = await client.CountryAsync(externalEndpoint.Address);
+                return country.Country.IsoCode;
+            }
+            catch (Exception)
+            {
+                return null;
+            }
+        }
+    }
+}

--- a/LmpMasterServer/Geolocalization/IpLocate.cs
+++ b/LmpMasterServer/Geolocalization/IpLocate.cs
@@ -1,5 +1,4 @@
-﻿using MaxMind.GeoIP2;
-using System;
+﻿using System;
 using System.Net;
 using System.Text.Json.Nodes;
 using System.Threading.Tasks;
@@ -16,25 +15,6 @@ namespace LmpMasterServer.Geolocalization
                 var output = JsonNode.Parse(
                     await client.GetStringAsync($"https://www.iplocate.io/api/lookup/{externalEndpoint.Address}"));
                 return output?["country_code"]?.GetValue<string>();
-            }
-            catch (Exception)
-            {
-                return null;
-            }
-        }
-
-        public static async Task<string> GetCountryAsyncGeoIp2(IPEndPoint externalEndpoint)
-        {
-            try
-            {
-                var licenseKey = Environment.GetEnvironmentVariable("license_key");
-
-                if (!int.TryParse(Environment.GetEnvironmentVariable("account_id"), out var accountId) || string.IsNullOrEmpty(licenseKey))
-                    return null;
-
-                var client = new WebServiceClient(accountId, licenseKey);
-                var country = await client.CountryAsync(externalEndpoint.Address);
-                return country.Country.IsoCode;
             }
             catch (Exception)
             {

--- a/LmpMasterServer/Geolocalization/ValkeyCache.cs
+++ b/LmpMasterServer/Geolocalization/ValkeyCache.cs
@@ -1,0 +1,97 @@
+﻿
+using Valkey.Glide;
+using static Valkey.Glide.ConnectionConfiguration;
+using LmpMasterServer.Log;
+using System;
+using System.Net;
+using System.Threading.Tasks;
+using Valkey.Glide.Commands.Options;
+
+namespace LmpMasterServer.Geolocalization
+{
+    internal class ValkeyCache : IGeolocalization
+    {
+
+        private static GlideClient client;
+        private static readonly Random random = Random.Shared;
+
+        static ValkeyCache()
+        {
+            var address = Environment.GetEnvironmentVariable("LMP_VALKEY_ADDRESS");
+            var port = Environment.GetEnvironmentVariable("LMP_VALKEY_PORT");
+            if (string.IsNullOrEmpty(address) || string.IsNullOrEmpty(port))
+                return;
+
+            if (!int.TryParse(port, out var portNumber))
+            {
+                LunaLog.Error($"Invalid port number for Valkey: {port}");
+                return;
+            }
+
+            var tls = bool.TryParse(Environment.GetEnvironmentVariable("LMP_VALKEY_TLS"), out var tlsValue) && tlsValue;
+            var username = Environment.GetEnvironmentVariable("LMP_VALKEY_USERNAME");
+            var password = Environment.GetEnvironmentVariable("LMP_VALKEY_PASSWORD");
+
+            ServerCredentials credentials = null;
+            if (!string.IsNullOrEmpty(password))
+            {
+                username = username == "" ? null : username; // Set empty username to null to let the library fall back to default username
+                credentials = new ServerCredentials(username, password);
+            }
+
+            var builder = new StandaloneClientConfigurationBuilder()
+                .WithAddress(address, (ushort)portNumber)
+                .WithTls(tls)
+                .WithClientName("LMPMasterServer");
+
+            if (credentials != null)
+            {
+                builder.WithCredentials(credentials);
+            }
+
+            var config = builder.Build();
+
+            // CreateClient() is async but we are in a static constructor, so we can't await it.
+            // Run it in a background task and
+            _ = Task.Run(async () =>
+            {
+                try
+                {
+                    client = await GlideClient.CreateClient(config);
+                    LunaLog.Debug($"Valkey client setup successful");
+                }
+                catch (Exception ex)
+                {
+                    LunaLog.Error($"Error setting up Valkey client: {ex.Message}");
+                }
+            });
+
+        }
+
+        public static async Task<string> GetCountryAsync(IPEndPoint externalEndpoint)
+        {
+            if (client == null)
+                return null;
+            try
+            {
+                var country = await client.GetAsync("lmp:geolocalization:" + externalEndpoint.Address);
+                if (country == ValkeyValue.Null || country == ValkeyValue.EmptyString)
+                    return null;
+                return country.ToString();
+            }
+            catch (Exception)
+            {
+                return null;
+            }
+        }
+
+        public static async Task SetCountryAsync(IPEndPoint externalEndpoint, string country)
+        {
+            if (client == null)
+                return;
+
+            var expiryOptions = SetExpiryOptions.ExpireIn(TimeSpan.FromDays(14) + TimeSpan.FromHours(random.Next(-12, 12))); // Randomize expiry a bit to avoid thundering herd on expiry
+            await client.SetAsync("lmp:geolocalization:" + externalEndpoint.Address, country, expiryOptions);
+        }
+    }
+}

--- a/LmpMasterServer/Lidgren/MasterServer.cs
+++ b/LmpMasterServer/Lidgren/MasterServer.cs
@@ -323,17 +323,12 @@ namespace LmpMasterServer.Lidgren
                         (var id, var endpoint) = item;
                         if (ServerDictionary.TryGetValue(id, out var server))
                         {
-                            try 
+                            try
                             {
-                                if (await server.SetCountryFromEndpointAsync(endpoint))
+                                if (await server.SetCountryFromEndpointAsync(endpoint)) // Returns whether it made an external request
                                     await Task.Delay(Server.MinCountryCodeRefreshInterval);
-                                else
-                                    Server.CountryCodeRefreshQueue.Enqueue(item);
                             }
-                            catch
-                            {
-                                Server.CountryCodeRefreshQueue.Enqueue(item);
-                            }
+                            catch { } // No need to requeue as that will be triggered on the next server update if the country code is still missing
                         }
                     } else {
                         await Task.Delay(CountryCodeRefreshInterval);

--- a/LmpMasterServer/Lidgren/MasterServer.cs
+++ b/LmpMasterServer/Lidgren/MasterServer.cs
@@ -8,6 +8,7 @@ using LmpCommon.Message.Types;
 using LmpCommon.RepoRetrievers;
 using LmpCommon.Time;
 using LmpGlobal;
+using LmpMasterServer.Geolocalization;
 using LmpMasterServer.Log;
 using LmpMasterServer.Structure;
 using Microsoft.VisualStudio.Threading;
@@ -316,7 +317,8 @@ namespace LmpMasterServer.Lidgren
         {
             var t = Task.Run(async () =>
             {
-                while(RunServer)
+                var _ = new ValkeyCache(); // Trigger static constructor to initialize Valkey client in the background
+                while (RunServer)
                 {
                     if (Server.CountryCodeRefreshQueue.TryDequeue(out var item))
                     {

--- a/LmpMasterServer/LmpMasterServer.csproj
+++ b/LmpMasterServer/LmpMasterServer.csproj
@@ -36,6 +36,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>
     <PackageReference Include="Mono.Nat" Version="3.0.4" />
+    <PackageReference Include="Valkey.Glide" Version="1.1.0" />
     <ProjectReference Include="..\LmpCommon\LmpCommon.csproj" />
     <ProjectReference Include="..\LmpGlobal\LmpGlobal.csproj" />
   </ItemGroup>

--- a/LmpMasterServer/Structure/Server.cs
+++ b/LmpMasterServer/Structure/Server.cs
@@ -54,10 +54,6 @@ namespace LmpMasterServer.Structure
             ServerVersion = msg.ServerVersion;
             ServerName = msg.ServerName.Length > 30 ? msg.ServerName.Substring(0, 30) : msg.ServerName;
             Description = msg.Description.Length > 200 ? msg.Description.Substring(0, 200) : msg.Description;
-
-            if (!string.IsNullOrEmpty(msg.CountryCode) && CountryCodes.Contains(msg.CountryCode.ToUpper()))
-                Country = msg.CountryCode.ToUpper();
-
             Website = msg.Website.Length > 60 ? msg.Website.Substring(0, 60) : msg.Website;
             WebsiteText = msg.WebsiteText.Length > 15 ? msg.WebsiteText.Substring(0, 15) : msg.WebsiteText;
             RainbowEffect = msg.RainbowEffect;
@@ -70,8 +66,23 @@ namespace LmpMasterServer.Structure
             WarpMode = msg.WarpMode;
             TerrainQuality = msg.TerrainQuality;
 
-            if (string.IsNullOrEmpty(Country) && !CountryCodeRefreshQueue.Contains((Id, ExternalEndpoint)))
-                CountryCodeRefreshQueue.Enqueue((Id, ExternalEndpoint));
+            if (!string.IsNullOrEmpty(msg.CountryCode) && CountryCodes.Contains(msg.CountryCode.ToUpper()))
+            {
+                // Always override with the message value if it's valid
+                Country = msg.CountryCode.ToUpper();
+            }
+            else if (string.IsNullOrEmpty(Country))
+            {
+                // Only if not yet set, try to fetch from cache or queue for refresh.
+                if (AddressCountries.TryGet(externalEndpoint.Address, out var countryCode))
+                {
+                    Country = countryCode;
+                }
+                else if (!CountryCodeRefreshQueue.Contains((Id, ExternalEndpoint)))
+                {
+                    CountryCodeRefreshQueue.Enqueue((Id, ExternalEndpoint));
+                }
+            }
 
             if (!Website.Contains("://"))
             {
@@ -119,12 +130,12 @@ namespace LmpMasterServer.Structure
                 else
                 {
                     LunaLog.Normal($"COUNTRY CODE LOOKUP for {externalEndpoint}");
-                    Country = await IpApi.GetCountryAsync(externalEndpoint);
+                    Country = await GeoIp2.GetCountryAsync(externalEndpoint);
                     if (string.IsNullOrEmpty(Country))
-                        Country = await IpLocate.GetCountryAsync(externalEndpoint);
+                        Country = await IpApi.GetCountryAsync(externalEndpoint);
 
                     if (string.IsNullOrEmpty(Country))
-                        Country = await IpLocate.GetCountryAsyncGeoIp2(externalEndpoint);
+                        Country = await IpLocate.GetCountryAsync(externalEndpoint);
 
                     if (string.IsNullOrEmpty(Country))
                         LunaLog.Debug($"SetCountryFromEndpoint failed for {externalEndpoint}: No lookup successful");

--- a/LmpMasterServer/Structure/Server.cs
+++ b/LmpMasterServer/Structure/Server.cs
@@ -111,8 +111,8 @@ namespace LmpMasterServer.Structure
         /// and writes it to the Country field.
         /// </summary>
         /// <returns>
-        /// A bool indicating whether a request to an external service has been made (true)
-        /// or the value could be fetched from cache (false).
+        /// A bool indicating whether a request to an external geolocation service has been made (true)
+        /// or the value could be fetched from cache (local or Valkey) (false).
         /// </returns>
         public async Task<bool> SetCountryFromEndpointAsync(IPEndPoint externalEndpoint)
         {
@@ -122,28 +122,42 @@ namespace LmpMasterServer.Structure
                     // Already resolved
                     return false;
 
+                // Check in-memory cache first, maybe we already looked it up in the meantime
                 if (AddressCountries.TryGet(externalEndpoint.Address, out var countryCode))
                 {
                     Country = countryCode;
                     return false;
                 }
+
+                // Try Valkey cache second
+                Country = await ValkeyCache.GetCountryAsync(externalEndpoint);
+                if (!string.IsNullOrEmpty(Country))
+                {
+                    LunaLog.Debug($"COUNTRY CODE FOUND in Valkey cache for {externalEndpoint}");
+                    AddressCountries.TryAdd(externalEndpoint.Address, Country);
+                    return false;
+                }
+
+                // Otherwise hit external APIs
+                LunaLog.Normal($"COUNTRY CODE LOOKUP for {externalEndpoint}");
+                if (string.IsNullOrEmpty(Country))
+                    Country = await GeoIp2.GetCountryAsync(externalEndpoint);
+                if (string.IsNullOrEmpty(Country))
+                    Country = await IpApi.GetCountryAsync(externalEndpoint);
+                if (string.IsNullOrEmpty(Country))
+                    Country = await IpLocate.GetCountryAsync(externalEndpoint);
+
+                // Check if any lookup was successful
+                if (string.IsNullOrEmpty(Country))
+                    LunaLog.Debug($"SetCountryFromEndpoint failed for {externalEndpoint}: No lookup successful");
                 else
                 {
-                    LunaLog.Normal($"COUNTRY CODE LOOKUP for {externalEndpoint}");
-                    Country = await GeoIp2.GetCountryAsync(externalEndpoint);
-                    if (string.IsNullOrEmpty(Country))
-                        Country = await IpApi.GetCountryAsync(externalEndpoint);
-
-                    if (string.IsNullOrEmpty(Country))
-                        Country = await IpLocate.GetCountryAsync(externalEndpoint);
-
-                    if (string.IsNullOrEmpty(Country))
-                        LunaLog.Debug($"SetCountryFromEndpoint failed for {externalEndpoint}: No lookup successful");
-                    else
-                        AddressCountries.TryAdd(externalEndpoint.Address, Country);
-
-                    return true;
+                    // And if so store in in-memory cache and Valkey cache for future lookups
+                    AddressCountries.TryAdd(externalEndpoint.Address, Country);
+                    ValkeyCache.SetCountryAsync(externalEndpoint, Country).Forget();
                 }
+
+                return true;
             }
             catch (Exception e)
             {


### PR DESCRIPTION
This depends on #681 - the first commit is of that PR, ignore it for this one.
Kept as draft until #681 is merged.

## Motivation
I have my master server containers set to auto-update, one to the `:latest` image (stable releases), one pointing to `:master` (nightly builds essentially). The timer looks for new images every 3 hours.
Whenever there's a commit to master and thus a new image available, my master server containers are thus restarted (in the three hour interval at most), and they loose the cached geolocalization data of the server IPs again. As I am understandably heavily rate-limited by the geo ip lookup services we use (I am asking the same IP addresses over and over again), it takes forever to fill in the country codes again. Usually it doesn't even get far before the next restart.
<img width="880" height="304" alt="Screenshot of Grafana panel showing server country statistics over time" src="https://github.com/user-attachments/assets/acc7d9a1-d6a1-4a81-bd43-6f854e863ce1" />

Even if I weren't rate-limited, it is still not good netiquette to use these APIs so inefficiently.

## Changes
This adds an external layer of caching using the [Valkey key-value store](https://valkey.io/topics/quickstart/), which
- survives restarts/updates of the master servers
- can even be shared between multiple master servers running in parallel (i.e. my stable and nightly server)

It is kept as simple as possible, the logic is:
1) Check if the geolocation for a given IP address is stored in the master server's `AddressCountries` list (with a TLL of 24h), if so, use it
2) Check if the geolocation is stored in Valkey. If so, use it and store it in `AddressCountries`
3) Ask our external providers with the existing logic (one after the other until one returns data). If anything has been found, use it and store it in Valkey and `AddressCountries`.

We set a TTL of 14 days +- 12h when writing to Valkey. This way, servers that are no longer online will age out eventually so we don't have an ever-increasing list.
The +- 12h is so that we don't end up with most keys expiring at the same time exactly 14 days after initial server start, causing increased load both for the server and the APIs (and heavily running into rate limits again).

The valkey connection can be configured using the following env vars:
- `LMP_VALKEY_ADDRESS` (required) - IP address or hostname of the Valkey server
- `LMP_VALKEY_PORT` (required) - Port of the Valkey server
- `LMP_VALKEY_TLS` (optional) - Whether to enable TLS for the connection. If set, must be parseable by `bool.Parse()`, i.e. be either `True`/`true` or `False`/`false`
- `LMP_VALKEY_USERNAME` (optional) - Username for Valkey
- `LMP_VALKEY_PASSWORD` (optional) - Password for Valkey

This uses the official [Valkey GLIDE](https://glide.valkey.io/overview/) library, which is added as additional dependency for the master servers.
For this to be as useful as possible, the Valkey instance should be set up with persistence enabled (`--save 60 1` or similar, with a persistent volume if running in a container).