### PR TITLE
Fix LunaCompat TypeLoadException by compiling LmpClient type forwarders

### DIFF
--- a/LmpClient/LmpClient.csproj
+++ b/LmpClient/LmpClient.csproj
@@ -477,6 +477,7 @@
     <Compile Include="Network\NetworkMain.cs" />
     <Compile Include="Network\NetworkStatistics.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="Properties\TypeForwarding.cs" />
     <Compile Include="Systems\Chat\ChatMessageHandler.cs" />
     <Compile Include="Systems\Chat\ChatMessageSender.cs" />
     <Compile Include="Systems\Chat\ChatSystem.cs" />

--- a/LmpClient/Properties/AssemblyInfo.cs
+++ b/LmpClient/Properties/AssemblyInfo.cs
@@ -1,6 +1,5 @@
 ﻿using System.Reflection;
 using System.Runtime.InteropServices;
-using System.Runtime.CompilerServices;
 
 [assembly: AssemblyTitle("Luna Multiplayer Mod")]
 [assembly: AssemblyDescription("Luna Multiplayer Mod (client)")]
@@ -18,32 +17,7 @@ using System.Runtime.CompilerServices;
 [assembly: AssemblyFileVersion("0.30.0")]
 [assembly: AssemblyInformationalVersion("0.30.0-compiled")]
 
-[assembly: TypeForwardedTo(typeof(LmpCommon.PlayerStatus))]
-[assembly: TypeForwardedTo(typeof(LmpCommon.Message.ClientMessageFactory))]
-[assembly: TypeForwardedTo(typeof(LmpCommon.Message.MasterServerMessageFactory))]
-[assembly: TypeForwardedTo(typeof(LmpCommon.Message.ServerMessageFactory))]
-[assembly: TypeForwardedTo(typeof(LmpCommon.Message.Client.ModCliMsg))]
-[assembly: TypeForwardedTo(typeof(LmpCommon.Message.Data.ModMsgData))]
-[assembly: TypeForwardedTo(typeof(LmpCommon.Message.Data.Vessel.VesselBaseMsgData))]
-[assembly: TypeForwardedTo(typeof(LmpCommon.Message.Data.Vessel.VesselActionGroupMsgData))]
-[assembly: TypeForwardedTo(typeof(LmpCommon.Message.Data.Vessel.VesselCoupleMsgData))]
-[assembly: TypeForwardedTo(typeof(LmpCommon.Message.Data.Vessel.VesselDecoupleMsgData))]
-[assembly: TypeForwardedTo(typeof(LmpCommon.Message.Data.Vessel.VesselFairingMsgData))]
-[assembly: TypeForwardedTo(typeof(LmpCommon.Message.Data.Vessel.VesselFlightStateMsgData))]
-[assembly: TypeForwardedTo(typeof(LmpCommon.Message.Data.Vessel.VesselPartSyncCallMsgData))]
-[assembly: TypeForwardedTo(typeof(LmpCommon.Message.Data.Vessel.VesselPartSyncFieldMsgData))]
-[assembly: TypeForwardedTo(typeof(LmpCommon.Message.Data.Vessel.VesselPartSyncUiFieldMsgData))]
-[assembly: TypeForwardedTo(typeof(LmpCommon.Message.Data.Vessel.VesselPositionMsgData))]
-[assembly: TypeForwardedTo(typeof(LmpCommon.Message.Data.Vessel.VesselProtoMsgData))]
-[assembly: TypeForwardedTo(typeof(LmpCommon.Message.Data.Vessel.VesselRemoveMsgData))]
-[assembly: TypeForwardedTo(typeof(LmpCommon.Message.Data.Vessel.VesselResourceMsgData))]
-[assembly: TypeForwardedTo(typeof(LmpCommon.Message.Data.Vessel.VesselSyncMsgData))]
-[assembly: TypeForwardedTo(typeof(LmpCommon.Message.Data.Vessel.VesselUndockMsgData))]
-[assembly: TypeForwardedTo(typeof(LmpCommon.Message.Data.Vessel.VesselUpdateMsgData))]
-
-[assembly: TypeForwardedTo(typeof(LmpCommon.Message.Types.VesselMessageType))]
-[assembly: TypeForwardedTo(typeof(LmpCommon.Enums.ClientMessageType))]
-[assembly: TypeForwardedTo(typeof(LmpCommon.Enums.MasterServerMessageType))]
-[assembly: TypeForwardedTo(typeof(LmpCommon.Enums.ServerMessageType))]
+// Type forwarders that keep older mods binding LmpCommon types via LmpClient live in
+// TypeForwarding.cs (single source to avoid duplicate CS0739 forwarder declarations).
 
 [assembly: KSPAssembly("LMP", 0, 30)]

