### PR TITLE
Allow common way of writing booleans in xml files

### DIFF
--- a/LmpCommon/Xml/LunaXmlSerializer.cs
+++ b/LmpCommon/Xml/LunaXmlSerializer.cs
@@ -56,7 +56,10 @@ namespace LmpCommon.Xml
                 return null;
             try
             {
-                using (TextReader r = new StreamReader(path))
+                var xml = File.ReadAllText(path);
+                xml = xml.Replace(">True<", ">true<").Replace(">False<", ">false<");
+
+                using (TextReader r = new StringReader(xml))
                 {
                     var deserializer = new XmlSerializer(classType);
                     var structure = deserializer.Deserialize(r);


### PR DESCRIPTION
<!-- Thank you for contributing to LMP!

If you are adding a dedicated server, please read https://github.com/LunaMultiplayer/LunaMultiplayer/wiki/Dedicated-server first,
especially:
* Your server doesn't need to be listed as "dedicated server" to show up in the server browser.
* Dedicated servers should have either a static IP address or working DynDNS
* Port forwarding should be set up statically, or at least UPnP needs to work reliably
* Dedicated servers should not be password protected
* Dedicated servers need to be available 24/7

Please confirm that you have read and verified all of the above.
-->
### Fixes included in this PR:
Solves #692 atleast for "True" and "False" cases but not for "FaLsE" or "TrUe" cases.

### Changes proposed in this PR:
Load the xml as text and replace ">True<" with ">true<" and same for false to allow this common way of writing booleans. This avoids confusion that users experience due to not knowing booleans should be lowercase. 

A regx could be used for even more control, for example allowing "FaLsE" but I did not see the need.