### PR TITLE
Make 404 errors occur (when warranted) on master servers

### DIFF
--- a/LmpMasterServer/Http/Handlers/NotFoundHandler.cs
+++ b/LmpMasterServer/Http/Handlers/NotFoundHandler.cs
@@ -1,0 +1,14 @@
+using System;
+using System.Threading.Tasks;
+using uhttpsharp;
+
+namespace LmpMasterServer.Http.Handlers
+{
+    public class NotFoundHandler : IHttpRequestHandler
+    {
+        public async Task Handle(IHttpContext context, Func<Task> next)
+        {
+            context.Response = new HttpResponse(HttpResponseCode.NotFound, "404 Not Found", false);
+        }
+    }
+}

--- a/LmpMasterServer/Http/Handlers/ServerListHandler.cs
+++ b/LmpMasterServer/Http/Handlers/ServerListHandler.cs
@@ -34,16 +34,10 @@ namespace LmpMasterServer.Http.Handlers
                 {
                     writer.Write("<!DOCTYPE html>");
                     writer.RenderBeginTag(HtmlTextWriterTag.Html);
-                    RenderHead(writer);
+                    RenderMetadata(writer);
                     writer.RenderBeginTag(HtmlTextWriterTag.Body);
 
-                    writer.RenderBeginTag(HtmlTextWriterTag.H1); writer.Write($"Luna Multiplayer servers - Version: {LmpVersioning.CurrentVersion}"); writer.RenderEndTag();
-
-                    writer.RenderBeginTag(HtmlTextWriterTag.H3);
-                    writer.Write($"Servers: {servers.Length}");
-                    writer.WriteBreak();
-                    writer.Write($"Players: {servers.Sum(s => s.PlayerCount)}");
-                    writer.RenderEndTag();
+                    RenderHeader(writer, servers);
 
                     RenderServersTable(writer, servers);
                     RenderFooter(writer);
@@ -55,7 +49,7 @@ namespace LmpMasterServer.Http.Handlers
             });
         }
 
-        private static void RenderHead(HtmlTextWriter writer)
+        private static void RenderMetadata(HtmlTextWriter writer)
         {
             // HtmlTextWriter makes <script> tags self-closing, which violates the HTML standard and is rejected by browsers.
             // So let's just do the <head> manually.
@@ -70,6 +64,19 @@ namespace LmpMasterServer.Http.Handlers
 	<script src=""js/lmp.js""></script>
 </head>
 ");
+        }
+
+        private static void RenderHeader(HtmlTextWriter writer, ServerInfo[] servers)
+        {
+
+            writer.RenderBeginTag(HtmlTextWriterTag.H1); writer.Write($"Luna Multiplayer servers - Version {LmpVersioning.CurrentVersion}"); writer.RenderEndTag();
+
+            writer.RenderBeginTag(HtmlTextWriterTag.H3);
+            writer.Write($"Servers: {servers.Length}");
+            writer.WriteBreak();
+            writer.Write($"Players: {servers.Sum(s => s.PlayerCount)}");
+            writer.RenderEndTag();
+            
         }
 
         private static void RenderFooter(HtmlTextWriter writer)

--- a/LmpMasterServer/Http/LunaHttpServer.cs
+++ b/LmpMasterServer/Http/LunaHttpServer.cs
@@ -26,14 +26,30 @@ namespace LmpMasterServer.Http
 
             FileHandler.HttpRootDirectory = WebHandler.BasePath;
 
+            // Exception handler, shows the user an error if an exception occurs
             Server.Use(new ExceptionHandler());
+
+            // Head handler, handles HTTP HEAD requests (like GET but without the content body)
             Server.Use(new HeadHandler());
+
+            // Compression handler
             Server.Use(new CompressionHandler(DeflateCompressor.Default, GZipCompressor.Default));
+
+            // Path guard, blocks path traversal attacks
             Server.Use(new PathGuard(WebHandler.BasePath));
+
+            // File handler, sends files if they're present on the server
             Server.Use(new FileHandler());
+
+            // HTTP router, selects between certain other handlers depending on the path
+            var listHandler = new ServerListHandler();
             Server.Use(new HttpRouter()
-                .With(string.Empty, new ServerListHandler())
-                .With("json", new RestHandler<ServerJson>(new ServerInfoRestHandler(), JsonResponseProvider.Default)));
+                .With(string.Empty, listHandler) // List handler, sends the server list
+                .With("serverlist", listHandler) // A reference to the same list handler as above
+                .With("json", new RestHandler<ServerJson>(new ServerInfoRestHandler(), JsonResponseProvider.Default))); // Sends a JSON version of the server list
+
+            // NotFound handler, returns a 404 page if nothing else.
+            Server.Use(new NotFoundHandler());
 
             Server.Start();
         }


### PR DESCRIPTION
### Fixes included in this PR:
- Places where 404 errors should occur are now correctly handled
### Changes proposed in this PR:
- Minor code cleanup for some related systems
- The master server now broadcasts the server list when the directory `serverlist` is provided and not just when no directory is provided