### PR TITLE
Fix incorrect version numbers in 11 files

### DIFF
--- a/.github/ISSUE_TEMPLATE/BugReportTemplate.md
+++ b/.github/ISSUE_TEMPLATE/BugReportTemplate.md
@@ -11,7 +11,7 @@ Note: All of the text in these brackets will not be shown. No need to remove the
 
 <!--
 If you are using a nighly build of LMP, make sure to include the build number.
-For example: 0.29.3.*757*
+For example: 0.29.1.*757*
 -->
 
 ## Details:
@@ -19,7 +19,7 @@ For example: 0.29.3.*757*
 
 Which OS are you using? (e.g. Windows, Mac, Linux):
 What version of KSP are you running? (e.g. 1.12.5):
-What version of LMP are you playing? (e.g. 0.29.0, 0.29.3.757):
+What version of LMP are you playing? (e.g. 0.29.0, 0.29.1.757):
 Which KSP DLCs do you have? (e.g. Breaking Ground, Making History):
 
 <!-- The logs are found at "Kerbal Space Program/KSP.log" and "%appdata%/../LocalLow/Squad/Kerbal Space Program/output_log.txt". Make sure to attach both. -->

--- a/Lidgren/Properties/AssemblyInfo.cs
+++ b/Lidgren/Properties/AssemblyInfo.cs
@@ -14,9 +14,9 @@ using System.Runtime.InteropServices;
 [assembly: ComVisible(false)]
 [assembly: Guid("78f2a988-46e1-4fc4-b7b4-dd2cbe46da6a")]
 
-[assembly: AssemblyVersion("0.29.3")]
-[assembly: AssemblyFileVersion("0.29.3")]
-[assembly: AssemblyInformationalVersion("0.29.3-compiled")]
+[assembly: AssemblyVersion("0.30.0")]
+[assembly: AssemblyFileVersion("0.30.0")]
+[assembly: AssemblyInformationalVersion("0.30.0-compiled")]
 
 [assembly: System.CLSCompliant(true)]
 [assembly: InternalsVisibleTo("LmpCommonTest")]

--- a/LmpClient/Properties/AssemblyInfo.cs
+++ b/LmpClient/Properties/AssemblyInfo.cs
@@ -14,9 +14,9 @@ using System.Runtime.CompilerServices;
 [assembly: ComVisible(false)]
 [assembly: Guid("cc8e38bb-d6d5-4bb9-ab74-a3a1a11ddc8d")]
 
-[assembly: AssemblyVersion("0.29.3")]
-[assembly: AssemblyFileVersion("0.29.3")]
-[assembly: AssemblyInformationalVersion("0.29.3-compiled")]
+[assembly: AssemblyVersion("0.30.0")]
+[assembly: AssemblyFileVersion("0.30.0")]
+[assembly: AssemblyInformationalVersion("0.30.0-compiled")]
 
 [assembly: TypeForwardedTo(typeof(LmpCommon.PlayerStatus))]
 [assembly: TypeForwardedTo(typeof(LmpCommon.Message.ClientMessageFactory))]

--- a/LmpCommon/Properties/AssemblyInfo.cs
+++ b/LmpCommon/Properties/AssemblyInfo.cs
@@ -13,5 +13,5 @@ using System.Runtime.InteropServices;
 [assembly: ComVisible(false)]
 [assembly: Guid("d4832184-1a94-4ffc-8d4c-3e3214f109f1")]
 
-[assembly: AssemblyVersion("0.29.3")]
-[assembly: AssemblyFileVersion("0.29.3")]
+[assembly: AssemblyVersion("0.30.0")]
+[assembly: AssemblyFileVersion("0.30.0")]

--- a/LmpGlobal/Properties/AssemblyInfo.cs
+++ b/LmpGlobal/Properties/AssemblyInfo.cs
@@ -13,5 +13,5 @@ using System.Runtime.InteropServices;
 [assembly: ComVisible(false)]
 [assembly: Guid("d558a5a6-3fae-4628-8d37-6dae155b645d")]
 
-[assembly: AssemblyVersion("0.29.3")]
-[assembly: AssemblyFileVersion("0.29.3")]
+[assembly: AssemblyVersion("0.30.0")]
+[assembly: AssemblyFileVersion("0.30.0")]