--- a/LmpClient/Properties/TypeForwarding.cs
+++ b/LmpClient/Properties/TypeForwarding.cs
@@ -1,9 +1,31 @@
 using System.Runtime.CompilerServices;
 
-[assembly: TypeForwardedTo(typeof(LmpCommon.Message.Client.ModCliMsg))]
-[assembly: TypeForwardedTo(typeof(LmpCommon.PlayerStatus))]
+// LmpCommon used to be merged into LmpClient, so mods (e.g. LunaCompat) compiled against
+// older LmpClient builds reference these types as living in LmpClient. Now that LmpCommon
+// ships as its own assembly, these forwarders keep those mods binding correctly at runtime.
+//
+// This is the single source of type forwarders for LmpClient. Keep it deduplicated:
+// declaring the same TypeForwardedTo in more than one place raises compiler error CS0739.
 
-// Forward other common client messages for broader mod compatibility
+// Core utilities
+[assembly: TypeForwardedTo(typeof(LmpCommon.PlayerStatus))]
+[assembly: TypeForwardedTo(typeof(LmpCommon.Common))]
+[assembly: TypeForwardedTo(typeof(LmpCommon.LmpVersioning))]
+
+// Message factories
+[assembly: TypeForwardedTo(typeof(LmpCommon.Message.ClientMessageFactory))]
+[assembly: TypeForwardedTo(typeof(LmpCommon.Message.ServerMessageFactory))]
+[assembly: TypeForwardedTo(typeof(LmpCommon.Message.MasterServerMessageFactory))]
+
+// Core message structures
+[assembly: TypeForwardedTo(typeof(LmpCommon.Message.Base.MessageBase<>))]
+[assembly: TypeForwardedTo(typeof(LmpCommon.Message.Base.MessageData))]
+[assembly: TypeForwardedTo(typeof(LmpCommon.Message.Base.FactoryBase))]
+[assembly: TypeForwardedTo(typeof(LmpCommon.Message.Base.MessageStore))]
+
+// Client messages
+[assembly: TypeForwardedTo(typeof(LmpCommon.Message.Client.Base.CliMsgBase<>))]
+[assembly: TypeForwardedTo(typeof(LmpCommon.Message.Client.ModCliMsg))]
 [assembly: TypeForwardedTo(typeof(LmpCommon.Message.Client.AdminCliMsg))]
 [assembly: TypeForwardedTo(typeof(LmpCommon.Message.Client.ChatCliMsg))]
 [assembly: TypeForwardedTo(typeof(LmpCommon.Message.Client.PlayerColorCliMsg))]
@@ -11,44 +33,36 @@ using System.Runtime.CompilerServices;
 [assembly: TypeForwardedTo(typeof(LmpCommon.Message.Client.VesselCliMsg))]
 [assembly: TypeForwardedTo(typeof(LmpCommon.Message.Client.WarpCliMsg))]
 
-// Forward message data types (often used by mods for custom data or hooking)
+// Message data types
 [assembly: TypeForwardedTo(typeof(LmpCommon.Message.Data.ModMsgData))]
 [assembly: TypeForwardedTo(typeof(LmpCommon.Message.Data.Vessel.VesselBaseMsgData))]
