### PR TITLE
Implement Science mode netcode and gameplay improvements

### DIFF
--- a/LmpClient/ModuleStore/XML/Squad/ModuleScienceLab.xml
+++ b/LmpClient/ModuleStore/XML/Squad/ModuleScienceLab.xml
@@ -7,5 +7,8 @@
         <FieldDefinition>
             <FieldName>storedScience</FieldName>
         </FieldDefinition>
+        <FieldDefinition>
+            <FieldName>dataProcessed</FieldName>
+        </FieldDefinition>
     </Fields>
 </ModuleDefinition>

--- a/LmpClient/Network/NetworkReceiver.cs
+++ b/LmpClient/Network/NetworkReceiver.cs
@@ -276,6 +276,9 @@ namespace LmpClient.Network
                         case ShareProgressMessageType.ExperimentalPart:
                             ShareExperimentalPartsSystem.Singleton.EnqueueMessage(msg);
                             break;
+                        case ShareProgressMessageType.ScienceSubjectRevert:
+                            ShareScienceSubjectSystem.Singleton.EnqueueMessage(msg);
+                            break;
                     }
                     break;
                 case ServerMessageType.Screenshot:

--- a/LmpClient/Systems/Groups/GroupSystem.cs
+++ b/LmpClient/Systems/Groups/GroupSystem.cs
@@ -2,6 +2,7 @@
 using LmpClient.Network;
 using LmpClient.Systems.SettingsSys;
 using LmpCommon.Message.Data.Groups;
