### PR TITLE
Restore maneuver node ingestion on skip-reload path

### DIFF
--- a/LmpClient/VesselUtilities/VesselLoader.cs
+++ b/LmpClient/VesselUtilities/VesselLoader.cs
@@ -732,6 +732,14 @@ namespace LmpClient.VesselUtilities
                 if (!forceReload && existingPartCount == vesselProto.protoPartSnapshots.Count &&
                     existingCrewCount == vesselProto.GetVesselCrew().Count)
                 {
+                    //Maneuver-node-only updates always land here (a flight plan edit never
+                    //changes part or crew count), so we must still ingest the incoming flight
+                    //plan even though we skip the reload. Without this the vessel keeps its
+                    //stale flight plan and the PatchedConicSolver loads empty/old maneuver
+                    //data on the next GoOffRails, silently dropping synced burns on handoff.
+                    if (existingVessel.protoVessel != null)
+                        existingVessel.protoVessel.flightPlan = vesselProto.flightPlan;
+
                     //Structure matches — no work needed. Returning the dedicated outcome
                     //lets the caller skip the misleading "Vessel reloaded" log line and
                     //the VesselReloadEvent fire that previously ran on every wire-drift


### PR DESCRIPTION
## Summary

Restores the receiving-side ingestion of maneuver node data that was accidentally dropped during a refactor, without which the maneuver-node sync feature is broadcast and relayed but silently discarded on the receiving client.

## Background

Maneuver node sync was originally added in #637 as three coordinated pieces:

1. **Send side** — `VesselSerializer` stopped stripping the `FLIGHTPLAN` node, so the flight plan rides along in every outgoing vessel proto.
2. **Detect side** — `onManeuverAdded` / `onManeuverRemoved` hooks plus a 2.5s signature poll in `VesselProtoSystem` to catch dV edits (which fire no KSP event).
3. **Ingest side** — a single line in `VesselLoader.LoadVesselIntoGame` that copied the incoming flight plan into an already-existing vessel on the skip-reload path.

Pieces 1 and 2 are still intact. Piece 3 was removed in `0_29_3-PR2` when the early-return in `LoadVesselIntoGame` was refactored from `return true;` into the new `VesselLoadOutcome.UnchangedEarlyOut` enum path. That was the only receiving-side ingestion in the entire client.

## The problem

Incoming protos funnel through `VesselLoader`, which has three branches:

- **Proto-swap** (`UpdateProtoInPlace`): `SPACECENTER` / `EDITOR` only — carries the full proto, but maneuver nodes are irrelevant in those scenes.
- **Destructive reload** (`vesselProto.Load`): only runs when part-count or crew-count changed, or on `forceReload`.
- **`UnchangedEarlyOut`**: same part/crew count, no force reload → returns immediately.

A maneuver-node edit never changes part or crew count, so **every** maneuver-only update lands in `UnchangedEarlyOut`. With the ingestion line gone, the incoming flight plan is discarded: the receiving vessel keeps its stale flight plan and the `PatchedConicSolver` loads empty/old maneuver data on the next `GoOffRails`. The net effect was the worst of both worlds — the sender serializes and broadcasts a full vessel proto on every node add/remove and every 2.5s of dV editing, the server relays it, and the receiver throws the maneuver portion away.

## The fix

Re-ingest `vesselProto.flightPlan` into `existingVessel.protoVessel` in the `UnchangedEarlyOut` branch, before the early return. A null guard on `existingVessel.protoVessel` was added for consistency with the surrounding refactored code (which already treats it as possibly null on the unloaded/packed path), and a comment documents why the copy is required even though the reload is skipped.

## Test plan

- [ ] Two clients against a local server, both in flight. Client A controls a vessel in orbit and adds a maneuver node; confirm the send fires (`LMP_ManeuverNodes.log` shows `ADDED`, server audit log shows the update).
- [ ] Vessel handoff: A plans a burn, B takes the update lock and switches to the vessel — confirm the planned burn survives on B.
- [ ] Confirm no regression on the existing early-out behavior (no spurious `Vessel reloaded` log line / `VesselReloadEvent` fire on wire-drift broadcasts).
