### PR TITLE
Fix duplicate research node purchase by closing the R&D panels on other clients  (#667)

### DIFF
--- a/LmpClient/Systems/ShareTechnology/ShareTechnologyMessageHandler.cs
+++ b/LmpClient/Systems/ShareTechnology/ShareTechnologyMessageHandler.cs
@@ -34,11 +34,28 @@ namespace LmpClient.Systems.ShareTechnology
             System.StartIgnoringEvents();
             var node = AssetBase.RnDTechTree.GetTreeTechs().ToList().Find(n => n.techID == tech.Id);
 
+            //Check (before we respawn the tree below) whether the R&D screen currently has this exact
+            //node's detail panel open. If it does, its Research button will need to be refreshed afterwards.
+            var panelWasShowingThisNode = RDController.Instance && RDController.Instance.node_selected != null
+                && RDController.Instance.node_selected.tech != null
+                && RDController.Instance.node_selected.tech.techID == tech.Id;
+
             //Unlock the technology
             ResearchAndDevelopment.Instance.UnlockProtoTechNode(node);
 
             //Refresh the tech tree
             ResearchAndDevelopment.RefreshTechTreeUI();
+
+            //RefreshTechTreeUI() respawns the tree nodes but does NOT refresh an already open node panel.
+            //If another player had this node open, its Research button stayed active and let them buy the
+            //node again, spending the science a second time (see issue #667). We can't just call UpdatePanel()
+            //because the respawn orphans node_selected (its cached RDTech.state is never re-synced), so instead
+            //we close the stale panel. The node correctly shows as researched once it is reopened.
+            if (panelWasShowingThisNode && RDController.Instance)
+            {
+                RDController.Instance.node_selected = null;
+                RDController.Instance.ShowNothingPanel();
+            }
 
             //Refresh the part list in case we are in the VAB/SPH
             if (EditorPartList.Instance) EditorPartList.Instance.Refresh();


### PR DESCRIPTION
Fixes #667 

## Problem
When one player researches a tech node while other players have that same node open/selected in the R&D screen, the other clients still show the purchase button. Clicking it purchased the node again and spends science a second time.

## Cause
The client applies the research with `ResearchAndDevelopment.UnlockProtoTechNode()` and calls the static `ResearchAndDevelopment.RefreshTechTreeUI()`. That respawns the tech-tree nodes but didnot refresh open node panels in other clients, and strands `RDController.Instance.node_selected` 

## Fix
When the node being purchased is selected by other clients, close the node panel `ShowNothingPanel()` so the stale Research button is removed. The node shows as researched when the panel is reopened and there's now no button to purchase.

Tested by building the client and ran two local KSP instances against a local carreer mode server server.
Client 2's open panel now closes when the research hits. The science is deducted once and the node can't be re-purchased.