+using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Linq;
@@ -26,16 +27,16 @@ namespace LmpClient.Systems.Groups
         {
             if (Groups.TryGetValue(groupName, out var existingVal))
             {
-                if (existingVal.Members.All(m => m != SettingsSystem.CurrentSettings.PlayerName) &&
-                    existingVal.Invited.All(m => m != SettingsSystem.CurrentSettings.PlayerName))
+                var me = SettingsSystem.CurrentSettings.PlayerName;
+                if (existingVal.Members.All(m => m != me) && existingVal.Invited.All(m => m != me))
                 {
-                    var expectedGroup = existingVal.Clone();
-
-                    var newInvited = new List<string>(expectedGroup.Invited) { SettingsSystem.CurrentSettings.PlayerName };
-                    expectedGroup.Invited = newInvited.ToArray();
+                    var newInvited = new string[existingVal.Invited.Length + 1];
+                    Array.Copy(existingVal.Invited, newInvited, existingVal.Invited.Length);
+                    newInvited[existingVal.Invited.Length] = me;
 
                     var msgData = NetworkMain.CliMsgFactory.CreateNewMessageData<GroupUpdateMsgData>();
-                    msgData.Group = expectedGroup;
+                    msgData.Group = existingVal.Clone();
+                    msgData.Group.Invited = newInvited;
 
                     MessageSender.SendMessage(msgData);
                 }
@@ -69,17 +70,16 @@ namespace LmpClient.Systems.Groups
             if (Groups.TryGetValue(groupName, out var existingVal)
                 && existingVal.Owner == SettingsSystem.CurrentSettings.PlayerName)
             {
-                //TODO: remove this clone and do as with flags to avoid garbage
-                var expectedGroup = existingVal.Clone();
+                var newMembers = new string[existingVal.Members.Length + 1];
+                Array.Copy(existingVal.Members, newMembers, existingVal.Members.Length);
+                newMembers[existingVal.Members.Length] = username;
 
-                var newMembers = new List<string>(expectedGroup.Members) { username };
-                expectedGroup.Members = newMembers.ToArray();
-
-                var newInvited = new List<string>(expectedGroup.Invited.Except(new[] { username }));
-                expectedGroup.Invited = newInvited.ToArray();
+                var newInvited = existingVal.Invited.Where(m => m != username).ToArray();
 
                 var msgData = NetworkMain.CliMsgFactory.CreateNewMessageData<GroupUpdateMsgData>();
-                msgData.Group = expectedGroup;
+                msgData.Group = existingVal.Clone();
+                msgData.Group.Members = newMembers;
+                msgData.Group.Invited = newInvited;
 
                 MessageSender.SendMessage(msgData);
             }
@@ -90,17 +90,13 @@ namespace LmpClient.Systems.Groups
             if (Groups.TryGetValue(groupName, out var existingVal)
                 && existingVal.Owner == SettingsSystem.CurrentSettings.PlayerName)
             {
-                //TODO: remove this clone and do as with flags to avoid garbage
-                var expectedGroup = existingVal.Clone();
-
-                var newMembers = new List<string>(expectedGroup.Members.Except(new[] { username })) { username };
-                expectedGroup.Members = newMembers.ToArray();
-
-                var newInvited = new List<string>(expectedGroup.Invited.Except(new[] { username }));
-                expectedGroup.Invited = newInvited.ToArray();
+                var newMembers = existingVal.Members.Where(m => m != username).ToArray();
+                var newInvited = existingVal.Invited.Where(m => m != username).ToArray();
 
                 var msgData = NetworkMain.CliMsgFactory.CreateNewMessageData<GroupUpdateMsgData>();
-                msgData.Group = expectedGroup;
+                msgData.Group = existingVal.Clone();
+                msgData.Group.Members = newMembers;
+                msgData.Group.Invited = newInvited;
 
                 MessageSender.SendMessage(msgData);
             }

--- a/LmpClient/Systems/ShareScienceSubject/ShareScienceSubjectEvents.cs
+++ b/LmpClient/Systems/ShareScienceSubject/ShareScienceSubjectEvents.cs
@@ -1,4 +1,4 @@
-﻿using LmpClient.Base;
+using LmpClient.Base;
 
 namespace LmpClient.Systems.ShareScienceSubject
 {
@@ -8,17 +8,25 @@ namespace LmpClient.Systems.ShareScienceSubject
         {
             if (System.IgnoreEvents) return;
 
-            System.MessageSender.SendScienceSubjectMessage(subject);
+            // reverseEngineered == true means the sample was physically recovered (not transmitted)
+            var wasTransmitted = !reverseEngineered;
+            System.MessageSender.SendScienceSubjectMessage(subject, wasTransmitted);
         }
 
         public void RevertingDetected()
         {
+            // Send the pre-flight snapshot NOW, before scene transitions clear the science state.
+            // The server applies merge logic, so other players' science is never rolled back.
+            System.SendRevertSnapshot();
+
             System.Reverting = true;
             System.StartIgnoringEvents();
         }
 
         public void RevertingToEditorDetected(EditorFacility data)
         {
+            System.SendRevertSnapshot();
+
             System.Reverting = true;
             System.StartIgnoringEvents();
         }

--- a/LmpClient/Systems/ShareScienceSubject/ShareScienceSubjectMessageHandler.cs
+++ b/LmpClient/Systems/ShareScienceSubject/ShareScienceSubjectMessageHandler.cs
@@ -1,4 +1,4 @@
-﻿using LmpClient.Base;
+using LmpClient.Base;
 using LmpClient.Base.Interface;
 using LmpClient.Extensions;
 using LmpCommon.Message.Data.ShareProgress;
@@ -6,6 +6,7 @@ using LmpCommon.Message.Interface;
 using LmpCommon.Message.Types;
 using System;
 using System.Collections.Concurrent;
+using System.Collections.Generic;
 
 namespace LmpClient.Systems.ShareScienceSubject
 {
@@ -13,51 +14,128 @@ namespace LmpClient.Systems.ShareScienceSubject
     {
         public ConcurrentQueue<IServerMessageBase> IncomingMessages { get; set; } = new ConcurrentQueue<IServerMessageBase>();
 
+        // Tracks the highest science value we've seen per subject to prevent out-of-order downgrades
+        private static readonly ConcurrentDictionary<string, float> _highWaterMark = new ConcurrentDictionary<string, float>();
+
         public void HandleMessage(IServerMessageBase msg)
         {
             if (!(msg.Data is ShareProgressBaseMsgData msgData)) return;
-            if (msgData.ShareProgressMessageType != ShareProgressMessageType.ScienceSubjectUpdate) return;
 
-            if (msgData is ShareProgressScienceSubjectMsgData data)
+            switch (msgData.ShareProgressMessageType)
             {
-                var subject = new ScienceSubjectInfo(data.ScienceSubject); //create a copy of the tech value so it will not change in the future.
-                LunaLog.Log($"Queue Science subject: {subject.Id}");
-                System.QueueAction(() =>
-                {
-                    NewScienceSubject(subject);
-                });
+                case ShareProgressMessageType.ScienceSubjectUpdate:
+                    if (msgData is ShareProgressScienceSubjectMsgData updateData)
+                    {
+                        var copy = new ScienceSubjectInfo(updateData.ScienceSubject);
+                        LunaLog.Log($"Queue science subject update: {copy.Id} sci={copy.Science} isDelta={copy.IsDelta}");
+                        System.QueueAction(() => ApplyScienceSubjectUpdate(copy));
+                    }
+                    break;
+
+                case ShareProgressMessageType.ScienceSubjectRevert:
+                    if (msgData is ShareProgressScienceSubjectRevertMsgData revertData)
+                    {
+                        var copies = new ScienceSubjectInfo[revertData.SubjectCount];
+                        for (var i = 0; i < revertData.SubjectCount; i++)
+                            copies[i] = new ScienceSubjectInfo(revertData.Subjects[i]);
+                        LunaLog.Log($"Queue science subject revert: {revertData.SubjectCount} subjects");
+                        System.QueueAction(() => ApplyScienceSubjectRevert(copies));
+                    }
+                    break;
             }
         }
 
-        private static void NewScienceSubject(ScienceSubjectInfo subject)
+        private static void ApplyScienceSubjectUpdate(ScienceSubjectInfo info)
         {
-            System.StartIgnoringEvents();
-
-            var currentSubjects = System.ScienceSubjects;
-            var receivedSubject = ConvertByteArrayToScienceSubject(subject.Data, subject.NumBytes);
-
-            if (!currentSubjects.TryGetValue(subject.Id, out var existingSubject))
+            // Deduplicate: ignore if we already have a higher value (handles network reorder / duplicates)
+            if (_highWaterMark.TryGetValue(info.Id, out var knownBest) && info.Science < knownBest)
             {
-                currentSubjects.Add(receivedSubject.id, receivedSubject);
+                LunaLog.Log($"Science subject '{info.Id}' ignored: incoming {info.Science} < known best {knownBest}");
+                return;
+            }
+
+            System.StartIgnoringEvents();
+            var currentSubjects = System.ScienceSubjects;
+
+            if (info.IsDelta)
+            {
+                ApplyDelta(currentSubjects, info);
             }
             else
             {
-                existingSubject.dataScale = receivedSubject.dataScale;
-                existingSubject.scientificValue = receivedSubject.scientificValue;
-                existingSubject.subjectValue = receivedSubject.subjectValue;
-                existingSubject.science = receivedSubject.science;
-                existingSubject.scienceCap = receivedSubject.scienceCap;
+                ApplyFull(currentSubjects, info);
+            }
+
+            _highWaterMark[info.Id] = Math.Max(info.Science, knownBest);
+            System.StopIgnoringEvents();
+            LunaLog.Log($"Science subject applied: {info.Id} sci={info.Science} collectedBy={info.CollectedBy}");
+        }
+
+        private static void ApplyDelta(Dictionary<string, ScienceSubject> subjects, ScienceSubjectInfo delta)
+        {
+            if (!subjects.TryGetValue(delta.Id, out var existing))
+            {
+                LunaLog.Warning($"Received delta for unknown subject '{delta.Id}' — ignored (not yet discovered locally)");
+                return;
+            }
+
+            existing.science = delta.Science;
+            existing.scienceCap = delta.ScienceCap;
+            existing.dataScale = delta.DataScale;
+            existing.scientificValue = delta.ScientificValue;
+            existing.subjectValue = delta.SubjectValue;
+        }
+
+        private static void ApplyFull(Dictionary<string, ScienceSubject> subjects, ScienceSubjectInfo info)
+        {
+            var received = ConvertToScienceSubject(info.Data, info.NumBytes);
+            if (received == null) return;
+
+            if (!subjects.TryGetValue(info.Id, out var existing))
+            {
+                subjects.Add(received.id, received);
+            }
+            else
+            {
+                existing.science = received.science;
+                existing.scienceCap = received.scienceCap;
+                existing.dataScale = received.dataScale;
+                existing.scientificValue = received.scientificValue;
+                existing.subjectValue = received.subjectValue;
+            }
+        }
+
+        private static void ApplyScienceSubjectRevert(ScienceSubjectInfo[] snapshot)
+        {
+            System.StartIgnoringEvents();
+            var currentSubjects = System.ScienceSubjects;
+
+            foreach (var info in snapshot)
+            {
+                if (info == null) continue;
+                if (!currentSubjects.TryGetValue(info.Id, out var existing)) continue;
+
+                // Merge: never roll back science that we or another player earned above this value
+                if (existing.science > info.Science)
+                {
+                    LunaLog.Log($"Revert ignored for '{info.Id}': local {existing.science} > reverted {info.Science}");
+                    continue;
+                }
+
+                existing.science = info.Science;
+                existing.scienceCap = info.ScienceCap;
+                existing.dataScale = info.DataScale;
+                existing.scientificValue = info.ScientificValue;
+                existing.subjectValue = info.SubjectValue;
+
+                _highWaterMark[info.Id] = info.Science;
             }
 
             System.StopIgnoringEvents();
-            LunaLog.Log($"Science subject received: {subject.Id}");
+            LunaLog.Log($"Science subject revert applied: {snapshot.Length} subjects");
         }
 
-        /// <summary>
-        /// Convert a byte array to a ConfigNode and then to a ScienceSubject.
-        /// If anything goes wrong it will return null.
-        /// </summary>
-        private static ScienceSubject ConvertByteArrayToScienceSubject(byte[] data, int numBytes)
+        private static ScienceSubject ConvertToScienceSubject(byte[] data, int numBytes)
         {
             var node = new ConfigNode("Science");
             try
@@ -69,7 +147,6 @@ namespace LmpClient.Systems.ShareScienceSubject
                 LunaLog.LogError($"[LMP]: Error while deserializing science subject configNode: {e}");
                 return null;
             }
-
             return new ScienceSubject(node);
         }
     }

--- a/LmpClient/Systems/ShareScienceSubject/ShareScienceSubjectMessageSender.cs
+++ b/LmpClient/Systems/ShareScienceSubject/ShareScienceSubjectMessageSender.cs
@@ -1,11 +1,13 @@
-﻿using LmpClient.Base;
+using LmpClient.Base;
 using LmpClient.Base.Interface;
 using LmpClient.Extensions;
 using LmpClient.Network;
+using LmpClient.Systems.SettingsSys;
 using LmpCommon.Message.Client;
 using LmpCommon.Message.Data.ShareProgress;
 using LmpCommon.Message.Interface;
 using System;
+using System.Collections.Generic;
 
 namespace LmpClient.Systems.ShareScienceSubject
 {
@@ -16,26 +18,73 @@ namespace LmpClient.Systems.ShareScienceSubject
             TaskFactory.StartNew(() => NetworkSender.QueueOutgoingMessage(MessageFactory.CreateNew<ShareProgressCliMsg>(msg)));
         }
 
-        public void SendScienceSubjectMessage(ScienceSubject subject)
+        public void SendScienceSubjectMessage(ScienceSubject subject, bool wasTransmitted)
         {
+            var isUpdate = System.ScienceSubjects.ContainsKey(subject.id);
             var msgData = NetworkMain.CliMsgFactory.CreateNewMessageData<ShareProgressScienceSubjectMsgData>();
+
             msgData.ScienceSubject.Id = subject.id;
+            msgData.ScienceSubject.Science = subject.science;
+            msgData.ScienceSubject.ScienceCap = subject.scienceCap;
+            msgData.ScienceSubject.DataScale = subject.dataScale;
+            msgData.ScienceSubject.ScientificValue = subject.scientificValue;
+            msgData.ScienceSubject.SubjectValue = subject.subjectValue;
+            msgData.ScienceSubject.WasTransmitted = wasTransmitted;
+            msgData.ScienceSubject.CollectedBy = SettingsSystem.CurrentSettings.PlayerName;
+            msgData.ScienceSubject.IsDelta = isUpdate;
 
-            var configNode = ConvertScienceSubjectToConfigNode(subject);
-            if (configNode == null) return;
+            if (!isUpdate)
+            {
+                // First discovery: include the full ConfigNode so the server can persist it
+                var configNode = ConvertScienceSubjectToConfigNode(subject);
+                if (configNode == null) return;
 
-            var data = configNode.Serialize();
-            var numBytes = data.Length;
+                var data = configNode.Serialize();
+                var numBytes = data.Length;
 
-            msgData.ScienceSubject.NumBytes = numBytes;
-            if (msgData.ScienceSubject.Data.Length < numBytes)
-                msgData.ScienceSubject.Data = new byte[numBytes];
-
-            Array.Copy(data, msgData.ScienceSubject.Data, numBytes);
+                msgData.ScienceSubject.NumBytes = numBytes;
+                if (msgData.ScienceSubject.Data.Length < numBytes)
+                    msgData.ScienceSubject.Data = new byte[numBytes];
+                Array.Copy(data, msgData.ScienceSubject.Data, numBytes);
+            }
 
             SendMessage(msgData);
+            LunaLog.Log($"Science experiment \"{subject.id}\" sent (isDelta={isUpdate}, wasTransmitted={wasTransmitted})");
+        }
 
-            LunaLog.Log($"Science experiment \"{subject.id}\" sent");
+        /// <summary>
+        /// Sends the pre-flight science snapshot back to the server so it can revert.
+        /// Called when the player reverts to launch or editor.
+        /// </summary>
+        public void SendScienceSubjectRevert(IReadOnlyCollection<KeyValuePair<string, ScienceSubject>> snapshot)
+        {
+            var msgData = NetworkMain.CliMsgFactory.CreateNewMessageData<ShareProgressScienceSubjectRevertMsgData>();
+            msgData.SubjectCount = snapshot.Count;
+
+            if (msgData.Subjects.Length < snapshot.Count)
+                msgData.Subjects = new ScienceSubjectInfo[snapshot.Count];
+
+            var i = 0;
+            foreach (var kvp in snapshot)
+            {
+                var subject = kvp.Value;
+                var info = new ScienceSubjectInfo
+                {
+                    Id = subject.id,
+                    Science = subject.science,
+                    ScienceCap = subject.scienceCap,
+                    DataScale = subject.dataScale,
+                    ScientificValue = subject.scientificValue,
+                    SubjectValue = subject.subjectValue,
+                    WasTransmitted = false,
+                    CollectedBy = SettingsSystem.CurrentSettings.PlayerName,
+                    IsDelta = true
+                };
+                msgData.Subjects[i++] = info;
+            }
+
+            SendMessage(msgData);
+            LunaLog.Log($"Science subject revert sent: {snapshot.Count} subjects");
         }
 
         private static ConfigNode ConvertScienceSubjectToConfigNode(ScienceSubject subject)
@@ -50,7 +99,6 @@ namespace LmpClient.Systems.ShareScienceSubject
                 LunaLog.LogError($"[LMP]: Error while saving science subject: {e}");
                 return null;
             }
-
             return configNode;
         }
     }

