### PR TITLE
WTK LMP Server added to Dedicated Server List

### DIFF
--- a/MasterServersList/DedicatedServersList.txt
+++ b/MasterServersList/DedicatedServersList.txt
@@ -9,3 +9,6 @@ ksp-na.styxnet.xyz:2140
 #Cygnus Servers
 abritin.space:8800
 abritin.space:9100
+
+#WTK Servers
+play.waydethekiwi.com:47786


### PR DESCRIPTION
<!-- Thank you for contributing to LMP!

If you are adding a dedicated server, please read https://github.com/LunaMultiplayer/LunaMultiplayer/wiki/Dedicated-server first,
especially:
* Your server doesn't need to be listed as "dedicated server" to show up in the server browser.
* Dedicated servers should have either a static IP address or working DynDNS
* Port forwarding should be set up statically, or at least UPnP needs to work reliably
* Dedicated servers should not be password protected
* Dedicated servers need to be available 24/7

Please confirm that you have read and verified all of the above.
-->
### Fixes included in this PR:

### Changes proposed in this PR:
Adding Dedicated Server to list