### PR TITLE
Ignore non-local addresses

### DIFF
--- a/LmpClient/Network/NetworkServerList.cs
+++ b/LmpClient/Network/NetworkServerList.cs
@@ -109,7 +109,10 @@ namespace LmpClient.Network
                 var amListeningOnIPv6 =
                     NetworkMain.ClientConnection.Socket.AddressFamily == AddressFamily.InterNetworkV6;
 
-                if (ServerIsInLocalLan(serverInfo.ExternalEndpoint) || (amListeningOnIPv6 && ServerIsInLocalLan(serverInfo.InternalEndpoint6)))
+                // Ignore the 255.255.255.255 address (and IPv6 equivalent) as a local address
+                bool isValidInternalEndpoint = !(serverInfo.InternalEndpoint.Address.Equals(IPAddress.None) || (amListeningOnIPv6 && serverInfo.InternalEndpoint6.Address.Equals(IPAddress.IPv6None)));
+
+                if ((ServerIsInLocalLan(serverInfo.ExternalEndpoint) || (amListeningOnIPv6 && ServerIsInLocalLan(serverInfo.InternalEndpoint6))) && isValidInternalEndpoint)
                 {
                     LunaLog.Log("Server is in LAN. Skipping NAT punch");
                     var endpoints = new List<IPEndPoint>();

--- a/LmpClient/Network/NetworkServerList.cs
+++ b/LmpClient/Network/NetworkServerList.cs
@@ -109,8 +109,10 @@ namespace LmpClient.Network
                 var amListeningOnIPv6 =
                     NetworkMain.ClientConnection.Socket.AddressFamily == AddressFamily.InterNetworkV6;
 
-                // Ignore the 255.255.255.255 address (and IPv6 equivalent) as a local address
-                bool isValidInternalEndpoint = !(serverInfo.InternalEndpoint.Address.Equals(IPAddress.None) || (amListeningOnIPv6 && serverInfo.InternalEndpoint6.Address.Equals(IPAddress.IPv6None)));
+                // Ignore the loopback addresses when checking if the server is on the local network
+                // The server will itself never use one of these as an internal address, so it must have been a non-local address to begin with.
+                bool isValidInternalEndpoint = !(IPAddress.IsLoopback(serverInfo.InternalEndpoint.Address) ||
+                           (amListeningOnIPv6 && IPAddress.IsLoopback(serverInfo.InternalEndpoint6.Address)));
 
                 if ((ServerIsInLocalLan(serverInfo.ExternalEndpoint) || (amListeningOnIPv6 && ServerIsInLocalLan(serverInfo.InternalEndpoint6))) && isValidInternalEndpoint)
                 {

--- a/LmpMasterServer/Structure/Server.cs
+++ b/LmpMasterServer/Structure/Server.cs
@@ -37,8 +37,18 @@ namespace LmpMasterServer.Structure
 
         public void Update(MsRegisterServerMsgData msg, IPEndPoint externalEndpoint)
         {
-            InternalEndpoint = msg.InternalEndpoint;
-            InternalEndpoint6 = msg.InternalEndpoint6;
+            if (!IsLocalIpAddress(msg.InternalEndpoint.Address))
+            {
+                // 255.255.255.255:port fallback address
+                // Clients can just ignore this address when checking if the server is on it's local network
+                InternalEndpoint = new IPEndPoint(IPAddress.None, msg.InternalEndpoint.Port);
+                InternalEndpoint6 = new IPEndPoint(IPAddress.IPv6None, msg.InternalEndpoint.Port);
+            }
+            else
+            {
+                InternalEndpoint = msg.InternalEndpoint;
+                InternalEndpoint6 = msg.InternalEndpoint6;
+            }
 
             // Due to NAT, non-static IP addresses and roaming the endpoint may change during the lifetime of a server.
             if (!externalEndpoint.Equals(ExternalEndpoint) && !IsLocalIpAddress(externalEndpoint.Address))

--- a/LmpMasterServer/Structure/Server.cs
+++ b/LmpMasterServer/Structure/Server.cs
@@ -37,7 +37,7 @@ namespace LmpMasterServer.Structure
 
         public void Update(MsRegisterServerMsgData msg, IPEndPoint externalEndpoint)
         {
-            if (!IsLocalIpAddress(msg.InternalEndpoint.Address))
+            if (msg.InternalEndpoint == null || !IsLocalIpAddress(msg.InternalEndpoint.Address))
             {
                 // 255.255.255.255:port fallback address
                 // Clients can just ignore this address when checking if the server is on it's local network

--- a/LmpMasterServer/Structure/Server.cs
+++ b/LmpMasterServer/Structure/Server.cs
@@ -42,7 +42,7 @@ namespace LmpMasterServer.Structure
                 // 127.0.0.1:port fallback address
                 // Clients can just ignore this address when checking if the server is on it's local network
                 InternalEndpoint = new IPEndPoint(IPAddress.Loopback, msg.InternalEndpoint.Port);
-                InternalEndpoint6 = new IPEndPoint(IPAddress.IPv6Loopback, msg.InternalEndpoint.Port);
+                InternalEndpoint6 = new IPEndPoint(IPAddress.IPv6Loopback, msg.InternalEndpoint6.Port);
             }
             else
             {

--- a/LmpMasterServer/Structure/Server.cs
+++ b/LmpMasterServer/Structure/Server.cs
@@ -39,10 +39,10 @@ namespace LmpMasterServer.Structure
         {
             if (msg.InternalEndpoint == null || !IsLocalIpAddress(msg.InternalEndpoint.Address))
             {
-                // 255.255.255.255:port fallback address
+                // 127.0.0.1:port fallback address
                 // Clients can just ignore this address when checking if the server is on it's local network
-                InternalEndpoint = new IPEndPoint(IPAddress.None, msg.InternalEndpoint.Port);
-                InternalEndpoint6 = new IPEndPoint(IPAddress.IPv6None, msg.InternalEndpoint.Port);
+                InternalEndpoint = new IPEndPoint(IPAddress.Loopback, msg.InternalEndpoint.Port);
+                InternalEndpoint6 = new IPEndPoint(IPAddress.IPv6Loopback, msg.InternalEndpoint.Port);
             }
             else
             {

--- a/LmpMasterServer/Structure/Server.cs
+++ b/LmpMasterServer/Structure/Server.cs
@@ -37,7 +37,7 @@ namespace LmpMasterServer.Structure
 
         public void Update(MsRegisterServerMsgData msg, IPEndPoint externalEndpoint)
         {
-            if (msg.InternalEndpoint != null || !IsLocalIpAddress(msg.InternalEndpoint.Address))
+            if (msg.InternalEndpoint != null && !IsLocalIpAddress(msg.InternalEndpoint.Address))
             {
                 // 127.0.0.1:port fallback address
                 // Clients can just ignore this address when checking if the server is on it's local network

--- a/LmpMasterServer/Structure/Server.cs
+++ b/LmpMasterServer/Structure/Server.cs
@@ -37,7 +37,7 @@ namespace LmpMasterServer.Structure
 
         public void Update(MsRegisterServerMsgData msg, IPEndPoint externalEndpoint)
         {
-            if (msg.InternalEndpoint == null || !IsLocalIpAddress(msg.InternalEndpoint.Address))
+            if (msg.InternalEndpoint != null || !IsLocalIpAddress(msg.InternalEndpoint.Address))
             {
                 // 127.0.0.1:port fallback address
                 // Clients can just ignore this address when checking if the server is on it's local network


### PR DESCRIPTION
### Fixes included in this PR:
- Fix #653
### Changes proposed in this PR:
- The master server now checks whether the internal endpoint is a local IP address
- If not, it sets the internal IPv4 and IPv6 addresses to `255.255.255.255` (and the IPv6 equivalent)
- The client then checks if the appropriate addresses are `255.255.255.255` (or the IPv6 equivalent) or not and only connects on LAN if it isn't.