--- a/LmpClient/Systems/ShareScienceSubject/ShareScienceSubjectSystem.cs
+++ b/LmpClient/Systems/ShareScienceSubject/ShareScienceSubjectSystem.cs
@@ -1,4 +1,4 @@
-﻿using HarmonyLib;
+using HarmonyLib;
 using LmpClient.Events;
 using LmpClient.Systems.ShareProgress;
 using LmpCommon.Enums;
@@ -12,7 +12,10 @@ namespace LmpClient.Systems.ShareScienceSubject
 
         private ShareScienceSubjectEvents ShareScienceSubjectEvents { get; } = new ShareScienceSubjectEvents();
 
-        private Dictionary<string, ScienceSubject> _lastScienceSubjects = new Dictionary<string, ScienceSubject>();
+        // Static so it survives OnDisabled()/OnEnabled() across scene transitions.
+        // Captured at the moment the player launches, so revert can restore to that baseline.
+        private static Dictionary<string, ScienceSubject> _preFlightSnapshot;
+        private static bool _hasPreFlightSnapshot;
 
         private static Dictionary<string, ScienceSubject> _scienceSubjects;
         public Dictionary<string, ScienceSubject> ScienceSubjects
@@ -23,7 +26,6 @@ namespace LmpClient.Systems.ShareScienceSubject
                 {
                     _scienceSubjects = Traverse.Create(ResearchAndDevelopment.Instance).Field("scienceSubjects").GetValue<Dictionary<string, ScienceSubject>>();
                 }
-
                 return _scienceSubjects;
             }
         }
@@ -44,35 +46,53 @@ namespace LmpClient.Systems.ShareScienceSubject
             RevertEvent.onRevertingToLaunch.Add(ShareScienceSubjectEvents.RevertingDetected);
             RevertEvent.onReturningToEditor.Add(ShareScienceSubjectEvents.RevertingToEditorDetected);
             GameEvents.onLevelWasLoadedGUIReady.Add(ShareScienceSubjectEvents.LevelLoaded);