-[assembly: TypeForwardedTo(typeof(LmpCommon.Message.Data.Vessel.VesselProtoMsgData))]
-[assembly: TypeForwardedTo(typeof(LmpCommon.Message.Data.Vessel.VesselUpdateMsgData))]
-[assembly: TypeForwardedTo(typeof(LmpCommon.Message.Data.Vessel.VesselSyncMsgData))]
-[assembly: TypeForwardedTo(typeof(LmpCommon.Message.Data.Vessel.VesselPositionMsgData))]
-[assembly: TypeForwardedTo(typeof(LmpCommon.Message.Data.Vessel.VesselFlightStateMsgData))]
 [assembly: TypeForwardedTo(typeof(LmpCommon.Message.Data.Vessel.VesselActionGroupMsgData))]
-[assembly: TypeForwardedTo(typeof(LmpCommon.Message.Data.Vessel.VesselResourceMsgData))]
+[assembly: TypeForwardedTo(typeof(LmpCommon.Message.Data.Vessel.VesselCoupleMsgData))]
+[assembly: TypeForwardedTo(typeof(LmpCommon.Message.Data.Vessel.VesselDecoupleMsgData))]
+[assembly: TypeForwardedTo(typeof(LmpCommon.Message.Data.Vessel.VesselFairingMsgData))]
+[assembly: TypeForwardedTo(typeof(LmpCommon.Message.Data.Vessel.VesselFlightStateMsgData))]
+[assembly: TypeForwardedTo(typeof(LmpCommon.Message.Data.Vessel.VesselPartSyncCallMsgData))]
+[assembly: TypeForwardedTo(typeof(LmpCommon.Message.Data.Vessel.VesselPartSyncFieldMsgData))]
+[assembly: TypeForwardedTo(typeof(LmpCommon.Message.Data.Vessel.VesselPartSyncUiFieldMsgData))]
+[assembly: TypeForwardedTo(typeof(LmpCommon.Message.Data.Vessel.VesselPositionMsgData))]
+[assembly: TypeForwardedTo(typeof(LmpCommon.Message.Data.Vessel.VesselProtoMsgData))]
 [assembly: TypeForwardedTo(typeof(LmpCommon.Message.Data.Vessel.VesselRemoveMsgData))]
+[assembly: TypeForwardedTo(typeof(LmpCommon.Message.Data.Vessel.VesselResourceMsgData))]
+[assembly: TypeForwardedTo(typeof(LmpCommon.Message.Data.Vessel.VesselSyncMsgData))]
+[assembly: TypeForwardedTo(typeof(LmpCommon.Message.Data.Vessel.VesselUndockMsgData))]
+[assembly: TypeForwardedTo(typeof(LmpCommon.Message.Data.Vessel.VesselUpdateMsgData))]
 
-// Forward message factories
-[assembly: TypeForwardedTo(typeof(LmpCommon.Message.ClientMessageFactory))]
-[assembly: TypeForwardedTo(typeof(LmpCommon.Message.ServerMessageFactory))]
-[assembly: TypeForwardedTo(typeof(LmpCommon.Message.MasterServerMessageFactory))]
-
-// Forward core message structures
-[assembly: TypeForwardedTo(typeof(LmpCommon.Message.Base.MessageBase<>))]
-[assembly: TypeForwardedTo(typeof(LmpCommon.Message.Base.MessageData))]
-[assembly: TypeForwardedTo(typeof(LmpCommon.Message.Base.FactoryBase))]
-[assembly: TypeForwardedTo(typeof(LmpCommon.Message.Base.MessageStore))]
-[assembly: TypeForwardedTo(typeof(LmpCommon.Message.Client.Base.CliMsgBase<>))]
-
-// Forward interfaces
+// Interfaces
 [assembly: TypeForwardedTo(typeof(LmpCommon.Message.Interface.IMessageData))]
 [assembly: TypeForwardedTo(typeof(LmpCommon.Message.Interface.IMessageBase))]
 [assembly: TypeForwardedTo(typeof(LmpCommon.Message.Interface.IClientMessageBase))]
 [assembly: TypeForwardedTo(typeof(LmpCommon.Message.Interface.IServerMessageBase))]
 [assembly: TypeForwardedTo(typeof(LmpCommon.Message.Interface.IMasterServerMessageBase))]
 
