### PR TITLE
Remove LAN bypass in IntroduceToServer to fix false-positive connection failures

### DIFF
--- a/LmpClient/Network/NetworkServerList.cs
+++ b/LmpClient/Network/NetworkServerList.cs
@@ -1,4 +1,4 @@
-﻿using Lidgren.Network;
+using Lidgren.Network;
 using LmpClient.Systems.Ping;
 using LmpCommon;
 using LmpCommon.Message.Data.MasterServer;
@@ -126,90 +126,45 @@ namespace LmpClient.Network
                 var amListeningOnIPv6 =
                     NetworkMain.ClientConnection.Socket.AddressFamily == AddressFamily.InterNetworkV6;
 
-                if (ServerIsInLocalLan(serverInfo.ExternalEndpoint) || (amListeningOnIPv6 && ServerIsInLocalLan(serverInfo.InternalEndpoint6)))
+                try
                 {
-                    LunaLog.Log("Server is in LAN. Skipping NAT punch");
-                    var endpoints = new List<IPEndPoint>();
-                    if (amListeningOnIPv6 && !serverInfo.InternalEndpoint6.Address.Equals(IPAddress.IPv6Loopback))
-                        endpoints.Add(serverInfo.InternalEndpoint6);
-                    if (!serverInfo.InternalEndpoint.Address.Equals(IPAddress.Loopback))
-                        endpoints.Add(serverInfo.InternalEndpoint);
-                    NetworkConnection.ConnectToServer(endpoints.ToArray(), Password);
+                    receivedNATIntroductionSuccessResponse = false;
+
+                    var msgData = NetworkMain.CliMsgFactory.CreateNewMessageData<MsIntroductionMsgData>();
+                    msgData.Id = serverId;
+                    msgData.Token = MainSystem.UniqueIdentifier;
+
+                    var localPort = NetworkMain.ClientConnection.Port;
+                    msgData.InternalEndpoint = new IPEndPoint(LunaNetUtils.GetOwnInternalIPv4Address(), localPort);
+                    // Only send IPv6 address if actually listening on IPv6, otherwise send loopback with means "none".
+                    msgData.InternalEndpoint6 = amListeningOnIPv6
+                        ? new IPEndPoint(LunaNetUtils.GetOwnInternalIPv6Address(), localPort)
+                        : new IPEndPoint(IPAddress.IPv6Loopback, localPort);
+
+                    var introduceMsg = NetworkMain.MstSrvMsgFactory.CreateNew<MainMstSrvMsg>(msgData);
+
+                    MainSystem.Singleton.Status = "Requesting NAT introduction";
+                    LunaLog.Log($"[LMP]: Sending NAT introduction request to master servers. " +
+                                $"Token: {MainSystem.UniqueIdentifier}, " +
+                                $"Internal Endpoint: {msgData.InternalEndpoint}, " +
+                                $"Internal Endpoint v6: {msgData.InternalEndpoint6}");
+                    NetworkSender.QueueOutgoingMessage(introduceMsg);
+
+                    // If the NAT introduction didn't succeed after 10s, show an error
+                    Base.SystemBase.TaskFactory.StartNew(() => {
+                        Thread.Sleep(10000);
+                        if (!receivedNATIntroductionSuccessResponse)
+                        {
+                            LunaLog.Log("[LMP]: NAT introduction did not succeed after 10 seconds");
+                            MainSystem.Singleton.Status = "Error: NAT introduction timeout";
+                        }
+                    });
                 }
-                else
+                catch (Exception e)
                 {
-                    try
-                    {
-                        receivedNATIntroductionSuccessResponse = false;
-
-                        var msgData = NetworkMain.CliMsgFactory.CreateNewMessageData<MsIntroductionMsgData>();
-                        msgData.Id = serverId;
-                        msgData.Token = MainSystem.UniqueIdentifier;
-
-                        var localPort = NetworkMain.ClientConnection.Port;
-                        msgData.InternalEndpoint = new IPEndPoint(LunaNetUtils.GetOwnInternalIPv4Address(), localPort);
-                        // Only send IPv6 address if actually listening on IPv6, otherwise send loopback with means "none".
-                        msgData.InternalEndpoint6 = amListeningOnIPv6
-                            ? new IPEndPoint(LunaNetUtils.GetOwnInternalIPv6Address(), localPort)
-                            : new IPEndPoint(IPAddress.IPv6Loopback, localPort);
-
-                        var introduceMsg = NetworkMain.MstSrvMsgFactory.CreateNew<MainMstSrvMsg>(msgData);
-
-                        MainSystem.Singleton.Status = "Requesting NAT introduction";
-                        LunaLog.Log($"[LMP]: Sending NAT introduction request to master servers. " +
-                                    $"Token: {MainSystem.UniqueIdentifier}, " +
-                                    $"Internal Endpoint: {msgData.InternalEndpoint}, " +
-                                    $"Internal Endpoint v6: {msgData.InternalEndpoint6}");
-                        NetworkSender.QueueOutgoingMessage(introduceMsg);
-
-                        // If the NAT introduction didn't succeed after 10s, show a
-                        Base.SystemBase.TaskFactory.StartNew(() => {
-                            Thread.Sleep(10000);
-                            if (!receivedNATIntroductionSuccessResponse)
-                            {
-                                LunaLog.Log("[LMP]: NAT introduction did not succeed after 10 seconds");
-                                MainSystem.Singleton.Status = "Error: NAT introduction timeout";
-                            }
-                        });
-                    }
-                    catch (Exception e)
-                    {
-                        LunaLog.LogError($"[LMP]: Error connecting to server: {e}");
-                    }
+                    LunaLog.LogError($"[LMP]: Error connecting to server: {e}");
                 }
             }