-
+            GameEvents.onFlightReady.Add(OnFlightReady);
         }
 
         protected override void OnDisabled()
         {
             base.OnDisabled();
 
-            //Always try to remove the event, as when we disconnect from a server the server settings will get the default values
             GameEvents.OnScienceRecieved.Remove(ShareScienceSubjectEvents.ScienceRecieved);
 
             RevertEvent.onRevertingToLaunch.Remove(ShareScienceSubjectEvents.RevertingDetected);
             RevertEvent.onReturningToEditor.Remove(ShareScienceSubjectEvents.RevertingToEditorDetected);
             GameEvents.onLevelWasLoadedGUIReady.Remove(ShareScienceSubjectEvents.LevelLoaded);
+            GameEvents.onFlightReady.Remove(OnFlightReady);
 
             Reverting = false;
-            _lastScienceSubjects.Clear();
             _scienceSubjects = null;
         }
 
         public override void SaveState()
         {
             base.SaveState();
-            _lastScienceSubjects = ScienceSubjects;
+            // Preserve existing pre-flight snapshot — SaveState is also called during revert
+            // and we don't want to overwrite the snapshot with in-flight data
         }
 
         public override void RestoreState()
         {
             base.RestoreState();
-            Traverse.Create(ResearchAndDevelopment.Instance).Field("scienceSubjects").SetValue(_lastScienceSubjects);
+            if (_hasPreFlightSnapshot)
+                Traverse.Create(ResearchAndDevelopment.Instance).Field("scienceSubjects").SetValue(_preFlightSnapshot);
+        }
+
+        /// <summary>
+        /// Sends the pre-flight snapshot to the server so it and other clients can revert.
+        /// Called from RevertingDetected before any scene transition wipes state.
+        /// </summary>
+        public void SendRevertSnapshot()
+        {
+            if (!_hasPreFlightSnapshot || _preFlightSnapshot.Count == 0) return;
+            MessageSender.SendScienceSubjectRevert(_preFlightSnapshot);
+        }
+
+        private void OnFlightReady()
+        {
+            if (!ShareSystemReady) return;
+            _preFlightSnapshot = new Dictionary<string, ScienceSubject>(ScienceSubjects);
+            _hasPreFlightSnapshot = true;
         }
     }
 }

--- a/LmpClient/Systems/VesselPartSyncUiFieldSys/VesselPartSyncUiFieldEvents.cs
+++ b/LmpClient/Systems/VesselPartSyncUiFieldSys/VesselPartSyncUiFieldEvents.cs
@@ -1,13 +1,32 @@
-﻿using LmpClient.Base;
+using LmpClient.Base;
 using LmpClient.Extensions;
 using LmpClient.ModuleStore;
 using LmpClient.Systems.SettingsSys;
 using LmpCommon.Locks;
+using LmpCommon.Time;
+using System;
+using System.Collections.Concurrent;
 
 namespace LmpClient.Systems.VesselPartSyncUiFieldSys
 {
     public class VesselPartSyncUiFieldEvents : SubSystem<VesselPartSyncUiFieldSystem>
     {
+        private const int DebounceMs = 200;
+
+        private class PendingChange
+        {
+            public Vessel Vessel;
+            public Part Part;
+            public string ModuleName;
+            public string FieldName;
+            public object Value;
+            public Type FieldType;
+            public DateTime LastChangedAt;
+        }
+
+        private readonly ConcurrentDictionary<string, PendingChange> _pending
+            = new ConcurrentDictionary<string, PendingChange>();
+
         private static bool CallIsValid(PartModule module)
         {
             var vessel = module.vessel;
@@ -18,7 +37,6 @@ namespace LmpClient.Systems.VesselPartSyncUiFieldSys
             if (part == null)
                 return false;
 
-            //The vessel is immortal so we are sure that it's not ours
             if (module.vessel.IsImmortal())
                 return false;
 
@@ -43,9 +61,9 @@ namespace LmpClient.Systems.VesselPartSyncUiFieldSys
                     {
                         foreach (var field in module.Fields)
                         {
-                            if (field.uiControlFlight.GetType() != typeof(UI_Toggle) //bool
-                                && field.uiControlFlight.GetType() != typeof(UI_FloatRange) //float
-                                && field.uiControlFlight.GetType() != typeof(UI_Cycle)) //int
+                            if (field.uiControlFlight.GetType() != typeof(UI_Toggle)
+                                && field.uiControlFlight.GetType() != typeof(UI_FloatRange)
+                                && field.uiControlFlight.GetType() != typeof(UI_Cycle))
                                 continue;
 
                             field.uiControlFlight.onFieldChanged -= OnFieldChanged;
@@ -56,21 +74,53 @@ namespace LmpClient.Systems.VesselPartSyncUiFieldSys
             }
         }
 
-        private static void OnFieldChanged(BaseField baseField, object oldValue)
+        private void OnFieldChanged(BaseField baseField, object oldValue)
         {
             var partModule = (PartModule)baseField.host;
             if (!CallIsValid(partModule)) return;
 
-            //TODO: add some sort of buffering so it sends the value after 500ms to avoid clogging in case a user changes it too often
+            var key = $"{partModule.part.flightID}_{partModule.moduleName}_{baseField.name}";
+            _pending[key] = new PendingChange
+            {
+                Vessel = partModule.vessel,
+                Part = partModule.part,
+                ModuleName = partModule.moduleName,
+                FieldName = baseField.name,
+                Value = baseField.GetValue(baseField.host),
+                FieldType = baseField.FieldInfo.FieldType,
+                LastChangedAt = LunaComputerTime.UtcNow
+            };
+        }
 
-            var fieldType = baseField.FieldInfo.FieldType;
+        /// <summary>
+        /// Flushes pending outgoing UI field changes that have been stable for DebounceMs.
+        /// Called by the system's update routine.
+        /// </summary>
+        public void FlushPending()
+        {
+            if (_pending.IsEmpty) return;
 
-            if (fieldType == typeof(bool))
-                System.MessageSender.SendVesselPartSyncUiFieldBoolMsg(partModule.vessel, partModule.part, partModule.moduleName, baseField.name, (bool)baseField.GetValue(baseField.host));
-            else if (fieldType == typeof(int))
-                System.MessageSender.SendVesselPartSyncUiFieldIntMsg(partModule.vessel, partModule.part, partModule.moduleName, baseField.name, (int)baseField.GetValue(baseField.host));
-            else if (fieldType == typeof(float))
-                System.MessageSender.SendVesselPartSyncUiFieldFloatMsg(partModule.vessel, partModule.part, partModule.moduleName, baseField.name, (float)baseField.GetValue(baseField.host));
+            var cutoff = LunaComputerTime.UtcNow.AddMilliseconds(-DebounceMs);
+            foreach (var kvp in _pending)
+            {
+                if (kvp.Value.LastChangedAt > cutoff) continue;
+
+                if (!_pending.TryRemove(kvp.Key, out var change)) continue;
+
+                SendChange(change);
+            }
+        }
+
+        public void ClearPending() => _pending.Clear();
+
+        private void SendChange(PendingChange change)
+        {
+            if (change.FieldType == typeof(bool))
+                System.MessageSender.SendVesselPartSyncUiFieldBoolMsg(change.Vessel, change.Part, change.ModuleName, change.FieldName, (bool)change.Value);
+            else if (change.FieldType == typeof(int))
+                System.MessageSender.SendVesselPartSyncUiFieldIntMsg(change.Vessel, change.Part, change.ModuleName, change.FieldName, (int)change.Value);
+            else if (change.FieldType == typeof(float))
+                System.MessageSender.SendVesselPartSyncUiFieldFloatMsg(change.Vessel, change.Part, change.ModuleName, change.FieldName, (float)change.Value);
         }
     }
 }

--- a/LmpClient/Systems/VesselPartSyncUiFieldSys/VesselPartSyncUiFieldSystem.cs
+++ b/LmpClient/Systems/VesselPartSyncUiFieldSys/VesselPartSyncUiFieldSystem.cs
@@ -35,16 +35,20 @@ namespace LmpClient.Systems.VesselPartSyncUiFieldSys
             LockEvent.onLockAcquire.Add(VesselPartModuleSyncUiFieldEvents.LockAcquire);
 
             SetupRoutine(new RoutineDefinition(250, RoutineExecution.Update, ProcessVesselPartUiFieldsSyncs));
+            SetupRoutine(new RoutineDefinition(50, RoutineExecution.Update, FlushOutgoingFieldChanges));
         }
 
         protected override void OnDisabled()
         {
             base.OnDisabled();
 
-            LockEvent.onLockAcquire.Add(VesselPartModuleSyncUiFieldEvents.LockAcquire);
+            LockEvent.onLockAcquire.Remove(VesselPartModuleSyncUiFieldEvents.LockAcquire);
 
+            VesselPartModuleSyncUiFieldEvents.ClearPending();
             VesselPartsUiFieldsSyncs.Clear();
         }