-// Forward enums
+// Enums
+[assembly: TypeForwardedTo(typeof(LmpCommon.Message.Types.VesselMessageType))]
 [assembly: TypeForwardedTo(typeof(LmpCommon.Enums.ClientMessageType))]
 [assembly: TypeForwardedTo(typeof(LmpCommon.Enums.ServerMessageType))]
 [assembly: TypeForwardedTo(typeof(LmpCommon.Enums.MasterServerMessageType))]
 [assembly: TypeForwardedTo(typeof(LmpCommon.Enums.ClientState))]
 [assembly: TypeForwardedTo(typeof(LmpCommon.Enums.LogLevels))]
-
-// Forward core utilities
-[assembly: TypeForwardedTo(typeof(LmpCommon.LmpVersioning))]
-[assembly: TypeForwardedTo(typeof(LmpCommon.Common))]


### PR DESCRIPTION
## Summary

Fixes a `System.TypeLoadException` that prevented mods compiled against the old, merged `LmpClient` (such as `LunaCompat`) from loading. The mods reference `LmpCommon` types (e.g. `LmpCommon.Message.Base.FactoryBase`) as living in `LmpClient`, and those references failed to resolve at runtime.

## Root cause

`LmpClient/Properties/TypeForwarding.cs` contained the `TypeForwardedTo` entries needed for mod compatibility, but the file was **never added to `LmpClient.csproj`**, so it was never compiled. As a result, none of its forwarders (`FactoryBase`, `MessageBase<>`, `MessageStore`, `MessageData`, `CliMsgBase<>`, the message interfaces, `ClientState`, `LogLevels`, `LmpVersioning`, `Common`, the `*CliMsg` types, etc.) were emitted into `LmpClient.dll`.

Only the forwarders in `AssemblyInfo.cs` were compiled in, and that set did **not** include `FactoryBase`. When `LunaCompat` was loaded, the runtime could not resolve `FactoryBase` (nor the other missing types) via `LmpClient`, throwing:

```
System.TypeLoadException: ... Could not resolve type with token 01000032
(from typeref, class/assembly LmpCommon.Message.Base.FactoryBase, LmpClient ...)
```

Simply adding `TypeForwarding.cs` to the build would have broken compilation, because ~20 forwarders were duplicated between `TypeForwarding.cs` and `AssemblyInfo.cs`, which raises compiler error CS0739 (duplicate `TypeForwardedTo`).

## Changes

- **`LmpClient/Properties/TypeForwarding.cs`** — reorganized into the single, deduplicated **superset** of every forwarder previously spread across both files (nothing that used to be forwarded is lost; the previously-dead `FactoryBase`, interfaces, `MessageStore`, etc. are now actually emitted).
- **`LmpClient/Properties/AssemblyInfo.cs`** — removed all `TypeForwardedTo` entries (and the now-unused `using`), leaving only assembly metadata so the forwarders have a single home.
- **`LmpClient/LmpClient.csproj`** — added `<Compile Include="Properties\TypeForwarding.cs" />` so the forwarders are actually compiled into `LmpClient.dll`.

No runtime logic changes; this only affects assembly metadata (type forwarders) emitted into `LmpClient.dll`. The forward targets live in `LmpCommon.dll`, which is already deployed alongside `LmpClient.dll`.

## Test plan

- [x] `LmpClient` builds cleanly in Debug (0 errors, no CS0739).
- [x] `LmpClient` builds cleanly in Release (0 errors, no CS0739).
- [x] Confirmed `TypeForwardedTo` now exists in exactly one compiled file, eliminating duplicate-forwarder collisions.
- [x] Confirmed `LmpCommon.dll` (the forward target) is produced in the build output and deployed with `LmpClient.dll`.
- [x] Load a mod that references the forwarded types (e.g. `LunaCompat`) in KSP and verify it loads without a `TypeLoadException`.
