### PR TITLE
Improved the speed of rendering and iterating through the server list

### DIFF
--- a/LmpClient/Network/NetworkServerList.cs
+++ b/LmpClient/Network/NetworkServerList.cs
@@ -20,12 +20,28 @@ namespace LmpClient.Network
 
         private static bool receivedNATIntroductionSuccessResponse = false;
 
+        private static int _serversVersion;
+
+        /// <summary>
+        /// Monotonic counter bumped every time the <see cref="Servers"/> collection or any of its
+        /// entries changes. Consumers (e.g. the server list window) can compare against a cached value
+        /// to detect whether they need to rebuild their view instead of doing it every frame.
+        /// </summary>
+        public static int ServersVersion => Volatile.Read(ref _serversVersion);
+
+        /// <summary>
+        /// Signals that the server list (or one of its entries) has changed.
+        /// Safe to call from any thread.
+        /// </summary>
+        public static void NotifyServersChanged() => Interlocked.Increment(ref _serversVersion);
+
         /// <summary>
         /// Sends a request for the server list to the master servers
         /// </summary>
         public static void RequestServers()
         {
             Servers.Clear();
+            NotifyServersChanged();
             var msgData = NetworkMain.CliMsgFactory.CreateNewMessageData<MsRequestServersMsgData>();
             var requestMsg = NetworkMain.MstSrvMsgFactory.CreateNew<MainMstSrvMsg>(msgData);
             NetworkSender.QueueOutgoingMessage(requestMsg);
@@ -76,6 +92,7 @@ namespace LmpClient.Network
                     Array.Copy(data.Color, server.Color, 3);
 
                     Servers.AddOrUpdate(data.Id, server, (l, info) => MergeServerInfos(info, server));
+                    NotifyServersChanged();
                     PingSystem.QueuePing(data.Id);
                 }
             }

--- a/LmpClient/Systems/Ping/PingSystem.cs
+++ b/LmpClient/Systems/Ping/PingSystem.cs
@@ -74,6 +74,7 @@ namespace LmpClient.Systems.Ping
                     {
                         serverInfo.Ping6 = int.MaxValue;
                         serverInfo.DisplayedPing6 = "X";
+                        NetworkServerList.NotifyServersChanged();
                         RunningPings.Remove((serverId, ipv6));
                         yield break;
                     }
@@ -85,6 +86,7 @@ namespace LmpClient.Systems.Ping
                     {
                         serverInfo.Ping = int.MaxValue;
                         serverInfo.DisplayedPing = "X";
+                        NetworkServerList.NotifyServersChanged();
                         RunningPings.Remove((serverId, ipv6));
                         yield break;
                     }
@@ -115,6 +117,8 @@ namespace LmpClient.Systems.Ping
                         server.Ping = result;
                         server.DisplayedPing = finished ? result.ToString() : "∞";
                     }
+
+                    NetworkServerList.NotifyServersChanged();
                 }
 
                 RunningPings.Remove((serverId, ipv6));

--- a/LmpClient/Windows/ServerList/ColorEffect.cs
+++ b/LmpClient/Windows/ServerList/ColorEffect.cs
@@ -1,4 +1,5 @@
-﻿using LmpCommon;
+﻿using LmpClient.Windows.ServerList;
+using LmpCommon;
 using UnityEngine;
 
 namespace LmpClient.Windows