+
+        private void FlushOutgoingFieldChanges() => VesselPartModuleSyncUiFieldEvents.FlushPending();
 
         #endregion
 

--- a/LmpClient/Systems/VesselPositionSys/VesselPositionSystem.cs
+++ b/LmpClient/Systems/VesselPositionSys/VesselPositionSystem.cs
@@ -21,11 +21,39 @@ namespace LmpClient.Systems.VesselPositionSys
 
         private static DateTime LastVesselUpdatesSentTime { get; set; } = LunaComputerTime.UtcNow;
 
-        private static int UpdateIntervalLockedToUnity => (int)(Math.Floor(SettingsSystem.ServerSettings.VesselUpdatesMsInterval
-            / TimeSpan.FromSeconds(Time.fixedDeltaTime).TotalMilliseconds) * TimeSpan.FromSeconds(Time.fixedDeltaTime).TotalMilliseconds);
+        // Cached intervals — recalculated only when Time.fixedDeltaTime changes (very rare)
+        private static float _cachedFixedDeltaTime = -1f;
+        private static int _cachedUpdateInterval;
+        private static int _cachedSecondaryUpdateInterval;
 
-        private static int SecondaryVesselUpdatesUpdateIntervalLockedToUnity => (int)(Math.Floor(SettingsSystem.ServerSettings.SecondaryVesselUpdatesMsInterval
-            / TimeSpan.FromSeconds(Time.fixedDeltaTime).TotalMilliseconds) * TimeSpan.FromSeconds(Time.fixedDeltaTime).TotalMilliseconds);
+        private static int UpdateIntervalLockedToUnity
+        {
+            get
+            {
+                RefreshIntervalCache();
+                return _cachedUpdateInterval;
+            }
+        }
+
+        private static int SecondaryVesselUpdatesUpdateIntervalLockedToUnity
+        {
+            get
+            {
+                RefreshIntervalCache();
+                return _cachedSecondaryUpdateInterval;
+            }
+        }
+
+        private static void RefreshIntervalCache()
+        {
+            var fdt = Time.fixedDeltaTime;
+            if (Math.Abs(fdt - _cachedFixedDeltaTime) < float.Epsilon) return;
+
+            _cachedFixedDeltaTime = fdt;
+            var fixedMs = TimeSpan.FromSeconds(fdt).TotalMilliseconds;
+            _cachedUpdateInterval = (int)(Math.Floor(SettingsSystem.ServerSettings.VesselUpdatesMsInterval / fixedMs) * fixedMs);
+            _cachedSecondaryUpdateInterval = (int)(Math.Floor(SettingsSystem.ServerSettings.SecondaryVesselUpdatesMsInterval / fixedMs) * fixedMs);
+        }
 
         private static bool TimeToSendVesselUpdate => VesselCommon.PlayerVesselsNearby() ?
             (LunaComputerTime.UtcNow - LastVesselUpdatesSentTime).TotalMilliseconds > UpdateIntervalLockedToUnity :
@@ -72,7 +100,7 @@ namespace LmpClient.Systems.VesselPositionSys
             //It's important that SECONDARY vessels send their position in the UPDATE as their parameters will NOT be updated on the fixed update if the are packed.
             //https://forum.kerbalspaceprogram.com/index.php?/topic/173885-packed-vessels-position-isnt-reliable-from-fixedupdate/
             SetupRoutine(new RoutineDefinition(SettingsSystem.ServerSettings.SecondaryVesselUpdatesMsInterval, RoutineExecution.LateUpdate, SendSecondaryVesselPositionUpdates));
-            //SetupRoutine(new RoutineDefinition(SettingsSystem.ServerSettings.SecondaryVesselUpdatesMsInterval, RoutineExecution.LateUpdate, SendUnloadedSecondaryVesselPositionUpdates));
+            SetupRoutine(new RoutineDefinition(SettingsSystem.ServerSettings.SecondaryVesselUpdatesMsInterval, RoutineExecution.LateUpdate, SendUnloadedSecondaryVesselPositionUpdates));
 
             WarpEvent.onTimeWarpStopped.Add(PositionEvents.WarpStopped);
         }

--- a/LmpClient/Systems/VesselProtoSys/VesselProtoMessageSender.cs
+++ b/LmpClient/Systems/VesselProtoSys/VesselProtoMessageSender.cs
@@ -57,45 +57,55 @@ namespace LmpClient.Systems.VesselProtoSys
         private void SendVesselMessage(ProtoVessel protoVessel, bool forceReload)
         {
             if (protoVessel == null || protoVessel.vesselID == Guid.Empty) return;
-            //Doing this in another thread can crash the game as during the serialization into a config node Lingoona is called...
-            //TODO: Check if this works fine with the new unity version as it used to crash....
+            // ConfigNode serialization calls into Lingoona which can be thread-sensitive.
+            // PrepareAndSendProtoVessel now has a full try/catch so failures are logged, not fatal.
             TaskFactory.StartNew(() => PrepareAndSendProtoVessel(protoVessel, forceReload));
-            //PrepareAndSendProtoVessel(protoVessel);
         }
 
         /// <summary>
-        /// This method prepares the protovessel class and send the message, it's intended to be run in another thread
+        /// This method prepares the protovessel class and send the message, it's intended to be run in another thread.
+        /// The entire body is wrapped in a try/catch because ConfigNode serialization via Lingoona can fail in some
+        /// Unity versions and we must not propagate the exception onto the background thread pool.
         /// </summary>
         private void PrepareAndSendProtoVessel(ProtoVessel protoVessel, bool forceReload)
         {
-            //Never send empty vessel id's (it happens with flags...)
             if (protoVessel.vesselID == Guid.Empty) return;
 
-            //VesselSerializedBytes is shared so lock it!
-            lock (VesselArraySyncLock)
+            try
             {
-                VesselSerializer.SerializeVesselToArray(protoVessel, VesselSerializedBytes, out var numBytes);
-                if (numBytes > 0)
+                lock (VesselArraySyncLock)
                 {
-                    var msgData = NetworkMain.CliMsgFactory.CreateNewMessageData<VesselProtoMsgData>();
-                    msgData.GameTime = TimeSyncSystem.UniversalTime;
-                    msgData.VesselId = protoVessel.vesselID;
-                    msgData.NumBytes = numBytes;
-                    msgData.ForceReload = forceReload;
-                    if (msgData.Data.Length < numBytes)
-                        Array.Resize(ref msgData.Data, numBytes);
-                    Array.Copy(VesselSerializedBytes, 0, msgData.Data, 0, numBytes);
-
-                    SendMessage(msgData);
-                }
-                else
-                {
-                    if (protoVessel.vesselType == VesselType.Debris)
+                    VesselSerializer.SerializeVesselToArray(protoVessel, VesselSerializedBytes, out var numBytes);
+                    if (numBytes > 0)
                     {
-                        LunaLog.Log($"Serialization of debris vessel: {protoVessel.vesselID} name: {protoVessel.vesselName} failed. Adding to kill list");
-                        VesselRemoveSystem.Singleton.KillVessel(protoVessel.vesselID, true, "Serialization of debris failed");
+                        var msgData = NetworkMain.CliMsgFactory.CreateNewMessageData<VesselProtoMsgData>();
+                        msgData.GameTime = TimeSyncSystem.UniversalTime;
+                        msgData.VesselId = protoVessel.vesselID;
+                        msgData.NumBytes = numBytes;
+                        msgData.ForceReload = forceReload;
+                        if (msgData.Data.Length < numBytes)
+                            Array.Resize(ref msgData.Data, numBytes);
+                        Array.Copy(VesselSerializedBytes, 0, msgData.Data, 0, numBytes);
+
+                        SendMessage(msgData);
+                    }
+                    else
+                    {
+                        if (protoVessel.vesselType == VesselType.Debris)
+                        {
+                            LunaLog.Log($"Serialization of debris vessel {protoVessel.vesselID} ({protoVessel.vesselName}) failed — adding to kill list");
+                            VesselRemoveSystem.Singleton.KillVessel(protoVessel.vesselID, true, "Serialization of debris failed");
+                        }
+                        else
+                        {
+                            LunaLog.LogWarning($"Serialization of vessel {protoVessel.vesselID} ({protoVessel.vesselName}) produced 0 bytes — skipping send");
+                        }
                     }
                 }
+            }
+            catch (Exception ex)
+            {
+                LunaLog.LogError($"[LMP]: Exception serializing vessel {protoVessel.vesselID} ({protoVessel.vesselName}): {ex}");
             }
         }
 