--- a/LmpMasterServer/Properties/AssemblyInfo.cs
+++ b/LmpMasterServer/Properties/AssemblyInfo.cs
@@ -13,6 +13,6 @@ using System.Runtime.InteropServices;
 [assembly: ComVisible(false)]
 [assembly: Guid("13549ede-d540-47ba-86bc-731bb7dd7bfb")]
 
-[assembly: AssemblyVersion("0.29.3")]
-[assembly: AssemblyFileVersion("0.29.3")]
-[assembly: AssemblyInformationalVersion("0.29.3-compiled")]
+[assembly: AssemblyVersion("0.30.0")]
+[assembly: AssemblyFileVersion("0.30.0")]
+[assembly: AssemblyInformationalVersion("0.30.0-compiled")]

--- a/LmpUpdater/Properties/AssemblyInfo.cs
+++ b/LmpUpdater/Properties/AssemblyInfo.cs
@@ -13,6 +13,6 @@ using System.Runtime.InteropServices;
 [assembly: ComVisible(false)]
 [assembly: Guid("35a57b77-236e-492c-b003-1f8fc2f544f3")]
 
-[assembly: AssemblyVersion("0.29.3")]
-[assembly: AssemblyFileVersion("0.29.3")]
-[assembly: AssemblyInformationalVersion("0.29.3-compiled")]
+[assembly: AssemblyVersion("0.30.0")]
+[assembly: AssemblyFileVersion("0.30.0")]
+[assembly: AssemblyInformationalVersion("0.30.0-compiled")]

--- a/LunaMultiplayer.version
+++ b/LunaMultiplayer.version
@@ -8,8 +8,8 @@
     },
     "VERSION": {
         "MAJOR": 0,
-        "MINOR": 29,
-        "PATCH": 3
+        "MINOR": 30,
+        "PATCH": 0
     },
     "KSP_VERSION": {
         "MAJOR": 1,

--- a/MasterServer/Properties/AssemblyInfo.cs
+++ b/MasterServer/Properties/AssemblyInfo.cs
@@ -13,6 +13,6 @@ using System.Runtime.InteropServices;
 [assembly: ComVisible(false)]
 [assembly: Guid("776706b0-f5a1-43a5-b13a-1ada5e77d0a5")]
 
-[assembly: AssemblyVersion("0.29.3")]
-[assembly: AssemblyFileVersion("0.29.3")]
-[assembly: AssemblyInformationalVersion("0.29.3-compiled")]
+[assembly: AssemblyVersion("0.30.0")]
+[assembly: AssemblyFileVersion("0.30.0")]
+[assembly: AssemblyInformationalVersion("0.30.0-compiled")]

--- a/Server/Properties/AssemblyInfo.cs
+++ b/Server/Properties/AssemblyInfo.cs
@@ -14,8 +14,8 @@ using System.Runtime.InteropServices;
 [assembly: ComVisible(false)]
 [assembly: Guid("fa6e9184-e243-49cc-94fa-ac557493b900")]
 
-[assembly: AssemblyVersion("0.29.3")]
-[assembly: AssemblyFileVersion("0.29.3")]
-[assembly: AssemblyInformationalVersion("0.29.3-compiled")]
+[assembly: AssemblyVersion("0.30.0")]
+[assembly: AssemblyFileVersion("0.30.0")]
+[assembly: AssemblyInformationalVersion("0.30.0-compiled")]
 
 [assembly: InternalsVisibleTo("ServerTest")]

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -22,7 +22,7 @@ image: Visual Studio 2022
 #---------------------------------#
 
 environment:
-  smallversion: 0.29.3
+  smallversion: 0.30.0
   WEBHOOK_URL:
     secure: bhCOtyDF+wInocIkKfUQdxpM4csyVv7cxhUGz0NzLnFrlEZsaviEDJeDbctuv4NBM4xPkl4Wpv3rb6VwNcvEr8IWW5Te0P/kx1VeNMD5espcLKzMwy46shi630b3wvIipOeBnupc6nsiw7/2liuNhJkvjdyu4wxQXVDVWNSi+t0=
   ZIPPASSWORD:


### PR DESCRIPTION
### Fixes included in this PR:
- Fix the nightly builds being labelled as `0.29.3` when they're actually `0.30.0`
- Fix the issue template having a `0.29.1.x` version number being replaced with `0.29.3.x` (a version that doesn't actually exist)
### Changes proposed in this PR:
- Changes made for the above fixes
- Nothing else