### PR TITLE
Fix the version checker

### DIFF
--- a/Server/Utilities/VersionChecker.cs
+++ b/Server/Utilities/VersionChecker.cs
@@ -26,21 +26,23 @@ namespace Server.Utilities
         {
             while (ServerContext.ServerRunning)
             {
+                var multiplier = 1;
                 if (LatestVersion > LmpVersioning.CurrentVersion)
                 {
-                    LunaLog.Warning($"There is a new version of LMP! Please download it! Current: {LmpVersioning.CurrentVersion} Latest: {LatestVersion}");
+                    LunaLog.Info($"There is an update available for LMP, please download it when you're able to: {LmpVersioning.CurrentVersion} -> {LatestVersion}");
                     if (LmpVersioning.IsCompatible(LatestVersion))
                     {
-                        LunaLog.Debug("Your version is compatible with the latest version so you will still be listed in the master servers.");
+                        LunaLog.Info($"This update is not required to stay compattibile with updated master servers and clients.");
+                        multiplier = 60;
                     }
                     else
                     {
-                        LunaLog.Warning("Your version is NOT compatible with the latest version. You won't be listed in the master servers!");
+                        LunaLog.Warning("This update is mandatory to be shown on the server list once it's updated. You should go update");
                     }
                 }
 
-                //Sleep for 30 seconds...
-                await Task.Delay(30 * 1000);
+                // Repeat again in an hour if it's non-essential, or in a minute if it is essential.
+                await Task.Delay(60 * 1000 * multiplier);
             }
         }
     }

--- a/Server/Utilities/VersionChecker.cs
+++ b/Server/Utilities/VersionChecker.cs
@@ -37,7 +37,8 @@ namespace Server.Utilities
                     }
                     else
                     {
-                        LunaLog.Warning("This update is mandatory to be shown on the server list once it's updated. You should update the server ASAP.");
+                        LunaLog.Warning("This update is required in order to be shown on the server list and to connect with clients running the new version.\n"
+                        + "You should update the server ASAP.");
                     }
                 }
 

--- a/Server/Utilities/VersionChecker.cs
+++ b/Server/Utilities/VersionChecker.cs
@@ -26,17 +26,24 @@ namespace Server.Utilities
         {
             while (ServerContext.ServerRunning)
             {
+                // LatestVersion is invalid, skip the warning message and wait a few minutes first
+                if (LatestVersion == null)
+                {
+                    await Task.Delay(TimeSpan.FromMinutes(5));
+                    continue;
+                }
+
                 // Repeat again in an hour if it's non-essential, or in a minute if it is essential.
-                var delayMs = LmpVersioning.IsCompatible(LatestVersion)
-                ? TimeSpan.FromHours(1)
-                : TimeSpan.FromMinutes(1);
+                var delay = LmpVersioning.IsCompatible(LatestVersion)
+                    ? TimeSpan.FromHours(1)
+                    : TimeSpan.FromMinutes(1);
 
                 if (LatestVersion > LmpVersioning.CurrentVersion)
                 {
                     LunaLog.Info($"There is an update available for LMP, please download it when you're able to: {LmpVersioning.CurrentVersion} -> {LatestVersion}");
                     if (LmpVersioning.IsCompatible(LatestVersion))
                     {
-                        LunaLog.Info($"This update is not required to stay compatible with updated master servers and clients.");
+                        LunaLog.Info("This update is not required to stay compatible with updated master servers and clients.");
                     }
                     else
                     {
@@ -45,7 +52,7 @@ namespace Server.Utilities
                     }
                 }
 
-                await Task.Delay(delayMs);
+                await Task.Delay(delay);
             }
         }
     }

--- a/Server/Utilities/VersionChecker.cs
+++ b/Server/Utilities/VersionChecker.cs
@@ -32,12 +32,12 @@ namespace Server.Utilities
                     LunaLog.Info($"There is an update available for LMP, please download it when you're able to: {LmpVersioning.CurrentVersion} -> {LatestVersion}");
                     if (LmpVersioning.IsCompatible(LatestVersion))
                     {
-                        LunaLog.Info($"This update is not required to stay compattibile with updated master servers and clients.");
+                        LunaLog.Info($"This update is not required to stay compatible with updated master servers and clients.");
                         multiplier = 60;
                     }
                     else
                     {
-                        LunaLog.Warning("This update is mandatory to be shown on the server list once it's updated. You should go update");
+                        LunaLog.Warning("This update is mandatory to be shown on the server list once it's updated. You should update the server ASAP.");
                     }
                 }
 

--- a/Server/Utilities/VersionChecker.cs
+++ b/Server/Utilities/VersionChecker.cs
@@ -26,14 +26,17 @@ namespace Server.Utilities
         {
             while (ServerContext.ServerRunning)
             {
-                var multiplier = 1;
+                // Repeat again in an hour if it's non-essential, or in a minute if it is essential.
+                var delayMs = LmpVersioning.IsCompatible(LatestVersion)
+                ? TimeSpan.FromHours(1)
+                : TimeSpan.FromMinutes(1);
+
                 if (LatestVersion > LmpVersioning.CurrentVersion)
                 {
                     LunaLog.Info($"There is an update available for LMP, please download it when you're able to: {LmpVersioning.CurrentVersion} -> {LatestVersion}");
                     if (LmpVersioning.IsCompatible(LatestVersion))
                     {
                         LunaLog.Info($"This update is not required to stay compatible with updated master servers and clients.");
-                        multiplier = 60;
                     }
                     else
                     {
@@ -42,8 +45,7 @@ namespace Server.Utilities
                     }
                 }
 
-                // Repeat again in an hour if it's non-essential, or in a minute if it is essential.
-                await Task.Delay(60 * 1000 * multiplier);
+                await Task.Delay(delayMs);
             }
         }
     }


### PR DESCRIPTION
### Fixes included in this PR:
- Fixes the version checker so that it won't log twice every 30 seconds whenever there's an update available.
### Changes proposed in this PR:
- Changes the version checker to make a pair of log entries every minute
- Add a "multiplier" to multiply the time between pairs of log entries by 60 whenever the new version is considered compatible with the old version. (should be paired with a system to load in cross-compatible major version numbers directly from github)