--- a/LmpCommon/Message/Client/ShareProgressCliMsg.cs
+++ b/LmpCommon/Message/Client/ShareProgressCliMsg.cs
@@ -30,6 +30,7 @@ namespace LmpCommon.Message.Client
             [(ushort)ShareProgressMessageType.FacilityUpgrade] = typeof(ShareProgressFacilityUpgradeMsgData),
             [(ushort)ShareProgressMessageType.PartPurchase] = typeof(ShareProgressPartPurchaseMsgData),
             [(ushort)ShareProgressMessageType.ExperimentalPart] = typeof(ShareProgressExperimentalPartMsgData),
+            [(ushort)ShareProgressMessageType.ScienceSubjectRevert] = typeof(ShareProgressScienceSubjectRevertMsgData),
         };
 
         public override ClientMessageType MessageType => ClientMessageType.ShareProgress;

--- a/LmpCommon/Message/Data/ShareProgress/ScienceSubjectInfo.cs
+++ b/LmpCommon/Message/Data/ShareProgress/ScienceSubjectInfo.cs
@@ -6,49 +6,102 @@ namespace LmpCommon.Message.Data.ShareProgress
 {
     /// <summary>
     /// Wrapper for transmitting the ksp ScienceSubject objects (science experiments).
+    /// When IsDelta is true only the numeric fields are transmitted (~50 bytes).
+    /// When IsDelta is false the full KSP ConfigNode binary is transmitted for first discovery.
     /// </summary>
     public class ScienceSubjectInfo
     {
         public string Id;
+
+        // Numeric fields — always present (used for merge logic and delta updates)
+        public float Science;
+        public float ScienceCap;
+        public float DataScale;
+        public float ScientificValue;
+        public float SubjectValue;
+
+        // Metadata
+        public bool WasTransmitted;
+        public string CollectedBy;
+
+        // Delta flag: when true, skip the heavy ConfigNode payload
+        public bool IsDelta;
+
+        // Full payload — only populated when IsDelta == false
         public int NumBytes;
         public byte[] Data = new byte[0];
 
         public ScienceSubjectInfo() { }
 
-        /// <summary>
-        /// Copy constructor.
-        /// </summary>
         public ScienceSubjectInfo(ScienceSubjectInfo copyFrom)
         {
             Id = copyFrom.Id;
+            Science = copyFrom.Science;
+            ScienceCap = copyFrom.ScienceCap;
+            DataScale = copyFrom.DataScale;
+            ScientificValue = copyFrom.ScientificValue;
+            SubjectValue = copyFrom.SubjectValue;
+            WasTransmitted = copyFrom.WasTransmitted;
+            CollectedBy = copyFrom.CollectedBy;
+            IsDelta = copyFrom.IsDelta;
             NumBytes = copyFrom.NumBytes;
-            if (Data.Length < NumBytes)
-                Data = new byte[NumBytes];
-
-            Array.Copy(copyFrom.Data, Data, NumBytes);
+            if (!IsDelta)
+            {
+                if (Data.Length < NumBytes)
+                    Data = new byte[NumBytes];
+                Array.Copy(copyFrom.Data, Data, NumBytes);
+            }
         }
 
         public void Serialize(NetOutgoingMessage lidgrenMsg)
         {
             lidgrenMsg.Write(Id);
-            lidgrenMsg.Write(NumBytes);
-            lidgrenMsg.Write(Data, 0, NumBytes);
+            lidgrenMsg.Write(Science);
+            lidgrenMsg.Write(ScienceCap);
+            lidgrenMsg.Write(DataScale);
+            lidgrenMsg.Write(ScientificValue);
+            lidgrenMsg.Write(SubjectValue);
+            lidgrenMsg.Write(WasTransmitted);
+            lidgrenMsg.Write(CollectedBy ?? string.Empty);
+            lidgrenMsg.Write(IsDelta);
+            if (!IsDelta)
+            {
+                lidgrenMsg.Write(NumBytes);
+                lidgrenMsg.Write(Data, 0, NumBytes);
+            }
         }
 
         public void Deserialize(NetIncomingMessage lidgrenMsg)
         {
             Id = lidgrenMsg.ReadString();
-
-            NumBytes = lidgrenMsg.ReadInt32();
-            if (Data.Length < NumBytes)
-                Data = new byte[NumBytes];
-
-            lidgrenMsg.ReadBytes(Data, 0, NumBytes);
+            Science = lidgrenMsg.ReadFloat();
+            ScienceCap = lidgrenMsg.ReadFloat();
+            DataScale = lidgrenMsg.ReadFloat();
+            ScientificValue = lidgrenMsg.ReadFloat();
+            SubjectValue = lidgrenMsg.ReadFloat();
+            WasTransmitted = lidgrenMsg.ReadBoolean();
+            lidgrenMsg.SkipPadBits();
+            CollectedBy = lidgrenMsg.ReadString();
+            IsDelta = lidgrenMsg.ReadBoolean();
+            lidgrenMsg.SkipPadBits();
+            if (!IsDelta)
+            {
+                NumBytes = lidgrenMsg.ReadInt32();
+                if (Data.Length < NumBytes)
+                    Data = new byte[NumBytes];
+                lidgrenMsg.ReadBytes(Data, 0, NumBytes);
+            }
         }
 
         public int GetByteCount()
         {
-            return Id.GetByteCount() + sizeof(int) + sizeof(byte) * NumBytes;
+            var size = Id.GetByteCount()
+                + sizeof(float) * 5
+                + 2 * sizeof(byte)  // WasTransmitted + IsDelta (1 bit each, padded to byte boundary)
+                + (CollectedBy ?? string.Empty).GetByteCount();
+            if (!IsDelta)
+                size += sizeof(int) + sizeof(byte) * NumBytes;
+            return size;
         }
     }
 }