@@ -23,6 +24,11 @@ namespace LmpClient.Windows
         // ReSharper disable once InconsistentNaming
         public void OnGUI()
         {
+            //This behaviour lives for the whole game (DontDestroyOnLoad), but the rainbow effect is
+            //only ever consumed by the server list window. Skip the per-pass work when it's not shown.
+            if (!ServerListWindow.Singleton.Display)
+                return;
+
             if (_colorTime <= 1)
             {
                 _lerpedColor = Color.Lerp(Colors[_currentColorIndex], Colors[_currentColorIndex == Colors.Length - 1 ? 0 : _currentColorIndex + 1], _colorTime);

--- a/LmpClient/Windows/ServerList/ServerFilter.cs
+++ b/LmpClient/Windows/ServerList/ServerFilter.cs
@@ -16,6 +16,7 @@ namespace LmpClient.Windows.ServerList
             {
                 SettingsSystem.CurrentSettings.ServerFilters.HideFullServers = hideFullServers;
                 SettingsSystem.SaveSettings();
+                ServerListWindow.MarkDirty();
             }
             GUILayout.FlexibleSpace();
             var hideEmptyServers = GUILayout.Toggle(SettingsSystem.CurrentSettings.ServerFilters.HideEmptyServers, LocalizationContainer.ServerListFiltersText.HideEmptyServers);
@@ -23,6 +24,7 @@ namespace LmpClient.Windows.ServerList
             {
                 SettingsSystem.CurrentSettings.ServerFilters.HideEmptyServers = hideEmptyServers;
                 SettingsSystem.SaveSettings();
+                ServerListWindow.MarkDirty();
             }
             GUILayout.FlexibleSpace();
             var hidePrivateServers = GUILayout.Toggle(SettingsSystem.CurrentSettings.ServerFilters.HidePrivateServers, LocalizationContainer.ServerListFiltersText.HidePrivateServers);
@@ -30,6 +32,7 @@ namespace LmpClient.Windows.ServerList
             {
                 SettingsSystem.CurrentSettings.ServerFilters.HidePrivateServers = hidePrivateServers;
                 SettingsSystem.SaveSettings();
+                ServerListWindow.MarkDirty();
             }
             GUILayout.FlexibleSpace();
             var dedicatedServersOnly = GUILayout.Toggle(SettingsSystem.CurrentSettings.ServerFilters.DedicatedServersOnly, LocalizationContainer.ServerListFiltersText.DedicatedServersOnly);
@@ -37,6 +40,7 @@ namespace LmpClient.Windows.ServerList
             {
                 SettingsSystem.CurrentSettings.ServerFilters.DedicatedServersOnly = dedicatedServersOnly;
                 SettingsSystem.SaveSettings();
+                ServerListWindow.MarkDirty();
             }
             GUILayout.FlexibleSpace();
             GUILayout.EndHorizontal();

--- a/LmpClient/Windows/ServerList/ServerListDrawer.cs
+++ b/LmpClient/Windows/ServerList/ServerListDrawer.cs
@@ -51,6 +51,7 @@ namespace LmpClient.Windows.ServerList
             if (GUILayout.Button(_ascending ? "▲" : "▼"))
             {
                 _ascending = !_ascending;
+                _forceRebuild = true;
             }
             if (Event.current.type == EventType.Repaint) HeaderGridSize[0] = GUILayoutUtility.GetLastRect().width;
             GUILayout.EndHorizontal();
@@ -58,7 +59,7 @@ namespace LmpClient.Windows.ServerList
             GUILayout.BeginHorizontal(GUILayout.MinWidth(30));
             if (GUILayout.Button(KeyIcon))
             {
-                _orderBy = "Password";
+                SetOrderBy("Password");
             }
             if (Event.current.type == EventType.Repaint) HeaderGridSize[1] = GUILayoutUtility.GetLastRect().width;
             GUILayout.EndHorizontal();
@@ -66,7 +67,7 @@ namespace LmpClient.Windows.ServerList
             GUILayout.BeginHorizontal(GUILayout.MinWidth(30));
             if (GUILayout.Button(GlobeIcon))
             {
-                _orderBy = "Country";
+                SetOrderBy("Country");
             }
             if (Event.current.type == EventType.Repaint) HeaderGridSize[2] = GUILayoutUtility.GetLastRect().width;
             GUILayout.EndHorizontal();
@@ -74,7 +75,7 @@ namespace LmpClient.Windows.ServerList
             GUILayout.BeginHorizontal(GUILayout.MinWidth(50));
             if (GUILayout.Button(LocalizationContainer.ServerListWindowText.Dedicated))
             {
-                _orderBy = "Dedicated";
+                SetOrderBy("Dedicated");
             }
             if (Event.current.type == EventType.Repaint) HeaderGridSize[3] = GUILayoutUtility.GetLastRect().width;
             GUILayout.EndHorizontal();
@@ -82,7 +83,7 @@ namespace LmpClient.Windows.ServerList
             GUILayout.BeginHorizontal(GUILayout.MinWidth(65));
             if (GUILayout.Button(LocalizationContainer.ServerListWindowText.Ping))
             {
-                _orderBy = "Ping";
+                SetOrderBy("Ping");
             }
             if (Event.current.type == EventType.Repaint) HeaderGridSize[4] = GUILayoutUtility.GetLastRect().width;
             GUILayout.EndHorizontal();
@@ -90,7 +91,7 @@ namespace LmpClient.Windows.ServerList
             GUILayout.BeginHorizontal(GUILayout.MinWidth(65));
             if (GUILayout.Button(LocalizationContainer.ServerListWindowText.Ping6))
             {
-                _orderBy = "Ping6";
+                SetOrderBy("Ping6");
             }
             if (Event.current.type == EventType.Repaint) HeaderGridSize[5] = GUILayoutUtility.GetLastRect().width;
             GUILayout.EndHorizontal();
@@ -98,7 +99,7 @@ namespace LmpClient.Windows.ServerList
             GUILayout.BeginHorizontal(GUILayout.MinWidth(50));
             if (GUILayout.Button(LocalizationContainer.ServerListWindowText.Players))
             {
-                _orderBy = "PlayerCount";
+                SetOrderBy("PlayerCount");
             }
             if (Event.current.type == EventType.Repaint) HeaderGridSize[6] = GUILayoutUtility.GetLastRect().width;
             GUILayout.EndHorizontal();
@@ -106,7 +107,7 @@ namespace LmpClient.Windows.ServerList
             GUILayout.BeginHorizontal(GUILayout.MinWidth(85));
             if (GUILayout.Button(LocalizationContainer.ServerListWindowText.MaxPlayers))
             {
-                _orderBy = "MaxPlayers";
+                SetOrderBy("MaxPlayers");
             }
             if (Event.current.type == EventType.Repaint) HeaderGridSize[7] = GUILayoutUtility.GetLastRect().width;
             GUILayout.EndHorizontal();
@@ -114,7 +115,7 @@ namespace LmpClient.Windows.ServerList
             GUILayout.BeginHorizontal(GUILayout.MinWidth(85));
             if (GUILayout.Button(LocalizationContainer.ServerListWindowText.Mode))
             {
-                _orderBy = "GameMode";
+                SetOrderBy("GameMode");
             }
             if (Event.current.type == EventType.Repaint) HeaderGridSize[8] = GUILayoutUtility.GetLastRect().width;
             GUILayout.EndHorizontal();
@@ -122,7 +123,7 @@ namespace LmpClient.Windows.ServerList
             GUILayout.BeginHorizontal(GUILayout.MinWidth(75));
             if (GUILayout.Button(LocalizationContainer.ServerListWindowText.WarpMode))
             {
-                _orderBy = "WarpMode";
+                SetOrderBy("WarpMode");
             }
             if (Event.current.type == EventType.Repaint) HeaderGridSize[9] = GUILayoutUtility.GetLastRect().width;
             GUILayout.EndHorizontal();
@@ -130,7 +131,7 @@ namespace LmpClient.Windows.ServerList
             GUILayout.BeginHorizontal(GUILayout.MinWidth(50));
             if (GUILayout.Button(LocalizationContainer.ServerListWindowText.Terrain))
             {
-                _orderBy = "TerrainQuality";
+                SetOrderBy("TerrainQuality");
             }
             if (Event.current.type == EventType.Repaint) HeaderGridSize[10] = GUILayoutUtility.GetLastRect().width;
             GUILayout.EndHorizontal();
@@ -138,7 +139,7 @@ namespace LmpClient.Windows.ServerList
             GUILayout.BeginHorizontal(GUILayout.MinWidth(50));
             if (GUILayout.Button(LocalizationContainer.ServerListWindowText.Cheats))
             {
-                _orderBy = "Cheats";
+                SetOrderBy("Cheats");
             }
             if (Event.current.type == EventType.Repaint) HeaderGridSize[11] = GUILayoutUtility.GetLastRect().width;
             GUILayout.EndHorizontal();
@@ -146,7 +147,7 @@ namespace LmpClient.Windows.ServerList
             GUILayout.BeginHorizontal(GUILayout.MinWidth(220));
             if (GUILayout.Button(LocalizationContainer.ServerListWindowText.Name))
             {
-                _orderBy = "ServerName";
+                SetOrderBy("ServerName");
             }
             if (Event.current.type == EventType.Repaint) HeaderGridSize[12] = GUILayoutUtility.GetLastRect().width > 220 ? GUILayoutUtility.GetLastRect().width : 220;
             GUILayout.EndHorizontal();
@@ -154,7 +155,7 @@ namespace LmpClient.Windows.ServerList
             GUILayout.BeginHorizontal(GUILayout.MinWidth(150));
             if (GUILayout.Button(LocalizationContainer.ServerListWindowText.Website))
             {
-                _orderBy = "WebsiteText";
+                SetOrderBy("WebsiteText");
             }
             if (Event.current.type == EventType.Repaint) HeaderGridSize[13] = GUILayoutUtility.GetLastRect().width;
             GUILayout.EndHorizontal();
@@ -162,7 +163,7 @@ namespace LmpClient.Windows.ServerList
             GUILayout.BeginHorizontal(GUILayout.MinWidth(600));
             if (GUILayout.Button(LocalizationContainer.ServerListWindowText.Description))
             {
-                _orderBy = "Description";
+                SetOrderBy("Description");
             }
             if (Event.current.type == EventType.Repaint) HeaderGridSize[14] = GUILayoutUtility.GetLastRect().width > 600 ? GUILayoutUtility.GetLastRect().width : 600;
             GUILayout.EndHorizontal();

--- a/LmpClient/Windows/ServerList/ServerListWindow.cs
+++ b/LmpClient/Windows/ServerList/ServerListWindow.cs
@@ -3,9 +3,8 @@ using LmpClient.Localization;
 using LmpClient.Network;
 using LmpCommon;
 using LmpCommon.Enums;
+using System;
 using System.Collections.Generic;
-using System.Linq;
-using System.Reflection;
 using UnityEngine;
 
 namespace LmpClient.Windows.ServerList
@@ -14,7 +13,27 @@ namespace LmpClient.Windows.ServerList
     {
         #region Fields
 
-        private static readonly Dictionary<string, PropertyInfo> OrderByPropertyDictionary = new Dictionary<string, PropertyInfo>();
+        /// <summary>
+        /// Strongly-typed comparers keyed by the same column identifiers used by the grid header.
+        /// This avoids the reflection + boxing that a per-frame property lookup would incur.
+        /// </summary>
+        private static readonly Dictionary<string, Comparison<ServerInfo>> OrderByComparers = new Dictionary<string, Comparison<ServerInfo>>
+        {
+            ["Password"] = (a, b) => a.Password.CompareTo(b.Password),
+            ["Country"] = (a, b) => string.Compare(a.Country, b.Country, StringComparison.OrdinalIgnoreCase),
+            ["Dedicated"] = (a, b) => a.DedicatedServer.CompareTo(b.DedicatedServer),
+            ["Ping"] = (a, b) => a.Ping.CompareTo(b.Ping),
+            ["Ping6"] = (a, b) => a.Ping6.CompareTo(b.Ping6),
+            ["PlayerCount"] = (a, b) => a.PlayerCount.CompareTo(b.PlayerCount),
+            ["MaxPlayers"] = (a, b) => a.MaxPlayers.CompareTo(b.MaxPlayers),
+            ["GameMode"] = (a, b) => a.GameMode.CompareTo(b.GameMode),
+            ["WarpMode"] = (a, b) => a.WarpMode.CompareTo(b.WarpMode),
+            ["TerrainQuality"] = (a, b) => a.TerrainQuality.CompareTo(b.TerrainQuality),
+            ["Cheats"] = (a, b) => a.Cheats.CompareTo(b.Cheats),
+            ["ServerName"] = (a, b) => string.Compare(a.ServerName, b.ServerName, StringComparison.OrdinalIgnoreCase),
+            ["WebsiteText"] = (a, b) => string.Compare(a.WebsiteText, b.WebsiteText, StringComparison.OrdinalIgnoreCase),
+            ["Description"] = (a, b) => string.Compare(a.Description, b.Description, StringComparison.OrdinalIgnoreCase),
+        };
 
         protected float WindowHeight = Screen.height * 0.95f;
         protected float WindowWidth = Screen.width * 0.95f;
@@ -43,6 +62,9 @@ namespace LmpClient.Windows.ServerList
         private static string _orderBy = "PlayerCount";
         private static bool _ascending;
 
+        private static int _lastServersVersion = int.MinValue;
+        private static bool _forceRebuild;
+
         private static GUIStyle _headerServerLine;
         private static GUIStyle _evenServerLine;
         private static GUIStyle _oddServerLine;
@@ -50,18 +72,6 @@ namespace LmpClient.Windows.ServerList
         private static GUIStyle _kspLabelStyle;
 
         protected override bool Resizable => true;
-
-        #endregion
-
-        #region Constructor
-
-        public ServerListWindow()
-        {
-            foreach (var property in typeof(ServerInfo).GetProperties())
-            {
-                OrderByPropertyDictionary.Add(property.Name, property);
-            }
-        }
 
         #endregion
 
@@ -136,12 +146,48 @@ namespace LmpClient.Windows.ServerList
         public override void Update()
         {
             base.Update();
-            if (Display)
+            if (!Display)
+                return;
+
+            //Only rebuild the displayed list when the underlying data or the sort/filter selection
+            //actually changed. Otherwise we'd re-sort and re-filter the whole list every single frame.
+            var version = NetworkServerList.ServersVersion;
+            if (!_forceRebuild && version == _lastServersVersion)
+                return;
+
+            _lastServersVersion = version;
+            _forceRebuild = false;
+            RebuildDisplayedServers();
+        }
+
+        private static void RebuildDisplayedServers()
+        {
+            DisplayedServers.Clear();
+
+            foreach (var server in NetworkServerList.Servers.Values)
             {
-                DisplayedServers.Clear();
-                DisplayedServers.AddRange(_ascending ? NetworkServerList.Servers.Values.OrderBy(s => OrderByPropertyDictionary[_orderBy].GetValue(s, null)) :
-                    NetworkServerList.Servers.Values.OrderByDescending(s => OrderByPropertyDictionary[_orderBy].GetValue(s, null)).Where(ServerFilter.MatchesFilters));
+                if (ServerFilter.MatchesFilters(server))
+                    DisplayedServers.Add(server);
             }
+
+            if (OrderByComparers.TryGetValue(_orderBy, out var comparison))
+            {
+                DisplayedServers.Sort(comparison);
+                if (!_ascending)
+                    DisplayedServers.Reverse();
+            }
+        }
+
+        /// <summary>
+        /// Forces the displayed server list to be rebuilt on the next update. Call this whenever the
+        /// sort column, sort direction or an active filter changes.
+        /// </summary>
+        public static void MarkDirty() => _forceRebuild = true;
+
+        private static void SetOrderBy(string orderBy)
+        {
+            _orderBy = orderBy;
+            _forceRebuild = true;
         }
 
         private static GUIStyle GetCorrectLabelStyle(ServerInfo server)


### PR DESCRIPTION
## Summary

Opening the server list in the main menu caused noticeable game lag. This PR removes the per-frame work and reflection that drove that cost, without changing how the list looks or behaves (aside from bug fixes noted below).

## Background

While the server list window is open, two things run in hot loops:

- `ServerListWindow.Update()` — once per frame
- The IMGUI draw code — inside `OnGUI`, which Unity calls multiple times per frame

The old `Update()` unconditionally rebuilt the displayed list **every frame**, re-sorting the entire collection using `PropertyInfo.GetValue()` (reflection + boxing on every comparison). That work happened continuously even when nothing had changed and the user was doing nothing.

## Changes

- **Only rebuild the displayed list when something actually changes.** Added a thread-safe change counter to `NetworkServerList` (`ServersVersion` / `NotifyServersChanged()`), bumped whenever the server collection or an entry changes (new/updated server received, list cleared on refresh, ping result updated). `ServerListWindow.Update()` now skips the rebuild unless the version changed or a UI interaction requested it.
- **Removed reflection from sorting.** Replaced the `Dictionary<string, PropertyInfo>` (populated via reflection in the constructor) with a `Dictionary<string, Comparison<ServerInfo>>` of strongly-typed comparers. No reflection, no boxing.
- **Routed all sort/filter interactions through an explicit dirty flag** so the list still updates immediately when the user clicks a column header, flips sort direction, or toggles a filter.
- **Gated `ColorEffect.OnGUI()`** so the rainbow color lerp only runs while the server list window is visible. It's a `DontDestroyOnLoad` behaviour that previously ran on every `OnGUI` pass game-wide, even when the list was closed.

## Bug fixes included

- **Filters now apply in both sort directions.** Previously `MatchesFilters` was only applied when sorting descending, so ascending mode showed the full, unfiltered list.
- **Sorting by the "Dedicated" column no longer throws.** The column key (`"Dedicated"`) never matched the real property name (`DedicatedServer`), so the old reflection lookup threw `KeyNotFoundException` every frame (silently swallowed by the window handler). The new comparer maps it correctly.

## Behavioral note

Sorting now uses `List.Sort` (unstable) instead of LINQ `OrderBy` (stable), so servers that tie on the sort key may appear in a different relative order than before. Functionally equivalent; only affects tie ordering.

## Files touched

- `LmpClient/Network/NetworkServerList.cs`
- `LmpClient/Systems/Ping/PingSystem.cs`
- `LmpClient/Windows/ServerList/ServerListWindow.cs`
- `LmpClient/Windows/ServerList/ServerListDrawer.cs`
- `LmpClient/Windows/ServerList/ServerFilter.cs`
- `LmpClient/Windows/ServerList/ColorEffect.cs`

## Test plan

- [ ] Open the server list from the main menu; confirm the lag/hitching is gone
- [ ] Verify servers still populate and pings update as replies arrive
- [ ] Sort by each column (incl. Dedicated) in both ascending and descending order
- [ ] Toggle each filter (hide full/empty/private, dedicated only) in both sort directions
- [ ] Refresh the list and confirm it clears and repopulates
- [ ] Connect to a passworded and a non-passworded server to confirm the flow is unaffected