### PR TITLE
0_29_3-PR1: Core Runtime and Network Fixes

### DIFF
--- a/Lidgren/NetConnection.cs
+++ b/Lidgren/NetConnection.cs
@@ -479,6 +479,9 @@ namespace Lidgren.Network
 					// Unusual situation where server is actually already known, but got a nat introduction - oh well, lets handle it as usual
 					m_peer.HandleNatIntroduction(ptr);
 					break;
+				case NetMessageType.NatPunchMessage:
+					m_peer.LogDebug("Received NAT Punch Message");
+					break;
 				default:
 					m_peer.LogWarning("Connection received unhandled library message: " + tp);
 					break;

--- a/Lidgren/NetConnection.cs
+++ b/Lidgren/NetConnection.cs
@@ -479,9 +479,6 @@ namespace Lidgren.Network
 					// Unusual situation where server is actually already known, but got a nat introduction - oh well, lets handle it as usual
 					m_peer.HandleNatIntroduction(ptr);
 					break;
-				case NetMessageType.NatPunchMessage:
-					m_peer.LogDebug("Received NAT Punch Message");
-					break;
 				default:
 					m_peer.LogWarning("Connection received unhandled library message: " + tp);
 					break;

--- a/LmpClient/Network/NetworkReceiver.cs
+++ b/LmpClient/Network/NetworkReceiver.cs
@@ -55,6 +55,8 @@ namespace LmpClient.Network
 {
     public class NetworkReceiver
     {
+        private const string BenignNatPunchUnhandledWarning = "Connection received unhandled library message: NatPunchMessage";
+
         /// <summary>
         /// Main receiving thread. Here we map each received message to the specific system
         /// </summary>
@@ -81,7 +83,11 @@ namespace LmpClient.Network
                                 LunaLog.Log($"[Lidgren VERBOSE] {msg.ReadString()}");
                                 break;
                             case NetIncomingMessageType.WarningMessage:
-                                LunaLog.Log($"[Lidgren WARNING] {msg.ReadString()}");
+                                var warningText = msg.ReadString();
+                                if (!string.Equals(warningText, BenignNatPunchUnhandledWarning, StringComparison.Ordinal))
+                                {
+                                    LunaLog.Log($"[Lidgren WARNING] {warningText}");
+                                }
                                 break;
                             case NetIncomingMessageType.NatIntroductionSuccess:
                                 NetworkServerList.HandleNatIntroductionSuccess(msg);

--- a/LmpCommon/LmpCommon.csproj
+++ b/LmpCommon/LmpCommon.csproj
@@ -9,6 +9,7 @@
   <ItemGroup>
     <PackageReference Include="CachedQuickLz" Version="1.3.1" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
+    <PackageReference Include="System.Net.Http" Version="4.3.4" Condition="'$(TargetFramework)' == 'net472'" />
   </ItemGroup>
 
   <ItemGroup>

--- a/LmpCommon/Message/Data/Vessel/VesselPartSyncFieldMsgData.cs
+++ b/LmpCommon/Message/Data/Vessel/VesselPartSyncFieldMsgData.cs
@@ -146,7 +146,7 @@ namespace LmpCommon.Message.Data.Vessel
                     break;
                 case PartSyncFieldType.Quaternion:
                     for (var i = 0; i < 4; i++)
-                        VectorValue[i] = lidgrenMsg.ReadFloat();
+                        QuaternionValue[i] = lidgrenMsg.ReadFloat();
                     break;
                 case PartSyncFieldType.Object:
                 case PartSyncFieldType.String:
@@ -203,6 +203,7 @@ namespace LmpCommon.Message.Data.Vessel
                 case PartSyncFieldType.Quaternion:
                     msgSize += sizeof(float) * 4;
                     break;
+                case PartSyncFieldType.Object:
                 case PartSyncFieldType.String:
                     msgSize += StrValue.GetByteCount();
                     break;

--- a/LmpCommon/RepoRetrievers/BannedIpsRetriever.cs
+++ b/LmpCommon/RepoRetrievers/BannedIpsRetriever.cs
@@ -7,8 +7,6 @@ using System.Linq;
 using System.Net;
 using System.Threading.Tasks;
 
-#pragma warning disable SYSLIB0014
-
 namespace LmpCommon.RepoRetrievers
 {
     /// <summary>
@@ -17,20 +15,24 @@ namespace LmpCommon.RepoRetrievers
     public static class BannedIpsRetriever
     {
         private static readonly ConcurrentHashSet<IPAddress> PrivBannedIPs = new ConcurrentHashSet<IPAddress>();
+        private static readonly object RefreshLock = new object();
+
         private static ConcurrentHashSet<IPAddress> BannedIps
         {
             get
             {
+                var now = LunaComputerTime.UtcNow;
                 if (_lastRequestTime == DateTime.MinValue)
                 {
-                    //Run syncronously if it's the first time
+                    //Run synchronously if it's the first time
                     RefreshBannedIps();
-                    _lastRequestTime = LunaComputerTime.UtcNow;
                 }
-                else if (LunaComputerTime.UtcNow - _lastRequestTime > MaxRequestInterval)
+                else if (now - _lastRequestTime > MaxRequestInterval)
                 {
-                    _ = Task.Run(() => RefreshBannedIps());
-                    _lastRequestTime = LunaComputerTime.UtcNow;
+                    // Update the timestamp eagerly so concurrent callers don't schedule
+                    // a flurry of background refreshes before the first one completes.
+                    _lastRequestTime = now;
+                    Task.Run(RefreshBannedIps);
                 }
 
                 return PrivBannedIPs;
@@ -46,22 +48,40 @@ namespace LmpCommon.RepoRetrievers
         }
 
         /// <summary>
-        /// Download the banned ips list from the <see cref="RepoConstants.BannedIpListUrl"/>, stored in <see cref="BannedIps"/>
+        /// Kick off an asynchronous refresh so the banned-ip cache is populated as early
+        /// as possible. Safe to call before any <see cref="IsBanned"/> call; subsequent
+        /// refreshes are coalesced via <see cref="MaxRequestInterval"/>.
         /// </summary>
-        public static void RefreshBannedIps()
+        public static void Prewarm()
         {
-            try
+            Task.Run(RefreshBannedIps);
+        }
+
+        /// <summary>
+        /// Download the banned ips list from <see cref="RepoConstants.BannedIpListUrl"/>
+        /// and store the correctly formed entries in <see cref="PrivBannedIPs"/>.
+        /// Concurrent calls are serialized; calls that arrive while a recent refresh is
+        /// still considered fresh are coalesced.
+        /// </summary>
+        private static void RefreshBannedIps()
+        {
+            lock (RefreshLock)
             {
-                ServicePointManager.ServerCertificateValidationCallback = GithubCertification.MyRemoteCertificateValidationCallback;
-                using (var client = new WebClient())
-                using (var stream = client.OpenRead(RepoConstants.BannedIpListUrl))
+                // Another caller already refreshed recently; skip to avoid stomping the set.
+                if (_lastRequestTime != DateTime.MinValue && LunaComputerTime.UtcNow - _lastRequestTime < MaxRequestInterval)
+                    return;
+
+                try
                 {
+                    ServicePointManager.ServerCertificateValidationCallback = GithubCertification.MyRemoteCertificateValidationCallback;
+                    using (var client = new WebClient())
+                    using (var stream = client.OpenRead(RepoConstants.BannedIpListUrl))
                     using (var reader = new StreamReader(stream))
                     {
                         var content = reader.ReadToEnd();
                         var ips = content
                             .Split('\n')
-                            .Select(s => s.Trim()) // Trim whitespace and \r characters in case of Windows line breaks
+                            .Select(s => s.Trim()) // Trim whitespace and \r in case of Windows line breaks
                             .Where(s => !s.StartsWith("#") && !string.IsNullOrWhiteSpace(s))
                             .ToArray();
 
@@ -69,24 +89,21 @@ namespace LmpCommon.RepoRetrievers
 
                         foreach (var ip in ips)
                         {
-                            try
+                            if (IPAddress.TryParse(ip, out var ipAddr))
                             {
-                                if (IPAddress.TryParse(ip, out var ipAddr))
-                                {
-                                    PrivBannedIPs.Add(ipAddr);
-                                }
-                            }
-                            catch (Exception)
-                            {
-                                //Ignore the bad server
+                                PrivBannedIPs.Add(ipAddr);
                             }
                         }
                     }
                 }
-            }
-            catch (Exception)
-            {
-                //Ignored
+                catch (Exception)
+                {
+                    //Ignored
+                }
+
+                // Always update so failures fall back to the normal periodic cadence
+                // rather than retrying synchronously on every IsBanned call.
+                _lastRequestTime = LunaComputerTime.UtcNow;
             }
         }
     }

--- a/LmpCommon/RepoRetrievers/BannedIpsRetriever.cs
+++ b/LmpCommon/RepoRetrievers/BannedIpsRetriever.cs
@@ -5,6 +5,7 @@ using System;
 using System.IO;
 using System.Linq;
 using System.Net;
+using System.Net.Http;
 using System.Threading.Tasks;
 
 namespace LmpCommon.RepoRetrievers
@@ -73,9 +74,12 @@ namespace LmpCommon.RepoRetrievers
 
                 try
                 {
-                    ServicePointManager.ServerCertificateValidationCallback = GithubCertification.MyRemoteCertificateValidationCallback;
-                    using (var client = new WebClient())
-                    using (var stream = client.OpenRead(RepoConstants.BannedIpListUrl))
+                    var handler = new HttpClientHandler();
+                    handler.ServerCertificateCustomValidationCallback = (httpRequestMessage, cert, certChain, policyErrors) =>
+                        GithubCertification.MyRemoteCertificateValidationCallback(null, cert, certChain, policyErrors);
+
+                    using (var client = new HttpClient(handler))
+                    using (var stream = client.GetStreamAsync(RepoConstants.BannedIpListUrl).Result)
                     using (var reader = new StreamReader(stream))
                     {
                         var content = reader.ReadToEnd();

--- a/LmpMasterServer/EntryPoint.cs
+++ b/LmpMasterServer/EntryPoint.cs
@@ -66,12 +66,30 @@ namespace LmpMasterServer
                 Lidgren.MasterServer.RunServer = true;
                 Http.Handlers.WebHandler.InitWebFiles();
                 LunaHttpServer.Start();
-#pragma warning disable VSTHRD110 // Observe result of async calls
-                Task.Run(DedicatedServerRetriever.RefreshDedicatedServersListAsync);
+
+                // Fire background tasks with proper exception handling
+                Task.Run(DedicatedServerRetriever.RefreshDedicatedServersListAsync)
+                    .ContinueWith(t => 
+                    {
+                        if (t.IsFaulted)
+                            LunaLog.Error($"Failed to refresh dedicated servers: {t.Exception?.InnerException?.Message}");
+                    }, TaskScheduler.Default);
+
                 BannedIpsRetriever.Prewarm();
-                Task.Run(MasterServerPortMapper.RefreshUpnpPortAsync);
-                Task.Run(Lidgren.MasterServer.StartAsync);
-#pragma warning restore VSTHRD110 // Observe result of async calls
+
+                Task.Run(MasterServerPortMapper.RefreshUpnpPortAsync)
+                    .ContinueWith(t =>
+                    {
+                        if (t.IsFaulted)
+                            LunaLog.Error($"Failed to refresh UPnP port: {t.Exception?.InnerException?.Message}");
+                    }, TaskScheduler.Default);
+
+                Task.Run(Lidgren.MasterServer.StartAsync)
+                    .ContinueWith(t =>
+                    {
+                        if (t.IsFaulted)
+                            LunaLog.Error($"Lidgren server startup failed: {t.Exception?.InnerException?.Message}");
+                    }, TaskScheduler.Default);
             }
         }
 

--- a/LmpMasterServer/EntryPoint.cs
+++ b/LmpMasterServer/EntryPoint.cs
@@ -35,10 +35,12 @@ namespace LmpMasterServer
             {
                 ConsoleUtil.DisableConsoleQuickEdit();
 
+#pragma warning disable CA1416 // Platform compatibility check via Common.PlatformIsWindows()
                 Console.Title = $"LMP MasterServer {LmpVersioning.CurrentVersion}";
 
                 if (IsNightly)
                     Console.Title += " NIGHTLY";
+#pragma warning restore CA1416
             }
 
             Console.OutputEncoding = Encoding.UTF8;
@@ -64,10 +66,12 @@ namespace LmpMasterServer
                 Lidgren.MasterServer.RunServer = true;
                 Http.Handlers.WebHandler.InitWebFiles();
                 LunaHttpServer.Start();
+#pragma warning disable VSTHRD110 // Observe result of async calls
                 Task.Run(DedicatedServerRetriever.RefreshDedicatedServersListAsync);
                 BannedIpsRetriever.Prewarm();
                 Task.Run(MasterServerPortMapper.RefreshUpnpPortAsync);
                 Task.Run(Lidgren.MasterServer.StartAsync);
+#pragma warning restore VSTHRD110 // Observe result of async calls
             }
         }
 

--- a/LmpMasterServer/EntryPoint.cs
+++ b/LmpMasterServer/EntryPoint.cs
@@ -64,10 +64,10 @@ namespace LmpMasterServer
                 Lidgren.MasterServer.RunServer = true;
                 Http.Handlers.WebHandler.InitWebFiles();
                 LunaHttpServer.Start();
-                _ = Task.Run(DedicatedServerRetriever.RefreshDedicatedServersListAsync);
-                _ = Task.Run(() => BannedIpsRetriever.RefreshBannedIps());
-                _ = Task.Run(MasterServerPortMapper.RefreshUpnpPortAsync);
-                _ = Task.Run(Lidgren.MasterServer.StartAsync);
+                Task.Run(DedicatedServerRetriever.RefreshDedicatedServersListAsync);
+                BannedIpsRetriever.Prewarm();
+                Task.Run(MasterServerPortMapper.RefreshUpnpPortAsync);
+                Task.Run(Lidgren.MasterServer.StartAsync);
             }
         }
 