--- a/LmpCommon/Message/Data/ShareProgress/ShareProgressScienceSubjectRevertMsgData.cs
+++ b/LmpCommon/Message/Data/ShareProgress/ShareProgressScienceSubjectRevertMsgData.cs
@@ -1,0 +1,49 @@
+using Lidgren.Network;
+using LmpCommon.Message.Types;
+
+namespace LmpCommon.Message.Data.ShareProgress
+{
+    /// <summary>
+    /// Sent by a client when it reverts to launch/editor so the server can restore
+    /// the science-subject state to the snapshot taken before that flight.
+    /// Each entry uses IsDelta=false so the server can reconstruct the full node.
+    /// </summary>
+    public class ShareProgressScienceSubjectRevertMsgData : ShareProgressBaseMsgData
+    {
+        internal ShareProgressScienceSubjectRevertMsgData() { }
+        public override ShareProgressMessageType ShareProgressMessageType => ShareProgressMessageType.ScienceSubjectRevert;
+        public override string ClassName { get; } = nameof(ShareProgressScienceSubjectRevertMsgData);
+
+        public int SubjectCount;
+        public ScienceSubjectInfo[] Subjects = new ScienceSubjectInfo[0];
+
+        internal override void InternalSerialize(NetOutgoingMessage lidgrenMsg)
+        {
+            base.InternalSerialize(lidgrenMsg);
+            lidgrenMsg.Write(SubjectCount);
+            for (var i = 0; i < SubjectCount; i++)
+                Subjects[i].Serialize(lidgrenMsg);
+        }
+
+        internal override void InternalDeserialize(NetIncomingMessage lidgrenMsg)
+        {
+            base.InternalDeserialize(lidgrenMsg);
+            SubjectCount = lidgrenMsg.ReadInt32();
+            if (Subjects.Length < SubjectCount)
+                Subjects = new ScienceSubjectInfo[SubjectCount];
+            for (var i = 0; i < SubjectCount; i++)
+            {
+                if (Subjects[i] == null) Subjects[i] = new ScienceSubjectInfo();
+                Subjects[i].Deserialize(lidgrenMsg);
+            }
+        }
+
+        internal override int InternalGetMessageSize()
+        {
+            var size = base.InternalGetMessageSize() + sizeof(int);
+            for (var i = 0; i < SubjectCount; i++)
+                size += Subjects[i].GetByteCount();
+            return size;
+        }
+    }
+}

--- a/LmpCommon/Message/Server/ShareProgressSrvMsg.cs
+++ b/LmpCommon/Message/Server/ShareProgressSrvMsg.cs
@@ -30,6 +30,7 @@ namespace LmpCommon.Message.Server
             [(ushort)ShareProgressMessageType.FacilityUpgrade] = typeof(ShareProgressFacilityUpgradeMsgData),
             [(ushort)ShareProgressMessageType.PartPurchase] = typeof(ShareProgressPartPurchaseMsgData),
             [(ushort)ShareProgressMessageType.ExperimentalPart] = typeof(ShareProgressExperimentalPartMsgData),
+            [(ushort)ShareProgressMessageType.ScienceSubjectRevert] = typeof(ShareProgressScienceSubjectRevertMsgData),
         };
 
         public override ServerMessageType MessageType => ServerMessageType.ShareProgress;

--- a/LmpCommon/Message/Types/ShareProgressMessageType.cs
+++ b/LmpCommon/Message/Types/ShareProgressMessageType.cs
@@ -13,5 +13,6 @@
         FacilityUpgrade = 8,
         PartPurchase = 9,
         ExperimentalPart = 10,
+        ScienceSubjectRevert = 11,
     }
 }

--- a/Server/Message/ShareProgressMsgReader.cs
+++ b/Server/Message/ShareProgressMsgReader.cs
@@ -47,6 +47,9 @@ namespace Server.Message
                 case ShareProgressMessageType.ExperimentalPart:
                     ShareExperimentalPartSystem.ExperimentalPartReceived(client, (ShareProgressExperimentalPartMsgData)data);
                     break;
+                case ShareProgressMessageType.ScienceSubjectRevert:
+                    ShareScienceSubjectSystem.ScienceSubjectRevertReceived(client, (ShareProgressScienceSubjectRevertMsgData)data);
+                    break;
             }
         }
     }

--- a/Server/System/Scenario/ScenarioScienceSubjectDataUpdater.cs
+++ b/Server/System/Scenario/ScenarioScienceSubjectDataUpdater.cs
@@ -1,6 +1,7 @@
 using LmpCommon.Message.Data.ShareProgress;
 using Server.Log;
 using System;
+using System.Globalization;
 using System.Linq;
 using System.Threading.Tasks;
 
@@ -9,7 +10,10 @@ namespace Server.System.Scenario
     public partial class ScenarioDataUpdater
     {
         /// <summary>
-        /// We received a science subject message so update the scenario file accordingly
+        /// We received a science subject message so update the scenario file accordingly.
+        /// For full payloads (IsDelta=false) we upsert the ConfigNode.
+        /// For delta payloads (IsDelta=true) we only patch the numeric fields on the existing node.
+        /// In both cases we apply merge logic: a lower science value never overwrites a higher one.
         /// </summary>
         public static void WriteScienceSubjectDataToFile(ScienceSubjectInfo scienceSubject)
         {
@@ -21,31 +25,10 @@ namespace Server.System.Scenario
                     {
                         if (!ScenarioStoreSystem.CurrentScenarios.TryGetValue("ResearchAndDevelopment", out var scenario)) return;
 
-                        var receivedNode = ParseClientConfigNode(scienceSubject.Data, scienceSubject.NumBytes, "Science");
-                        receivedNode.Parent = scenario;
-                        if (receivedNode.IsEmpty()) return;
-
-                        var receivedId = receivedNode.GetValue("id");
-                        if (receivedId == null)
-                        {
-                            LunaLog.Error("Science subject update received with no id — skipping");
-                            return;
-                        }
-
-                        var scienceNodes = scenario.GetNodes("Science").Select(v => v.Value);
-                        var specificNode = scienceNodes.FirstOrDefault(n =>
-                        {
-                            var id = n.GetValue("id");
-                            return id != null && id.Value == receivedId.Value;
-                        });
-                        if (specificNode != null)
-                        {
-                            scenario.ReplaceNode(specificNode, receivedNode);
-                        }
+                        if (scienceSubject.IsDelta)
+                            ApplyDeltaToExistingSubject(scenario, scienceSubject);
                         else
-                        {
-                            scenario.AddNode(receivedNode);
-                        }
+                            UpsertSubjectFromConfigNode(scenario, scienceSubject);
                     }
                 }
                 catch (Exception e)
@@ -53,6 +36,116 @@ namespace Server.System.Scenario
                     LunaLog.Error($"Error updating science subject scenario data: {e}");
                 }
             });