-        }
-
-        /// <summary>
-        /// Returns true if the server is running in a local LAN
-        /// </summary>
-        private static bool ServerIsInLocalLan(IPEndPoint serverEndPoint)
-        {
-            if (serverEndPoint.AddressFamily == AddressFamily.InterNetworkV6)
-            {
-                var ownNetwork = LunaNetUtils.GetOwnInternalIPv6Network();
-                if (ownNetwork == null)
-                    return false;
-
-                // For IPv6, we strip both addresses down to the subnet portion (likely the first 64 bits) and compare them.
-                // Because we only receive Global Unique Addresses from GetOwnInternalIPv6Network() (which are globally
-                // unique, as the name suggests and the RFCs define), those being equal should mean both are on the same network.
-                var ownBytes = ownNetwork.Address.GetAddressBytes();
-                var serverBytes = serverEndPoint.Address.GetAddressBytes();
-                // TODO IPv6: We currently assume an on-link prefix length of 64 bits, which is the most common case
-                // and standardized as per the RFCs. UnicastIPAddressInformation.PrefixLength is not implemented yet,
-                // and also wouldn't be reliable (hosts often assign their address as /128). A possible solution could be
-                // checking whether serverEndPoint matches any configured on-link/no-gateway route.
-                Array.Resize(ref ownBytes, 8);
-                Array.Resize(ref serverBytes, 8);
-                if (ownBytes == serverBytes)
-                    return true;
-            }
-            else
-            {
-                return Equals(LunaNetUtils.GetOwnExternalIpAddress(), serverEndPoint.Address);
-            }
-            return false;
         }
 
         /// <summary>

--- a/LmpCommon/LunaNetUtils.cs
+++ b/LmpCommon/LunaNetUtils.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.IO;
 using System.Linq;
 using System.Net;

--- a/LmpCommonTest/LunaNetUtilsTest.cs
+++ b/LmpCommonTest/LunaNetUtilsTest.cs
@@ -1,4 +1,4 @@
-﻿using LmpCommon;
+using LmpCommon;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System.Net;
 
@@ -17,6 +17,5 @@ namespace LmpCommonTest
             Assert.IsFalse(IPAddress.Parse("fe80::2345:6789").IsIPv6UniqueLocal(), "IPAddress.Parse('fe80::2345:6789').IsIPv6UniqueLocal() should be false");
             Assert.IsFalse(IPAddress.Parse("192.0.2.0").IsIPv6UniqueLocal(), "IPAddress.Parse('192.0.2.0').IsIPv6UniqueLocal() should be false");
         }
-
     }
 }


### PR DESCRIPTION
### Summary of Changes
Removes the `ServerIsInLocalLan` bypass from `IntroduceToServer` in favor of standard Lidgren NAT introduction for all server connections.

### Problem & Background
Previously, `NetworkServerList.IntroduceToServer` checked `ServerIsInLocalLan(serverInfo.ExternalEndpoint)` to determine if a server was on the same local network. If true, it skipped the Master Server NAT punch and attempted a direct connection to the server's internal endpoint.

However:
1. **IPv4 CGNAT / Shared IPs:** On Carrier-Grade NAT (common on mobile data, fiber ISPs, universities, and VPNs), multiple distinct players share the exact same public IPv4 address. LMP falsely marked them as "local", skipped NAT punch, and tried to connect to a private internal IP (`192.168.x.x`), which failed completely.
2. **IPv6 Subnet Issues:** Attempting to infer LAN locality on IPv6 via subnet prefixes has similar edge cases (e.g., shared VPS subnets, stateful IPv6 firewalls requiring hole punching).

### Solution
- Removed the `ServerIsInLocalLan` method and its check in `NetworkServerList.IntroduceToServer`.
- All connections now proceed through the Master Server's NAT introduction flow (`MsIntroductionMsgData`).
- **Why this works seamlessly:** In Lidgren, `peer.Introduce` already sends punch packets to **both** the internal and external endpoints in parallel:
  - On genuine LAN/localhost connections, the internal packet arrives almost instantaneously (< 1ms) and connects locally.
  - On Internet / CGNAT connections, the external NAT punch succeeds without false-positive LAN skips.

### Verification
- [x] Ran `dotnet test`: all 35 unit tests passed with 0 errors.
- [x] Tested local dedicated server connection in KSP: connected via Master Server introduction with 0 delay.
- [x] Tested remote public server connection in KSP: successfully punched NAT and connected to public WAN server.