--- a/LmpMasterServer/EntryPoint.cs
+++ b/LmpMasterServer/EntryPoint.cs
@@ -68,7 +68,8 @@ namespace LmpMasterServer
                 LunaHttpServer.Start();
 
                 // Fire background tasks with proper exception handling
-                Task.Run(DedicatedServerRetriever.RefreshDedicatedServersListAsync)
+                // Use discard _ to explicitly indicate fire-and-forget pattern
+                _ = Task.Run(DedicatedServerRetriever.RefreshDedicatedServersListAsync)
                     .ContinueWith(t => 
                     {
                         if (t.IsFaulted)
@@ -77,14 +78,14 @@ namespace LmpMasterServer
 
                 BannedIpsRetriever.Prewarm();
 
-                Task.Run(MasterServerPortMapper.RefreshUpnpPortAsync)
+                _ = Task.Run(MasterServerPortMapper.RefreshUpnpPortAsync)
                     .ContinueWith(t =>
                     {
                         if (t.IsFaulted)
                             LunaLog.Error($"Failed to refresh UPnP port: {t.Exception?.InnerException?.Message}");
                     }, TaskScheduler.Default);
 
-                Task.Run(Lidgren.MasterServer.StartAsync)
+                _ = Task.Run(Lidgren.MasterServer.StartAsync)
                     .ContinueWith(t =>
                     {
                         if (t.IsFaulted)

--- a/Server/Server/LidgrenServer.cs
+++ b/Server/Server/LidgrenServer.cs
@@ -18,6 +18,8 @@ namespace Server.Server
 {
     public class LidgrenServer
     {
+        private const string BenignNatPunchUnhandledWarning = "Connection received unhandled library message: NatPunchMessage";
+
         public static NetServer Server { get; private set; }
         public static MessageReceiver ClientMessageReceiver { get; set; } = new MessageReceiver();
 
@@ -130,7 +132,11 @@ namespace Server.Server
                                     ClientMessageReceiver.ReceiveCallback(client, msg);
                                     break;
                                 case NetIncomingMessageType.WarningMessage:
-                                    LunaLog.Warning(msg.ReadString());
+                                    var warningText = msg.ReadString();
+                                    if (!string.Equals(warningText, BenignNatPunchUnhandledWarning, StringComparison.Ordinal))
+                                    {
+                                        LunaLog.Warning(warningText);
+                                    }
                                     break;
                                 case NetIncomingMessageType.DebugMessage:
                                     LunaLog.NetworkDebug(msg.ReadString());


### PR DESCRIPTION
Cherry-picked/layered PR1 content from AdmiralRadish fork for 0_29_3 backport series
Scope:
- NetConnection NatPunch handling
- VesselPartSyncFieldMsgData deserialization fix
- Banned IP retriever/entrypoint runtime fixes