+        }
+
+        /// <summary>
+        /// Processes a revert snapshot from a client reverting to launch.
+        /// We apply merge logic: science never decreases if another player already submitted a higher value.
+        /// This protects other players' science from being rolled back by an unrelated revert.
+        /// </summary>
+        public static void WriteScienceSubjectRevertToFile(ShareProgressScienceSubjectRevertMsgData revert)
+        {
+            _ = Task.Run(() =>
+            {
+                try
+                {
+                    lock (Semaphore.GetOrAdd("ResearchAndDevelopment", new object()))
+                    {
+                        if (!ScenarioStoreSystem.CurrentScenarios.TryGetValue("ResearchAndDevelopment", out var scenario)) return;
+
+                        for (var i = 0; i < revert.SubjectCount; i++)
+                        {
+                            var subject = revert.Subjects[i];
+                            if (subject == null) continue;
+                            // Reuse normal delta path — merge logic prevents rolling back other players' science
+                            ApplyDeltaToExistingSubject(scenario, subject);
+                        }
+                    }
+                }
+                catch (Exception e)
+                {
+                    LunaLog.Error($"Error writing science subject revert to scenario: {e}");
+                }
+            });
+        }
+
+        // ------------------------------------------------------------------
+        // Private helpers
+        // ------------------------------------------------------------------
+
+        private static void UpsertSubjectFromConfigNode(LunaConfigNode.CfgNode.ConfigNode scenario, ScienceSubjectInfo subject)
+        {
+            var receivedNode = ParseClientConfigNode(subject.Data, subject.NumBytes, "Science");
+            receivedNode.Parent = scenario;
+            if (receivedNode.IsEmpty()) return;
+
+            var receivedId = receivedNode.GetValue("id");
+            if (receivedId == null)
+            {
+                LunaLog.Error("Science subject update received with no id — skipping");
+                return;
+            }
+
+            var scienceNodes = scenario.GetNodes("Science").Select(v => v.Value);
+            var specificNode = scienceNodes.FirstOrDefault(n =>
+            {
+                var id = n.GetValue("id");
+                return id != null && id.Value == receivedId.Value;
+            });
+
+            if (specificNode != null)
+            {
+                // Merge: never reduce science
+                var currentSciStr = specificNode.GetValue("sci")?.Value;
+                if (currentSciStr != null
+                    && float.TryParse(currentSciStr, NumberStyles.Float, CultureInfo.InvariantCulture, out var currentSci)
+                    && subject.Science < currentSci)
+                {
+                    LunaLog.Debug($"Ignoring full science subject for '{receivedId.Value}': incoming {subject.Science} < current {currentSci}");
+                    return;
+                }
+                scenario.ReplaceNode(specificNode, receivedNode);
+            }
+            else
+            {
+                scenario.AddNode(receivedNode);
+            }
+        }
+
+        private static void ApplyDeltaToExistingSubject(LunaConfigNode.CfgNode.ConfigNode scenario, ScienceSubjectInfo delta)
+        {
+            var scienceNodes = scenario.GetNodes("Science").Select(v => v.Value);
+            var existingNode = scienceNodes.FirstOrDefault(n =>
+            {
+                var id = n.GetValue("id");
+                return id != null && id.Value == delta.Id;
+            });
+
+            if (existingNode == null)
+            {
+                LunaLog.Warning($"Delta update for unknown science subject '{delta.Id}' — skipped (subject not yet discovered)");
+                return;
+            }
+
+            // Merge: never reduce science
+            var currentSciStr = existingNode.GetValue("sci")?.Value;
+            if (currentSciStr != null
+                && float.TryParse(currentSciStr, NumberStyles.Float, CultureInfo.InvariantCulture, out var currentSci)
+                && delta.Science < currentSci)
+            {
+                LunaLog.Debug($"Ignoring delta for '{delta.Id}': incoming {delta.Science} < current {currentSci}");
+                return;
+            }
+
+            PatchSubjectNode(existingNode, delta);
+        }
+
+        private static void PatchSubjectNode(LunaConfigNode.CfgNode.ConfigNode node, ScienceSubjectInfo delta)
+        {
+            node.UpdateValue("sci", delta.Science.ToString(CultureInfo.InvariantCulture));
+            node.UpdateValue("cap", delta.ScienceCap.ToString(CultureInfo.InvariantCulture));
+            node.UpdateValue("scv", delta.ScientificValue.ToString(CultureInfo.InvariantCulture));
+            node.UpdateValue("sbv", delta.SubjectValue.ToString(CultureInfo.InvariantCulture));
         }
     }
 }

--- a/Server/System/ShareScienceSubjectSystem.cs
+++ b/Server/System/ShareScienceSubjectSystem.cs
@@ -11,11 +11,18 @@ namespace Server.System
     {
         public static void ScienceSubjectReceived(ClientStructure client, ShareProgressScienceSubjectMsgData data)
         {
-            LunaLog.Debug($"Science experiment received: {data.ScienceSubject.Id}");
+            LunaLog.Debug($"Science experiment received: {data.ScienceSubject.Id} IsDelta={data.ScienceSubject.IsDelta}");
 
-            //send the science subject update to all other clients
             MessageQueuer.RelayMessage<ShareProgressSrvMsg>(client, data);
             ScenarioDataUpdater.WriteScienceSubjectDataToFile(data.ScienceSubject);
+        }
+
+        public static void ScienceSubjectRevertReceived(ClientStructure client, ShareProgressScienceSubjectRevertMsgData data)
+        {
+            LunaLog.Debug($"Science subject revert received from {client.PlayerName}: {data.SubjectCount} subjects");
+
+            MessageQueuer.RelayMessage<ShareProgressSrvMsg>(client, data);
+            ScenarioDataUpdater.WriteScienceSubjectRevertToFile(data);
         }
     }
 }


### PR DESCRIPTION
Science sync bandwidth:
- Replace full ConfigNode binary (~800 bytes) with delta format (~50 bytes) for repeat experiment updates; full payload only sent on first discovery per subject
- Add WasTransmitted and CollectedBy metadata to every science subject message
- Add ScienceSubjectRevert message type: on revert-to-launch, client sends a pre-flight snapshot so server and other clients can roll back collected science; merge logic (science never decreases) protects concurrent players' progress

Science correctness:
- Server-side merge: incoming science value is ignored if it is lower than the current stored value, preventing race conditions when two players run the same experiment simultaneously
- Client-side deduplication via high-water-mark per subject; out-of-order or duplicate packets no longer cause unexpected science point changes
- Delta updates correctly apply to existing subjects; first-discovery full payloads are upserted regardless

Science Lab sync:
- Add dataProcessed field to ModuleScienceLab.xml so the lab processing state is included in the existing VesselPartSyncField sync path

Part UI field debounce:
- Buffer outgoing part UI field changes for 200ms before sending; rapid slider adjustments now coalesce into a single packet instead of flooding the network

Vessel position:
- Cache UpdateIntervalLockedToUnity and SecondaryVesselUpdatesUpdateIntervalLockedToUnity; values are recomputed only when Time.fixedDeltaTime changes instead of every frame
- Re-enable SendUnloadedSecondaryVesselPositionUpdates for abandoned/parked vessels

VesselProto stability:
- Wrap PrepareAndSendProtoVessel in try/catch; serialisation exceptions are logged with vessel id/name instead of silently crashing the background thread pool; non-debris vessels with 0-byte serialisation now produce a warning instead of being silently dropped

Group system GC:
- Remove intermediate List<string> allocations in AddMember, RemoveMember, and JoinGroup; build updated arrays directly and clone only once per operation

https://claude.ai/code/session_013Svqs8MSrPcfvLHosESs5F

<!-- Thank you for contributing to LMP!

If you are adding a dedicated server, please read https://github.com/LunaMultiplayer/LunaMultiplayer/wiki/Dedicated-server first,
especially:
* Your server doesn't need to be listed as "dedicated server" to show up in the server browser.
* Dedicated servers should have either a static IP address or working DynDNS
* Port forwarding should be set up statically, or at least UPnP needs to work reliably
* Dedicated servers should not be password protected
* Dedicated servers need to be available 24/7

Please confirm that you have read and verified all of the above.
-->
### Fixes included in this PR:

### Changes proposed in this PR:
