### PR TITLE
Time correction fix

### DIFF
--- a/LmpClient/Extensions/VesselExtension.cs
+++ b/LmpClient/Extensions/VesselExtension.cs
@@ -49,9 +49,11 @@ namespace LmpClient.Extensions
             if (vessel.situation <= Vessel.Situations.FLYING)
             {
                 // Account for the rotation of the main body
+                /*
                 vessel.SetPosition(vessel.mainBody.rotation * (vessel.CurrentCoM - vessel.mainBody.position));
                 vessel.SetRotation(vessel.mainBody.rotation * (QuaternionD)vessel.transform.rotation);
                 vessel.SetWorldVelocity(vessel.mainBody.rotation * vessel.srf_velocity);
+                */
             }
             else
             {

--- a/LmpClient/Extensions/VesselExtension.cs
+++ b/LmpClient/Extensions/VesselExtension.cs
@@ -44,6 +44,8 @@ namespace LmpClient.Extensions
         /// </summary>
         public static void AdvanceShipPosition(this Vessel vessel, double time)
         {
+            var throttle = vessel.ctrlState.MainThrottle;
+
             //If we advance the orbit when flying, we risk going inside the terrain as the orbit goes deep down the planet!
             if (vessel.situation <= Vessel.Situations.FLYING) return;
 
@@ -59,6 +61,8 @@ namespace LmpClient.Extensions
             OrbitPhysicsManager.CheckReferenceFrame();
             OrbitPhysicsManager.HoldVesselUnpack(10);
             vessel.IgnoreGForces(20);
+
+            vessel.ctrlState.MainThrottle = throttle;
         }
 
         /// <summary>

--- a/LmpClient/Extensions/VesselExtension.cs
+++ b/LmpClient/Extensions/VesselExtension.cs
@@ -44,7 +44,7 @@ namespace LmpClient.Extensions
         /// </summary>
         public static void AdvanceShipPosition(this Vessel vessel, double time)
         {
-            var throttle = vessel.ctrlState.MainThrottle;
+            var throttle = vessel.ctrlState.mainThrottle;
 
             //If we advance the orbit when flying, we risk going inside the terrain as the orbit goes deep down the planet!
             if (vessel.situation <= Vessel.Situations.FLYING) return;
@@ -62,7 +62,8 @@ namespace LmpClient.Extensions
             OrbitPhysicsManager.HoldVesselUnpack(10);
             vessel.IgnoreGForces(20);
 
-            vessel.ctrlState.MainThrottle = throttle;
+            // Fix for throttle reset
+            vessel.ctrlState.mainThrottle = throttle;
         }
 
         /// <summary>

--- a/LmpClient/Extensions/VesselExtension.cs
+++ b/LmpClient/Extensions/VesselExtension.cs
@@ -46,20 +46,29 @@ namespace LmpClient.Extensions
         {
             var throttle = vessel.ctrlState.mainThrottle;
 
-            //If we advance the orbit when flying, we risk going inside the terrain as the orbit goes deep down the planet!
-            if (vessel.situation <= Vessel.Situations.FLYING) return;
+            if (vessel.situation <= Vessel.Situations.FLYING)
+            {
+                // Account for the rotation of the main body
+                vessel.SetPosition(vessel.mainBody.rotation * (vessel.CurrentCoM - vessel.mainBody.position));
+                vessel.SetRotation(vessel.mainBody.rotation * (QuaternionD)vessel.transform.rotation);
+                vessel.SetWorldVelocity(vessel.mainBody.rotation * vessel.srf_velocity);
+            }
+            else
+            {
+                // Update the vessel with it's orbit.
+                // We should only do this while the vessel is in space.
+                var obtPos = vessel.orbit.getRelativePositionAtUT(time);
+                var obtVel = vessel.orbit.getOrbitalVelocityAtUT(time);
 
-            var obtPos = vessel.orbit.getRelativePositionAtUT(time);
-            var obtVel = vessel.orbit.getOrbitalVelocityAtUT(time);
+                if (!vessel.packed)
+                    vessel.GoOnRails();
 
-            if (!vessel.packed)
-                vessel.GoOnRails();
+                vessel.orbit.UpdateFromStateVectors(obtPos, obtVel, vessel.mainBody, time);
+                vessel.orbitDriver.updateFromParameters();
 
-            vessel.orbit.UpdateFromStateVectors(obtPos, obtVel, vessel.mainBody, time);
-            vessel.orbitDriver.updateFromParameters();
-
-            OrbitPhysicsManager.CheckReferenceFrame();
-            OrbitPhysicsManager.HoldVesselUnpack(10);
+                OrbitPhysicsManager.CheckReferenceFrame();
+                OrbitPhysicsManager.HoldVesselUnpack(10);
+            }
             vessel.IgnoreGForces(20);
 
             // Fix for throttle reset

--- a/LmpClient/Systems/TimeSync/TimeSyncSystem.cs
+++ b/LmpClient/Systems/TimeSync/TimeSyncSystem.cs
@@ -153,19 +153,30 @@ namespace LmpClient.Systems.TimeSync
                 var targetTime = WarpSystem.Singleton.CurrentSubspaceTime;
                 var currentError = TimeUtil.SecondsToMilliseconds(CurrentErrorSec);
 
+                // Restore normal physics speed
                 if (Math.Abs(currentError) < MinPhysicsClockMsError)
                 {
                     Time.timeScale = 1;
                 }
+
                 if (Math.Abs(currentError) > MinPhysicsClockMsError && Math.Abs(currentError) < MaxPhysicsClockMsError)
                 {
-                    //Time error is not so big so we can fix it adjusting the physics time
+                    // Increase/decrease physics time warp rate to try and correct the error.
                     SkewClock();
                 }
                 else if (Math.Abs(currentError) > MaxPhysicsClockMsError)
                 {
-                    LunaLog.LogWarning($"[LMP] Adjusted time from: {UniversalTime} to: {targetTime} due to error: {currentError}");
-                    SetGameTime(targetTime);
+                    if (WarpSystem.Singleton.GetSubspacePlayers(WarpSystem.Singleton.CurrentSubspace).Length == 1)
+                    {
+                        // Because we're the only one in our subspace, we can change the subspace to match our time by recreating it.
+                        WarpSystem.Singleton.RequestNewSubspace(false);
+                    }
+                    else
+                    {
+                        // Rubberband our time to the subspace.
+                        LunaLog.LogWarning($"[LMP] Adjusted time from {UniversalTime} to {targetTime}, due to error {CurrentErrorSec}.");
+                        SetGameTime(targetTime);
+                    }
                 }
             }
 

--- a/LmpClient/Systems/TimeSync/TimeSyncSystem.cs
+++ b/LmpClient/Systems/TimeSync/TimeSyncSystem.cs
@@ -68,7 +68,7 @@ namespace LmpClient.Systems.TimeSync
         /// <summary>
         /// Limit at which we won't fix the time with the GAME timescale
         /// </summary>
-        private const int MaxPhysicsClockMsError = 7500;
+        private const int MaxPhysicsClockMsError = 2500;
 
         #endregion
 

--- a/LmpClient/Systems/TimeSync/TimeSyncSystem.cs
+++ b/LmpClient/Systems/TimeSync/TimeSyncSystem.cs
@@ -68,7 +68,7 @@ namespace LmpClient.Systems.TimeSync
         /// <summary>
         /// Limit at which we won't fix the time with the GAME timescale
         /// </summary>
-        private const int MaxPhysicsClockMsError = 2500;
+        private const int MaxPhysicsClockMsError = 5000;
 
         #endregion
 

--- a/LmpClient/Systems/TimeSync/TimeSyncSystem.cs
+++ b/LmpClient/Systems/TimeSync/TimeSyncSystem.cs
@@ -60,15 +60,15 @@ namespace LmpClient.Systems.TimeSync
         /// <summary>
         /// Minimum speed that the game can go
         /// </summary>
-        private const float MinPhysicsClockRate = 0.85f;
+        private const float MinPhysicsClockRate = 0.60f;
         /// <summary>
         /// Max speed that the game can go. If you put this number too high the game will lag a lot.
         /// </summary>
-        private const float MaxPhysicsClockRate = 1.20f;
+        private const float MaxPhysicsClockRate = 1.60f;
         /// <summary>
         /// Limit at which we won't fix the time with the GAME timescale
         /// </summary>
-        private const int MaxPhysicsClockMsError = 3500;
+        private const int MaxPhysicsClockMsError = 7500;
 
         #endregion
 

--- a/LmpClient/Systems/Warp/WarpSystem.cs
+++ b/LmpClient/Systems/Warp/WarpSystem.cs
@@ -265,6 +265,11 @@ namespace LmpClient.Systems.Warp
             return ClientSubspaceList.ContainsKey(playerName) ? ClientSubspaceList[playerName] : 0;
         }
 
+        public string[] GetSubspacePlayers(int subspace)
+        {
+            return ClientSubspaceList.Where(kvp => kvp.Value == subspace).Select(kvp => kvp.Key).ToArray();
+        }
+
         public void DisplayMessage(string messageText, float messageDuration)
         {
             if (WarpMessage != null)
@@ -355,11 +360,13 @@ namespace LmpClient.Systems.Warp
         /// <summary>
         /// Task that requests a new subspace to the server.
         /// </summary>
-        private void RequestNewSubspace()
+        private void RequestNewSubspace(bool is_stopped_warping = true)
         {
             WaitingSubspaceIdFromServer = true;
             MessageSender.SendNewSubspace();
-            _stoppedWarpingTimeStamp = LunaComputerTime.UtcNow;
+
+            if (is_stopped_warping)
+                _stoppedWarpingTimeStamp = LunaComputerTime.UtcNow;
         }
 
         #endregion

--- a/LmpClient/Systems/Warp/WarpSystem.cs
+++ b/LmpClient/Systems/Warp/WarpSystem.cs
@@ -334,6 +334,18 @@ namespace LmpClient.Systems.Warp
             WarpEvent.onTimeWarpStopped.Fire();
         }
 
+        /// <summary>
+        /// Task that requests a new subspace to the server.
+        /// </summary>
+        public void RequestNewSubspace(bool is_stopped_warping = true)
+        {
+            WaitingSubspaceIdFromServer = true;
+            MessageSender.SendNewSubspace();
+
+            if (is_stopped_warping)
+                _stoppedWarpingTimeStamp = LunaComputerTime.UtcNow;
+        }
+
         #endregion
 
         #region Private methods
@@ -355,18 +367,6 @@ namespace LmpClient.Systems.Warp
             }
 
             return false;
-        }
-
-        /// <summary>
-        /// Task that requests a new subspace to the server.
-        /// </summary>
-        private void RequestNewSubspace(bool is_stopped_warping = true)
-        {
-            WaitingSubspaceIdFromServer = true;
-            MessageSender.SendNewSubspace();
-
-            if (is_stopped_warping)
-                _stoppedWarpingTimeStamp = LunaComputerTime.UtcNow;
         }
 
         #endregion


### PR DESCRIPTION
### Fixes included in this PR:
- Fixes #255.
- Fixes #469. (partial, root cause not yet addressed)
- Fixes "throttle reset issue"
### Changes proposed in this PR:
- Make subspace time correction use more physics time warp
- Create new subspaces instead of temporal rubberbanding when in a solo subspace (equivalent to warping for 0 frames)
- Preserve throttle when rubberbanding
- (WIP) Update vessel position correctly (that is, at all) when rubberbanding in flight/while landed