### PR TITLE
Fix Breaking Ground deployed science synchronization

### DIFF
--- a/LmpClient/LmpClient.csproj
+++ b/LmpClient/LmpClient.csproj
@@ -458,6 +458,9 @@
     <Compile Include="VesselUtilities\OwnVesselReloader.cs" />
     <Compile Include="VesselUtilities\VesselSerializer.cs" />
     <Compile Include="VesselUtilities\TransientDeployedStateDetector.cs" />
+    <Compile Include="VesselUtilities\PersistentIdEvictionPolicy.cs" />
+    <Compile Include="VesselUtilities\VesselLoadTransaction.cs" />
+    <Compile Include="VesselUtilities\StalePersistentIdEvictor.cs" />
     <Compile Include="Systems\VesselSwitcherSys\VesselSwitcherSystem.cs" />
     <Compile Include="Windows\Admin\AdminDrawer.cs" />
     <Compile Include="Windows\Admin\AdminWindow.cs" />

--- a/LmpClient/LmpClient.csproj
+++ b/LmpClient/LmpClient.csproj
@@ -457,6 +457,7 @@
     <Compile Include="VesselUtilities\DiscoveryInfoSanitizer.cs" />
     <Compile Include="VesselUtilities\OwnVesselReloader.cs" />
     <Compile Include="VesselUtilities\VesselSerializer.cs" />
+    <Compile Include="VesselUtilities\TransientDeployedStateDetector.cs" />
     <Compile Include="Systems\VesselSwitcherSys\VesselSwitcherSystem.cs" />
     <Compile Include="Windows\Admin\AdminDrawer.cs" />
     <Compile Include="Windows\Admin\AdminWindow.cs" />
@@ -510,6 +511,7 @@
     <Compile Include="VesselUtilities\DockingPortUtil.cs" />
     <Compile Include="Systems\VesselProtoSys\VesselProtoMessageHandler.cs" />
     <Compile Include="Systems\VesselProtoSys\VesselProtoMessageSender.cs" />
+    <Compile Include="Systems\VesselProtoSys\TransientVesselSendHandler.cs" />
     <Compile Include="Systems\VesselProtoSys\VesselProtoSystem.cs" />
     <Compile Include="Systems\VesselRemoveSys\VesselRemoveEvents.cs" />
     <Compile Include="Systems\VesselRemoveSys\VesselRemoveMessageHandler.cs" />

--- a/LmpClient/LmpClient.csproj
+++ b/LmpClient/LmpClient.csproj
@@ -553,6 +553,7 @@
     <Compile Include="Systems\ModApi\ModApiMessageHandler.cs" />
     <Compile Include="Systems\Mod\ModFileHandler.cs" />
     <Compile Include="Systems\Scenario\ScenarioStructures.cs" />
+    <Compile Include="Systems\Scenario\DeployedScienceSyncGate.cs" />
     <Compile Include="Systems\SettingsSys\SettingsReadSaveHandler.cs" />
     <Compile Include="Systems\SettingsSys\SettingsStructures.cs" />
     <Compile Include="Systems\ModApi\ModApiSystem.cs" />

--- a/LmpClient/LmpClient.csproj
+++ b/LmpClient/LmpClient.csproj
@@ -461,6 +461,7 @@
     <Compile Include="VesselUtilities\PersistentIdEvictionPolicy.cs" />
     <Compile Include="VesselUtilities\VesselLoadTransaction.cs" />
     <Compile Include="VesselUtilities\StalePersistentIdEvictor.cs" />
+    <Compile Include="VesselUtilities\SolarPanelActualOutputPolicy.cs" />
     <Compile Include="Systems\VesselSwitcherSys\VesselSwitcherSystem.cs" />
     <Compile Include="Windows\Admin\AdminDrawer.cs" />
     <Compile Include="Windows\Admin\AdminWindow.cs" />
@@ -554,6 +555,7 @@
     <Compile Include="Systems\Mod\ModFileHandler.cs" />
     <Compile Include="Systems\Scenario\ScenarioStructures.cs" />
     <Compile Include="Systems\Scenario\DeployedScienceSyncGate.cs" />
+    <Compile Include="Systems\Scenario\DeployedScienceRelinker.cs" />
     <Compile Include="Systems\SettingsSys\SettingsReadSaveHandler.cs" />
     <Compile Include="Systems\SettingsSys\SettingsStructures.cs" />
     <Compile Include="Systems\ModApi\ModApiSystem.cs" />

--- a/LmpClient/LmpClient.csproj
+++ b/LmpClient/LmpClient.csproj
@@ -556,6 +556,8 @@
     <Compile Include="Systems\Scenario\ScenarioStructures.cs" />
     <Compile Include="Systems\Scenario\DeployedScienceSyncGate.cs" />
     <Compile Include="Systems\Scenario\DeployedScienceRelinker.cs" />
+    <Compile Include="Systems\Scenario\DeployedScienceLiveRegistrationPolicy.cs" />
+    <Compile Include="Systems\Scenario\DeployedScienceLiveRegistration.cs" />
     <Compile Include="Systems\SettingsSys\SettingsReadSaveHandler.cs" />
     <Compile Include="Systems\SettingsSys\SettingsStructures.cs" />
     <Compile Include="Systems\ModApi\ModApiSystem.cs" />

--- a/LmpClient/Systems/Scenario/DeployedScienceLiveRegistration.cs
+++ b/LmpClient/Systems/Scenario/DeployedScienceLiveRegistration.cs
@@ -1,0 +1,130 @@
+using System;
+using System.Collections.Generic;
+using Expansions.Serenity.DeployedScience.Runtime;
+using LmpClient.Utilities;
+
+namespace LmpClient.Systems.Scenario
+{
+    public static class DeployedScienceLiveRegistration
+    {
+        private static readonly System.Reflection.FieldInfo BeingDeployedField =
+            typeof(ModuleGroundPart).GetField("beingDeployed", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance);
+
+        public static void EvaluatePendingRegistrations()
+        {
+            //Only after the authoritative scenario applied — earlier clusters are the previous join's.
+            if (!DeployedScienceSyncGate.DeployedScienceReady)
+                return;
+
+            var deployedScience = DeployedScience.Instance;
+            if (deployedScience?.DeployedScienceClusters == null || deployedScience.DeployedScienceClusters.Count == 0)
+                return;
+
+            try
+            {
+                var vessels = FlightGlobals.Vessels;
+                if (vessels == null) return;
+
+                for (var i = 0; i < vessels.Count; i++)
+                {
+                    var vessel = vessels[i];
+                    if (vessel == null || !vessel.loaded || vessel.parts == null) continue;
+
+                    for (var p = 0; p < vessel.parts.Count; p++)
+                    {
+                        var part = vessel.parts[p];
+                        var module = part?.FindModuleImplementing<ModuleGroundSciencePart>();
+                        if (module == null) continue;
+
+                        EvaluateModule(deployedScience, part, module);
+                    }
+                }
+            }
+            catch (Exception e)
+            {
+                LunaLog.LogWarning($"[LMP]: GroundScience live registration sweep failed: {e.Message}");
+            }
+        }
+
+        private static void EvaluateModule(DeployedScience deployedScience, global::Part part, ModuleGroundSciencePart module)
+        {
+            deployedScience.DeployedScienceClusters.TryGetValue(module.ControlUnitId, out var cluster);
+
+            var clusterFound = cluster != null;
+            var clusterContainsPart = false;
+            var isExperiment = false;
+            var clusterHasSameExperiment = false;
+
+            if (clusterFound && cluster.DeployedScienceParts != null)
+            {
+                clusterContainsPart = cluster.DeployedScienceParts.Get(part.persistentId) != null;
+
+                if (module is ModuleGroundExperiment experimentModule)
+                {
+                    isExperiment = true;
+                    clusterHasSameExperiment = ClusterHasExperiment(cluster, experimentModule.experimentId);
+                }
+            }
+
+            if (!DeployedScienceLiveRegistrationPolicy.ShouldRegister(
+                    deployedOnGround: module.DeployedOnGround,
+                    beingDeployed: IsBeingDeployed(module),
+                    controlUnitIdAssigned: module.ControlUnitId != 0,
+                    clusterFound: clusterFound,
+                    clusterContainsPart: clusterContainsPart,
+                    isExperiment: isExperiment,
+                    clusterHasSameExperiment: clusterHasSameExperiment))
+                return;
+
+            var control = FindLiveController(module.ControlUnitId);
+            if (control == null)
+            {
+                // Controller out of physics range is normal; retried every sweep.
+                return;
+            }
+
+            LunaLog.Log($"[LMP]: GroundScience live registration: part {part.persistentId} (controller {module.ControlUnitId}) missing from live cluster {cluster.ControlModulePartId} - replaying stock onGroundScienceControllerChanged");
+
+            var parts = new List<ModuleGroundSciencePart> { module };
+            GameEvents.onGroundScienceControllerChanged.Fire(control, false, parts);
+
+            DeployedScienceRelinker.RefreshControllerUi(control);
+        }
+
+        private static bool _beingDeployedFieldMissingLogged;
+
+        private static bool IsBeingDeployed(ModuleGroundSciencePart module)
+        {
+            if (module == null) return false;
+            if (BeingDeployedField == null)
+            {
+                if (!_beingDeployedFieldMissingLogged)
+                {
+                    LunaLog.LogWarning("[LMP]: beingDeployed reflection field missing; treating all modules as deploying (fail-closed)");
+                    _beingDeployedFieldMissingLogged = true;
+                }
+                return true;
+            }
+            return BeingDeployedField.GetValue(module) is bool beingDeployed && beingDeployed;
+        }
+
+        private static bool ClusterHasExperiment(DeployedScienceCluster cluster, string experimentId)
+        {
+            var parts = cluster.DeployedScienceParts;
+            for (var i = 0; i < parts.Count; i++)
+            {
+                var experiment = parts[i] != null ? parts[i].Experiment : null;
+                if (experiment != null && experiment.ExperimentId == experimentId)
+                    return true;
+            }
+            return false;
+        }
+
+        private static ModuleGroundExpControl FindLiveController(uint controlUnitId)
+        {
+            return FlightGlobals.FindLoadedPart(controlUnitId, out var part) && part != null
+                ? part.FindModuleImplementing<ModuleGroundExpControl>()
+                : null;
+        }
+    }
+}

--- a/LmpClient/Systems/Scenario/DeployedScienceLiveRegistrationPolicy.cs
+++ b/LmpClient/Systems/Scenario/DeployedScienceLiveRegistrationPolicy.cs
@@ -1,0 +1,17 @@
+namespace LmpClient.Systems.Scenario
+{
+    public static class DeployedScienceLiveRegistrationPolicy
+    {
+        public static bool ShouldRegister(
+            bool deployedOnGround, bool beingDeployed, bool controlUnitIdAssigned,
+            bool clusterFound, bool clusterContainsPart,
+            bool isExperiment, bool clusterHasSameExperiment)
+        {
+            if (beingDeployed || !deployedOnGround) return false;
+            if (!controlUnitIdAssigned || !clusterFound) return false;
+            if (clusterContainsPart) return false;
+            if (isExperiment && clusterHasSameExperiment) return false;
+            return true;
+        }
+    }
+}

--- a/LmpClient/Systems/Scenario/DeployedScienceRelinker.cs
+++ b/LmpClient/Systems/Scenario/DeployedScienceRelinker.cs
@@ -1,0 +1,289 @@
+using System;
+using Expansions.Serenity.DeployedScience.Runtime;
+using LmpClient.Utilities;
+using LmpClient.VesselUtilities;
+using UnityEngine;
+
+namespace LmpClient.Systems.Scenario
+{
+    public static class DeployedScienceRelinker
+    {
+        //Stock caches the cluster in a private field whose only writer is the lazy getter; a
+        //module that cached the previous join's orphaned cluster never re-resolves after the
+        //deferred OnLoad replaces the dictionary. Null the cache so the stock lazy path restores.
+        private static readonly System.Reflection.FieldInfo ClusterCacheField =
+            typeof(ModuleGroundSciencePart).GetField("scienceClusterData",
+                System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance);
+
+        private static readonly System.Reflection.MethodInfo UpdateModuleUiMethod =
+            typeof(ModuleGroundSciencePart).GetMethod("UpdateModuleUI",
+                System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance);
+
+        //Mirror stock's protected tracking fields so actual output is recomputed, not forced to potential.
+        private static readonly System.Reflection.FieldInfo SecondaryTransformField =
+            typeof(ModuleGroundSciencePart).GetField("secondaryTransform",
+                System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance);
+
+        private static readonly System.Reflection.FieldInfo TrackingBodyField =
+            typeof(ModuleGroundSciencePart).GetField("trackingBody",
+                System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance);
+
+        public static void RelinkAfterDeferredOnLoad(DeployedScience deployedScience)
+        {
+            if (deployedScience?.DeployedScienceClusters == null)
+                return;
+
+            foreach (var cluster in deployedScience.DeployedScienceClusters.Values)
+            {
+                RestoreClusterPowerInputs(cluster);
+                cluster.UpdatePowerState();
+                InvalidateStaleClusterCaches(cluster);
+
+                var control = FindControlModule(cluster);
+                if (control == null)
+                {
+                    // Packed controller is normal (station out of physics range); modules re-bind on load.
+                    if (!FlightGlobals.FindUnloadedPart(cluster.ControlModulePartId, out _))
+                        LunaLog.LogError($"[LMP]: DeployedScience relink: cluster {cluster.ControlModulePartId} - control part not found in FlightGlobals (neither loaded nor packed). Live-module events skipped.");
+                }
+                else
+                {
+                    GameEvents.onGroundScienceClusterUpdated.Fire(control, cluster);
+                    GameEvents.onGroundScienceClusterPowerStateChanged.Fire(cluster);
+                    InvokeStockControllerRefresh(control);
+                    MonoUtilities.RefreshContextWindows(control.part);
+                }
+
+                SyncSolarPanelRuntimeValues(cluster);
+                RelinkExperiments(cluster);
+            }
+        }
+
+        private static void RestoreClusterPowerInputs(DeployedScienceCluster cluster)
+        {
+            var parts = cluster.DeployedScienceParts;
+            if (parts == null)
+                return;
+
+            foreach (var part in parts)
+            {
+                if (part == null || !part.IsSolarPanel)
+                    continue;
+
+                var livePart = part.PartIsLoaded();
+                ProtoPartSnapshot snapshot = null;
+                if (livePart != null)
+                {
+                    var snapshots = livePart.vessel?.protoVessel?.protoPartSnapshots;
+                    if (snapshots != null)
+                        for (var i = 0; i < snapshots.Count; i++)
+                            if (snapshots[i] != null && snapshots[i].flightID == livePart.flightID)
+                                snapshot = snapshots[i];
+                }
+                else
+                {
+                    FlightGlobals.FindUnloadedPart(part.PartId, out snapshot);
+                }
+
+                var moduleValues = FindProtoModuleValues(snapshot, "ModuleGroundSciencePart");
+                if (moduleValues == null)
+                    continue;
+
+                var protoEnabled = ParseBool(moduleValues.GetValue("isEnabled"));
+                var protoDeployed = ParseBool(moduleValues.GetValue("deployedOnGround"));
+                var protoDeploying = ParseBool(moduleValues.GetValue("beingDeployed"));
+                var protoProduced = ParseInt(moduleValues.GetValue("powerUnitsProduced"));
+
+                if (!part.Enabled && protoEnabled == true && protoDeployed == true && protoDeploying != true)
+                {
+                    part.Enabled = true;
+                }
+
+                var liveModule = livePart?.FindModuleImplementing<ModuleGroundSciencePart>();
+                if (liveModule != null && protoProduced.HasValue && liveModule.PowerUnitsProduced != protoProduced.Value)
+                {
+                    liveModule.PowerUnitsProduced = protoProduced.Value;
+                }
+            }
+        }
+
+        private static void SyncSolarPanelRuntimeValues(DeployedScienceCluster cluster)
+        {
+            if (cluster.DeployedScienceParts == null)
+                return;
+
+            foreach (var part in cluster.DeployedScienceParts)
+            {
+                if (part == null || !part.IsSolarPanel)
+                    continue;
+
+                var livePart = part.PartIsLoaded();
+                var liveModule = livePart?.FindModuleImplementing<ModuleGroundSciencePart>();
+                if (liveModule == null)
+                    continue;
+
+                Transform secondary = null;
+                CelestialBody trackingBody = null;
+                if (SecondaryTransformField != null)
+                    secondary = SecondaryTransformField.GetValue(liveModule) as Transform;
+                if (TrackingBodyField != null)
+                    trackingBody = TrackingBodyField.GetValue(liveModule) as CelestialBody;
+
+                bool hasLineOfSight = false;
+                if (secondary != null && trackingBody != null && livePart.partTransform != null)
+                {
+                    var dir = (trackingBody.position - livePart.partTransform.position).normalized;
+                    string blocker = null;
+                    try { hasLineOfSight = liveModule.CalculateTrackingLOS(dir, ref blocker); }
+                    catch (Exception e)
+                    {
+                        LunaLog.LogWarning($"[LMP]: DeployedScience relink: CalculateTrackingLOS failed for part {part.PartId}: {e.Message}");
+                        continue;
+                    }
+                }
+
+                var target = SolarPanelActualOutputPolicy.ComputeTarget(
+                    moduleBehaviourEnabled: liveModule.enabled,
+                    hasSecondaryTransform: secondary != null,
+                    hasTrackingBody: trackingBody != null,
+                    timeWarpRateIsOne: TimeWarp.CurrentRate == 1f,
+                    hasLineOfSight: hasLineOfSight,
+                    deployedOnGround: liveModule.DeployedOnGround,
+                    isEnabled: liveModule.isEnabled,
+                    potentialOutput: liveModule.PowerUnitsProduced);
+
+                //null target = stock freezes the last value (timewarp / no tracking body) — do not write.
+                if (target.HasValue && liveModule.ActualPowerUnitsProduced != target.Value)
+                {
+                    liveModule.ActualPowerUnitsProduced = target.Value; //setter fires onGroundSciencePartChanged
+                    MonoUtilities.RefreshContextWindows(livePart);
+                }
+            }
+        }
+
+        private static bool? ParseBool(string value)
+        {
+            if (bool.TryParse(value, out var result)) return result;
+            return null;
+        }
+
+        private static int? ParseInt(string value)
+        {
+            if (int.TryParse(value, out var result)) return result;
+            return null;
+        }
+
+        private static void InvalidateStaleClusterCaches(DeployedScienceCluster cluster)
+        {
+            if (ClusterCacheField == null)
+            {
+                LunaLog.LogWarning("[LMP]: DeployedScience relink: ModuleGroundSciencePart.scienceClusterData field not found - stale-cache invalidation skipped");
+                return;
+            }
+
+            try
+            {
+                var vessels = FlightGlobals.Vessels;
+                if (vessels == null) return;
+
+                for (var i = 0; i < vessels.Count; i++)
+                {
+                    var vessel = vessels[i];
+                    if (vessel == null || !vessel.loaded || vessel.parts == null) continue;
+
+                    for (var p = 0; p < vessel.parts.Count; p++)
+                    {
+                        var part = vessel.parts[p];
+                        var module = part?.FindModuleImplementing<ModuleGroundSciencePart>();
+                        if (module == null || module.ControlUnitId != cluster.ControlModulePartId) continue;
+
+                        if (ClusterCacheField.GetValue(module) != null)
+                        {
+                            ClusterCacheField.SetValue(module, null);
+                        }
+                    }
+                }
+            }
+            catch (Exception e)
+            {
+                LunaLog.LogWarning($"[LMP]: DeployedScience relink: cluster cache invalidation failed: {e.Message}");
+            }
+        }
+
+        public static void RefreshControllerUi(ModuleGroundExpControl control)
+        {
+            if (control == null) return;
+
+            InvokeStockControllerRefresh(control);
+            if (control.part != null)
+                MonoUtilities.RefreshContextWindows(control.part);
+        }
+
+        private static void InvokeStockControllerRefresh(ModuleGroundExpControl control)
+        {
+            if (UpdateModuleUiMethod == null)
+            {
+                LunaLog.LogWarning("[LMP]: DeployedScience relink: ModuleGroundSciencePart.UpdateModuleUI not found - controller PAW refresh left to stock PAW-open path");
+                return;
+            }
+
+            try
+            {
+                UpdateModuleUiMethod.Invoke(control, null);
+            }
+            catch (Exception e)
+            {
+                LunaLog.LogWarning($"[LMP]: DeployedScience relink: stock controller UpdateModuleUI invoke failed: {e.Message}");
+            }
+        }
+
+        private static ModuleGroundExpControl FindControlModule(DeployedScienceCluster cluster)
+        {
+            uint controlPartId = cluster.ControlModulePartId;
+            return FlightGlobals.FindLoadedPart(controlPartId, out var part) && part != null
+                ? part.FindModuleImplementing<ModuleGroundExpControl>()
+                : null;
+        }
+
+        private static void RelinkExperiments(DeployedScienceCluster cluster)
+        {
+            foreach (var part in cluster.DeployedScienceParts)
+            {
+                var experiment = part.Experiment; // null for solar panels / antennas
+                if (experiment == null)
+                    continue;
+
+                var module = experiment.GroundExperimentModule; // null when the vessel is unloaded
+                if (module == null)
+                    continue;
+
+                module.ScienceModifierRate = experiment.ScienceModifierRate;
+                module.ScienceLimit = experiment.ScienceLimit;
+                module.ScienceValue = experiment.ScienceValue;
+                MonoUtilities.RefreshContextWindows(module.part);
+            }
+        }
+
+        private static global::ConfigNode FindProtoModuleValues(global::ProtoPartSnapshot snapshot, string moduleName)
+        {
+            try
+            {
+                var modules = snapshot?.modules;
+                if (modules == null)
+                    return null;
+
+                for (var i = 0; i < modules.Count; i++)
+                {
+                    var moduleSnapshot = modules[i];
+                    if (moduleSnapshot != null && moduleSnapshot.moduleName == moduleName)
+                        return moduleSnapshot.moduleValues;
+                }
+            }
+            catch
+            {
+            }
+
+            return null;
+        }
+    }
+}

--- a/LmpClient/Systems/Scenario/DeployedScienceSyncGate.cs
+++ b/LmpClient/Systems/Scenario/DeployedScienceSyncGate.cs
@@ -1,0 +1,114 @@
+using System;
+using System.Collections.Generic;
+
+namespace LmpClient.Systems.Scenario
+{
+    public static class DeployedScienceSyncGate
+    {
+        public const string ScenarioModuleName = "DeployedScience";
+
+        public static bool DeployedScienceReady { get; set; }
+
+        public static bool ShouldSend(string scenarioModuleName)
+        {
+            if (!string.Equals(scenarioModuleName, ScenarioModuleName, StringComparison.Ordinal))
+                return true;
+            return DeployedScienceReady;
+        }
+
+        public static bool ShouldMarkFreshModuleAuthoritative(bool receivedScenarioEntry, bool vesselSyncComplete, bool alreadyReady)
+        {
+            return !receivedScenarioEntry && vesselSyncComplete && !alreadyReady;
+        }
+
+        public sealed class ClusterMembership
+        {
+            public readonly HashSet<uint> PartIds = new HashSet<uint>();
+            public readonly HashSet<string> ExperimentIds = new HashSet<string>(StringComparer.Ordinal);
+        }
+
+        public static bool IsMembershipApplied(IReadOnlyDictionary<uint, ClusterMembership> declared, IReadOnlyDictionary<uint, ClusterMembership> applied)
+        {
+            if (declared.Count != applied.Count)
+                return false;
+
+            foreach (var pair in declared)
+            {
+                if (!applied.TryGetValue(pair.Key, out var appliedCluster))
+                    return false;
+
+                if (!pair.Value.PartIds.SetEquals(appliedCluster.PartIds))
+                    return false;
+
+                if (!pair.Value.ExperimentIds.SetEquals(appliedCluster.ExperimentIds))
+                    return false;
+            }
+
+            return true;
+        }
+    }
+
+    public class VesselSyncCompletionTracker
+    {
+        private readonly double _graceSeconds;
+        private bool _isComplete;
+        private bool _wasReady;
+        private double? _readySince;
+        private double? _lastActivity;
+
+        public VesselSyncCompletionTracker(double graceSeconds)
+        {
+            _graceSeconds = graceSeconds;
+        }
+
+        public bool IsComplete => _isComplete;
+
+        public void Update(double now, bool protoSystemReady, bool anyProtoPending, bool vesselLoadedThisTick)
+        {
+            if (_isComplete)
+                return; // latched
+
+            if (!protoSystemReady)
+            {
+                _wasReady = false;
+                _readySince = null;
+                _lastActivity = null;
+                return;
+            }
+
+            bool hasActivity = anyProtoPending || vesselLoadedThisTick;
+            if (hasActivity)
+            {
+                //Completion is measured from the last observed activity.
+                _lastActivity = now;
+                _readySince = null;
+                return;
+            }
+
+            if (_lastActivity.HasValue)
+            {
+                if (now - _lastActivity.Value >= _graceSeconds)
+                    _isComplete = true;
+                return;
+            }
+
+            if (!_wasReady)
+            {
+                //Ready with nothing pending: the grace window starts now.
+                _readySince = now;
+                _wasReady = true;
+            }
+
+            if (_readySince.HasValue && now - _readySince.Value >= _graceSeconds)
+                _isComplete = true;
+        }
+
+        public void Reset()
+        {
+            _isComplete = false;
+            _wasReady = false;
+            _readySince = null;
+            _lastActivity = null;
+        }
+    }
+}

--- a/LmpClient/Systems/Scenario/ScenarioSystem.cs
+++ b/LmpClient/Systems/Scenario/ScenarioSystem.cs
@@ -830,6 +830,7 @@ namespace LmpClient.Systems.Scenario
                     return;
                 }
 
+                DeployedScienceRelinker.RelinkAfterDeferredOnLoad(deployedScience);
             }
             catch (Exception e)
             {

--- a/LmpClient/Systems/Scenario/ScenarioSystem.cs
+++ b/LmpClient/Systems/Scenario/ScenarioSystem.cs
@@ -1,7 +1,9 @@
 ﻿using LmpClient.Base;
 using LmpClient.Extensions;
+using LmpClient.Events;
 using LmpClient.Systems.SettingsSys;
 using LmpClient.Systems.ShareContracts;
+using LmpClient.Systems.VesselProtoSys;
 using LmpClient.Utilities;
 using LmpCommon;
 using System;
@@ -11,6 +13,7 @@ using System.IO;
 using System.Text;
 using Expansions;
 using UniLinq;
+using UnityEngine;
 
 namespace LmpClient.Systems.Scenario
 {
@@ -43,6 +46,20 @@ namespace LmpClient.Systems.Scenario
 
         private static List<string> ScenarioName { get; } = new List<string>();
         private static List<byte[]> ScenarioData { get; } = new List<byte[]>();
+
+        private const int DeferredApplyIntervalMs = 5000;
+        private const int MaxDeferredApplyAttempts = 60;
+
+        private readonly VesselSyncCompletionTracker _vesselSyncTracker = new VesselSyncCompletionTracker(5);
+        private ConfigNode _deferredDeployedScienceNode;
+        private bool _deferredDeployedScienceApplied;
+        private int _deferredApplyAttempts;
+        private bool _vesselLoadedThisTick;
+
+        //True once the server delivered a DeployedScience entry this connection; lets a server with
+        //no DeployedScience.txt treat the client-created module as authoritative and sendable.
+        private bool _receivedDeployedScienceScenarioEntry;
+
         #endregion
 
         #region Base overrides
@@ -54,13 +71,27 @@ namespace LmpClient.Systems.Scenario
         protected override void OnEnabled()
         {
             base.OnEnabled();
+            DeployedScienceSyncGate.DeployedScienceReady = false;
+            _receivedDeployedScienceScenarioEntry = false;
             //Run it every 30 seconds
             SetupRoutine(new RoutineDefinition(30000, RoutineExecution.Update, SendScenarioModules));
+            //Apply the deferred DeployedScience data once the initial vessel sync completes
+            SetupRoutine(new RoutineDefinition(DeferredApplyIntervalMs, RoutineExecution.Update, ApplyDeferredDeployedScience));
+            VesselLoadEvent.onLmpVesselLoaded.Add(OnLmpVesselLoaded);
         }
 
         protected override void OnDisabled()
         {
             base.OnDisabled();
+            VesselLoadEvent.onLmpVesselLoaded.Remove(OnLmpVesselLoaded);
+            _vesselSyncTracker.Reset();
+            _deferredDeployedScienceNode = null;
+            _deferredDeployedScienceApplied = false;
+            _deferredApplyAttempts = 0;
+            _vesselLoadedThisTick = false;
+            _receivedDeployedScienceScenarioEntry = false;
+            DeployedScienceSyncGate.DeployedScienceReady = false;
+
             CheckData.Clear();
             ScenarioQueue = new ConcurrentQueue<ScenarioEntry>();
             AllScenarioTypesInAssemblies.Clear();
@@ -167,6 +198,13 @@ namespace LmpClient.Systems.Scenario
                 if (!IsScenarioModuleAllowed(scenarioType))
                     continue;
 
+                //Never send a pruned/partial DeployedScience state — only after its authoritative
+                //node was applied (a premature send would poison the server copy).
+                if (!DeployedScienceSyncGate.ShouldSend(scenarioType))
+                {
+                    continue;
+                }
+
                 var configNode = new ConfigNode();
                 scenarioModule.Save(configNode);
 
@@ -222,6 +260,37 @@ namespace LmpClient.Systems.Scenario
                     LunaLog.LogError(
                         $"[LMP]: Skipping scenario '{scenarioEntry.ScenarioModule}' with null ConfigNode. See NullScenario.log in your KSP install folder.");
                     WriteNullScenarioDebugLog(scenarioEntry);
+                    continue;
+                }
+
+                //Deferred until the vessel sync completes: stock OnLoad prunes clusters whose
+                //parts are not in FlightGlobals yet, so an early apply would be poisoned.
+                if (string.Equals(scenarioEntry.ScenarioModule, DeployedScienceSyncGate.ScenarioModuleName, StringComparison.Ordinal))
+                {
+                    if (!IsScenarioModuleAllowed(scenarioEntry.ScenarioModule))
+                    {
+                        LunaLog.Log($"[LMP]: Skipping {scenarioEntry.ScenarioModule} scenario data (not allowed in this game)");
+                        continue;
+                    }
+
+                    //The server delivered a node: the fresh-server (client-created module)
+                    //branch must not fire, and a late entry clears Ready and re-defers.
+                    _receivedDeployedScienceScenarioEntry = true;
+
+                    DeployedScienceSyncGate.DeployedScienceReady = false;
+
+                    _deferredDeployedScienceNode = scenarioEntry.ScenarioNode.CreateCopy();
+                    _deferredDeployedScienceApplied = false;
+                    _deferredApplyAttempts = 0;
+
+                    if (_vesselSyncTracker.IsComplete)
+                    {
+                        ApplyDeployedScienceNode();
+                    }
+                    else
+                    {
+                        LunaLog.Log($"[LMP]: Deferring {scenarioEntry.ScenarioModule} scenario data until the initial vessel sync completes");
+                    }
                     continue;
                 }
 
@@ -690,6 +759,170 @@ namespace LmpClient.Systems.Scenario
         #endregion
 
         #region Private methods
+
+        private void OnLmpVesselLoaded(Vessel vessel)
+        {
+            _vesselLoadedThisTick = true;
+        }
+
+        private void ApplyDeferredDeployedScience()
+        {
+            if (!Enabled) return;
+
+            try
+            {
+                var protoSystem = VesselProtoSystem.Singleton;
+                var anyProtoPending = protoSystem.VesselProtos.Values.Any(q => !q.IsEmpty);
+                _vesselSyncTracker.Update(Time.realtimeSinceStartup, protoSystem.ProtoSystemReady, anyProtoPending, _vesselLoadedThisTick);
+                _vesselLoadedThisTick = false;
+
+                if (DeployedScienceSyncGate.ShouldMarkFreshModuleAuthoritative(
+                        _receivedDeployedScienceScenarioEntry, _vesselSyncTracker.IsComplete, DeployedScienceSyncGate.DeployedScienceReady))
+                {
+                    DeployedScienceSyncGate.DeployedScienceReady = true;
+                    LunaLog.Log("[LMP]: No DeployedScience scenario data received from the server - the locally created module is authoritative and sendable");
+                }
+
+                if (!_vesselSyncTracker.IsComplete || _deferredDeployedScienceNode == null || _deferredDeployedScienceApplied)
+                    return;
+
+                ApplyDeployedScienceNode();
+            }
+            catch (Exception e)
+            {
+                LunaLog.LogError($"Error while trying to apply the deferred DeployedScience scenario data. Details: {e}");
+            }
+        }
+
+        private void ApplyDeployedScienceNode()
+        {
+            var deployedScience = Expansions.Serenity.DeployedScience.Runtime.DeployedScience.Instance;
+            if (deployedScience == null)
+                return;
+
+            var dataNode = _deferredDeployedScienceNode.GetNode("SCENARIO")?.CreateCopy() ?? _deferredDeployedScienceNode.CreateCopy();
+
+            try
+            {
+                foreach (var oldCluster in deployedScience.DeployedScienceClusters.Values)
+                    if (oldCluster != null) UnityEngine.Object.Destroy(oldCluster.gameObject);
+
+                deployedScience.DeployedScienceClusters.Clear();
+
+                deployedScience.OnLoad(dataNode);
+
+                var declaredMembership = BuildDeclaredMembership(dataNode);
+                var appliedMembership = BuildAppliedMembership(deployedScience);
+                var declaredClusters = declaredMembership.Count;
+                var appliedClusters = appliedMembership.Count;
+
+                if (!DeployedScienceSyncGate.IsMembershipApplied(declaredMembership, appliedMembership))
+                {
+                    _deferredApplyAttempts++;
+                    if (_deferredApplyAttempts < MaxDeferredApplyAttempts)
+                        return;
+
+                    _deferredDeployedScienceNode = null;
+                    _deferredDeployedScienceApplied = true;
+                    DeployedScienceSyncGate.DeployedScienceReady = false;
+
+                    LunaLog.LogError($"[LMP]: Giving up applying the DeployedScience scenario data after {MaxDeferredApplyAttempts} attempts ({appliedClusters}/{declaredClusters} clusters applied). The scenario remains unsent so the pruned state cannot poison the server.");
+                    return;
+                }
+
+            }
+            catch (Exception e)
+            {
+                _deferredApplyAttempts++;
+                if (_deferredApplyAttempts < MaxDeferredApplyAttempts)
+                {
+                    LunaLog.LogWarning($"[LMP]: DeployedScience apply failed (attempt {_deferredApplyAttempts}/{MaxDeferredApplyAttempts}), retrying: {e.Message}");
+                    return;
+                }
+
+                _deferredDeployedScienceNode = null;
+                _deferredDeployedScienceApplied = true;
+                DeployedScienceSyncGate.DeployedScienceReady = false;
+                LunaLog.LogError($"[LMP]: Giving up applying DeployedScience after {MaxDeferredApplyAttempts} attempts. Last error: {e}");
+                return;
+            }
+
+            _deferredDeployedScienceApplied = true;
+            _deferredDeployedScienceNode = null;
+            DeployedScienceSyncGate.DeployedScienceReady = true;
+
+            LunaLog.Log($"[LMP]: Applied the DeployedScience scenario data after the initial vessel sync completed");
+        }
+
+        private static Dictionary<uint, DeployedScienceSyncGate.ClusterMembership> BuildDeclaredMembership(ConfigNode dataNode)
+        {
+            var declared = new Dictionary<uint, DeployedScienceSyncGate.ClusterMembership>();
+            var clustersNode = dataNode?.GetNode("SCIENCECLUSTERS");
+            if (clustersNode == null) return declared;
+
+            foreach (var clusterNode in clustersNode.GetNodes("SCIENCECLUSTER"))
+            {
+                if (clusterNode == null) continue;
+                var cidText = clusterNode.GetValue("ControlModulePartId");
+                if (!uint.TryParse(cidText, out var controlId) || controlId == 0) continue;
+
+                var membership = new DeployedScienceSyncGate.ClusterMembership();
+
+                var partsNode = clusterNode.GetNode("MANNEDSCIENCEPARTS");
+                if (partsNode != null)
+                {
+                    foreach (var partNode in partsNode.GetNodes("MANNEDSCIENCEPART"))
+                    {
+                        if (partNode == null) continue;
+                        var pidText = partNode.GetValue("PartId");
+                        if (uint.TryParse(pidText, out var partId) && partId != 0)
+                            membership.PartIds.Add(partId);
+
+                        var experimentNode = partNode.GetNode("EXPERIMENT");
+                        var experimentId = experimentNode?.GetValue("ExperimentId");
+                        if (!string.IsNullOrEmpty(experimentId))
+                            membership.ExperimentIds.Add(experimentId);
+                    }
+                }
+
+                declared[controlId] = membership;
+            }
+
+            return declared;
+        }
+
+        private static Dictionary<uint, DeployedScienceSyncGate.ClusterMembership> BuildAppliedMembership(
+            Expansions.Serenity.DeployedScience.Runtime.DeployedScience deployedScience)
+        {
+            var applied = new Dictionary<uint, DeployedScienceSyncGate.ClusterMembership>();
+            if (deployedScience?.DeployedScienceClusters == null) return applied;
+
+            foreach (var cluster in deployedScience.DeployedScienceClusters.Values)
+            {
+                if (cluster == null) continue;
+
+                var membership = new DeployedScienceSyncGate.ClusterMembership();
+
+                var parts = cluster.DeployedScienceParts;
+                if (parts != null)
+                {
+                    for (var i = 0; i < parts.Count; i++)
+                    {
+                        var part = parts[i];
+                        if (part == null) continue;
+                        membership.PartIds.Add(part.PartId);
+
+                        var experiment = part.Experiment;
+                        if (experiment != null && !string.IsNullOrEmpty(experiment.ExperimentId))
+                            membership.ExperimentIds.Add(experiment.ExperimentId);
+                    }
+                }
+
+                applied[cluster.ControlModulePartId] = membership;
+            }
+
+            return applied;
+        }
 
         private static void WriteNullScenarioDebugLog(ScenarioEntry entry)
         {

--- a/LmpClient/Systems/Scenario/ScenarioSystem.cs
+++ b/LmpClient/Systems/Scenario/ScenarioSystem.cs
@@ -77,6 +77,8 @@ namespace LmpClient.Systems.Scenario
             SetupRoutine(new RoutineDefinition(30000, RoutineExecution.Update, SendScenarioModules));
             //Apply the deferred DeployedScience data once the initial vessel sync completes
             SetupRoutine(new RoutineDefinition(DeferredApplyIntervalMs, RoutineExecution.Update, ApplyDeferredDeployedScience));
+            //Live deployed-science registration sweep
+            SetupRoutine(new RoutineDefinition(2000, RoutineExecution.Update, DeployedScienceLiveRegistration.EvaluatePendingRegistrations));
             VesselLoadEvent.onLmpVesselLoaded.Add(OnLmpVesselLoaded);
         }
 

--- a/LmpClient/Systems/VesselProtoSys/TransientVesselSendHandler.cs
+++ b/LmpClient/Systems/VesselProtoSys/TransientVesselSendHandler.cs
@@ -1,0 +1,204 @@
+using LmpClient.Systems.VesselRemoveSys;
+using LmpClient.Utilities;
+using LmpClient.VesselUtilities;
+using System;
+using System.Collections.Concurrent;
+using UnityEngine;
+
+namespace LmpClient.Systems.VesselProtoSys
+{
+    public class TransientVesselSendHandler
+    {
+        private const float RetryDelaySeconds = 1f;
+
+        private const int MaxRetries = 30;
+
+        private class DeferredVesselState
+        {
+            public string VesselName { get; set; }
+            public bool ForceReload { get; set; }
+            public string Reason { get; set; }
+            public int RetryCount { get; set; }
+        }
+
+        public class DeferResult
+        {
+            public bool Deferred { get; set; }
+
+            public bool EffectiveForceReload { get; set; }
+
+            public string EffectiveReason { get; set; }
+        }
+
+        private readonly Action<ProtoVessel, bool, string> _sendAction;
+
+        private readonly ConcurrentDictionary<Guid, DeferredVesselState> _deferredVessels = new ConcurrentDictionary<Guid, DeferredVesselState>();
+
+        public TransientVesselSendHandler(Action<ProtoVessel, bool, string> sendAction)
+        {
+            _sendAction = sendAction;
+        }
+
+        public void Clear()
+        {
+            _deferredVessels.Clear();
+        }
+
+        public DeferResult DeferIfTransient(ProtoVessel protoVessel, bool forceReload, string reason)
+        {
+            var result = new DeferResult
+            {
+                EffectiveForceReload = forceReload,
+                EffectiveReason = reason,
+            };
+
+            if (protoVessel == null) return result;
+
+            //Skip vessels that cannot carry ground state.
+            if (!HasGroundModule(protoVessel)) return result;
+
+            if (!IsTransient(protoVessel))
+            {
+                //Settled with a pending deferred send: consume it now so the retry loop
+                //cannot fire a duplicate on the now-settled vessel.
+                if (_deferredVessels.TryRemove(protoVessel.vesselID, out var pending))
+                {
+                    result.EffectiveForceReload = forceReload || pending.ForceReload;
+                    //Keep the pending reason — it describes the original send that triggered the deferral.
+                    result.EffectiveReason = pending.Reason ?? reason;
+                }
+                return result;
+            }
+
+            //Already deferred: merge into the pending entry instead of a second retry loop.
+            if (_deferredVessels.TryGetValue(protoVessel.vesselID, out var existing))
+            {
+                existing.ForceReload |= forceReload;
+                result.Deferred = true;
+                return result;
+            }
+
+            _deferredVessels[protoVessel.vesselID] = new DeferredVesselState
+            {
+                VesselName = protoVessel.vesselName,
+                ForceReload = forceReload,
+                Reason = reason,
+            };
+
+            ScheduleRetry(protoVessel.vesselID);
+
+            result.Deferred = true;
+            return result;
+        }
+
+        #region Private methods
+
+        private static bool HasGroundModule(ProtoVessel protoVessel)
+        {
+            if (protoVessel.protoPartSnapshots == null) return false;
+
+            foreach (var part in protoVessel.protoPartSnapshots)
+            {
+                if (part?.modules == null) continue;
+
+                for (var i = 0; i < part.modules.Count; i++)
+                {
+                    if (TransientDeployedStateDetector.IsGroundModule(part.modules[i].moduleName))
+                        return true;
+                }
+            }
+
+            return false;
+        }
+
+        private static bool IsTransient(ProtoVessel protoVessel)
+        {
+            try
+            {
+                foreach (var part in protoVessel.protoPartSnapshots)
+                {
+                    if (part?.modules == null) continue;
+
+                    for (var i = 0; i < part.modules.Count; i++)
+                    {
+                        var module = part.modules[i];
+                        if (!TransientDeployedStateDetector.IsGroundModule(module.moduleName)) continue;
+
+                        var values = module.moduleValues;
+                        var beingDeployed = GetPersistedBool(values, "beingDeployed");
+                        var deployedOnGround = GetPersistedBool(values, "deployedOnGround");
+                        var isEnabled = GetPersistedBool(values, "isEnabled");
+
+                        if (TransientDeployedStateDetector.IsTransientDeployedModule(module.moduleName, beingDeployed, deployedOnGround, isEnabled))
+                            return true;
+                    }
+                }
+
+                return false;
+            }
+            catch (Exception e)
+            {
+                // Never block a send just because the detection failed.
+                LunaLog.LogError($"[LMP]: Failed to check transient deployed state of vessel {protoVessel.vesselID}: {e}");
+                return false;
+            }
+        }
+
+        private static bool? GetPersistedBool(ConfigNode moduleValues, string key)
+        {
+            var value = moduleValues?.GetValue(key);
+            if (value == null) return null;
+            if (bool.TryParse(value, out var result)) return result;
+            return null;
+        }
+
+        private void ScheduleRetry(Guid vesselId)
+        {
+            CoroutineUtil.StartDelayedRoutine($"RetryVesselSend_{vesselId}", () => RetrySend(vesselId), RetryDelaySeconds);
+        }
+
+        private void RetrySend(Guid vesselId)
+        {
+            if (!_deferredVessels.TryGetValue(vesselId, out var state)) return;
+
+            var vessel = FlightGlobals.FindVessel(vesselId);
+            if (vessel == null || vessel.state == Vessel.State.DEAD || VesselRemoveSystem.Singleton.VesselWillBeKilled(vesselId))
+            {
+                _deferredVessels.TryRemove(vesselId, out _);
+                return;
+            }
+
+            if (state.RetryCount >= MaxRetries)
+            {
+                _deferredVessels.TryRemove(vesselId, out _);
+                LunaLog.LogWarning($"[LMP]: Aborted deferred send of vessel {state.VesselName} - {vesselId} - deployment never settled after {MaxRetries} retries");
+                return;
+            }
+
+            state.RetryCount++;
+
+            ProtoVessel freshProto;
+            try
+            {
+                freshProto = vessel.BackupVessel();
+            }
+            catch (Exception e)
+            {
+                LunaLog.LogWarning($"[LMP]: BackupVessel failed for deferred send of {vesselId} (will retry): {e.Message}");
+                ScheduleRetry(vesselId);
+                return;
+            }
+
+            if (!IsTransient(freshProto))
+            {
+                _deferredVessels.TryRemove(vesselId, out _);
+                _sendAction?.Invoke(freshProto, state.ForceReload, state.Reason);
+                return;
+            }
+
+            ScheduleRetry(vesselId);
+        }
+
+        #endregion
+    }
+}

--- a/LmpClient/Systems/VesselProtoSys/VesselProtoMessageSender.cs
+++ b/LmpClient/Systems/VesselProtoSys/VesselProtoMessageSender.cs
@@ -22,6 +22,18 @@ namespace LmpClient.Systems.VesselProtoSys
 
         private static readonly object VesselArraySyncLock = new object();
 
+        private readonly TransientVesselSendHandler _transientSendHandler;
+
+        public VesselProtoMessageSender()
+        {
+            _transientSendHandler = new TransientVesselSendHandler(SendVesselMessage);
+        }
+
+        public void ClearTransientDeferrals()
+        {
+            _transientSendHandler.Clear();
+        }
+
         public void SendMessage(IMessageData msg)
         {
             NetworkSender.QueueOutgoingMessage(MessageFactory.CreateNew<VesselCliMsg>(msg));
@@ -62,9 +74,19 @@ namespace LmpClient.Systems.VesselProtoSys
         private void SendVesselMessage(ProtoVessel protoVessel, bool forceReload, string reason)
         {
             if (protoVessel == null || protoVessel.vesselID == Guid.Empty) return;
+
+            //Defer sends of mid-deploy ground vessels — a transient snapshot stored as canonical would corrupt them.
+            var deferResult = _transientSendHandler.DeferIfTransient(protoVessel, forceReload, reason);
+            if (deferResult.Deferred)
+                return;
+
+            //Use the effective values: a consumed pending entry merged ForceReload/Reason into the result.
+            var effectiveForceReload = deferResult.EffectiveForceReload;
+            var effectiveReason = deferResult.EffectiveReason;
+
             //Doing this in another thread can crash the game as during the serialization into a config node Lingoona is called...
             //TODO: Check if this works fine with the new unity version as it used to crash....
-            TaskFactory.StartNew(() => PrepareAndSendProtoVessel(protoVessel, forceReload, reason));
+            TaskFactory.StartNew(() => PrepareAndSendProtoVessel(protoVessel, effectiveForceReload, effectiveReason));
             //PrepareAndSendProtoVessel(protoVessel);
         }
 

--- a/LmpClient/Systems/VesselProtoSys/VesselProtoSystem.cs
+++ b/LmpClient/Systems/VesselProtoSys/VesselProtoSystem.cs
@@ -106,6 +106,7 @@ namespace LmpClient.Systems.VesselProtoSys
             LocalTopologyTracker.ClearAll();
             //The sender survives reconnection — drop a deferral pending from the previous connection.
             MessageSender.ClearTransientDeferrals();
+            StalePersistentIdEvictor.ClearAll();
         }
 
         #endregion
@@ -269,6 +270,8 @@ namespace LmpClient.Systems.VesselProtoSys
                     var vesselId = vesselProto.VesselId;
                     keyVal.Value.Recycle(vesselProto);
 
+                    try
+                    {
                     var verboseErrors = !VesselsUnableToLoad.Contains(vesselId);
                     if (protoVessel == null)
                     {
@@ -282,6 +285,7 @@ namespace LmpClient.Systems.VesselProtoSys
                             SafePartCount(protoVessel),
                             reason: "ProtoVessel.Validate returned false");
                         VesselsUnableToLoad.Add(vesselId);
+                        StalePersistentIdEvictor.RollbackEvictions(vesselId, protoVessel);
                         continue;
                     }
                     if (protoVessel.HasInvalidParts(verboseErrors))
@@ -290,6 +294,7 @@ namespace LmpClient.Systems.VesselProtoSys
                             SafePartCount(protoVessel),
                             reason: "ProtoVessel.HasInvalidParts returned true (one or more part definitions absent from local install)");
                         VesselsUnableToLoad.Add(vesselId);
+                        StalePersistentIdEvictor.RollbackEvictions(vesselId, protoVessel);
                         continue;
                     }
 
@@ -343,9 +348,16 @@ namespace LmpClient.Systems.VesselProtoSys
                             //still gets the UNCHANGED event above because "incoming wire
                             //update for an already-matched vessel" is a useful signal
                             //when reading the trace.
+                            StalePersistentIdEvictor.RollbackEvictions(vesselId, protoVessel);
                             break;
                         case VesselLoadOutcome.Failed:
+                            StalePersistentIdEvictor.RollbackEvictions(vesselId, protoVessel);
                             break;
+                    }
+                    }
+                    finally
+                    {
+                        StalePersistentIdEvictor.RollbackEvictions(vesselId, protoVessel);
                     }
                 }
             }

--- a/LmpClient/Systems/VesselProtoSys/VesselProtoSystem.cs
+++ b/LmpClient/Systems/VesselProtoSys/VesselProtoSystem.cs
@@ -104,6 +104,8 @@ namespace LmpClient.Systems.VesselProtoSys
             ManeuverSignatures.Clear();
             LastBroadcastDriftPartCount.Clear();
             LocalTopologyTracker.ClearAll();
+            //The sender survives reconnection — drop a deferral pending from the previous connection.
+            MessageSender.ClearTransientDeferrals();
         }
 
         #endregion

--- a/LmpClient/Systems/VesselRemoveSys/VesselRemoveSystem.cs
+++ b/LmpClient/Systems/VesselRemoveSys/VesselRemoveSystem.cs
@@ -104,7 +104,23 @@ namespace LmpClient.Systems.VesselRemoveSys
                 RemovedVessels.TryAdd(vesselId, LunaNetworkTime.UtcNow);
             }
 
-            KillVessel(FlightGlobals.FindVessel(vesselId), reason);
+            var liveVessel = FlightGlobals.FindVessel(vesselId);
+
+            //Orphan case: the Vessel overload below early-outs when the live vessel is gone, and a
+            //leftover proto keeps every persistentId registered, so stock renames on reconnect.
+            if (liveVessel == null || liveVessel.state == Vessel.State.DEAD)
+            {
+                try
+                {
+                    HighLogic.CurrentGame?.flightState?.protoVessels.RemoveAll(v => v != null && v.vesselID == vesselId);
+                }
+                catch (Exception e)
+                {
+                    LunaLog.LogWarning($"[LMP]: Failed to remove proto of vessel {vesselId} from flightState: {e.Message}");
+                }
+            }
+
+            KillVessel(liveVessel, reason);
         }
 
         /// <summary>

--- a/LmpClient/VesselUtilities/PersistentIdEvictionPolicy.cs
+++ b/LmpClient/VesselUtilities/PersistentIdEvictionPolicy.cs
@@ -1,0 +1,43 @@
+using System;
+
+namespace LmpClient.VesselUtilities
+{
+    public enum PersistentIdEvictionDecision
+    {
+        NotRegistered,
+        EvictStaleOwner,
+        KeepForeignOwner,
+    }
+
+    public static class PersistentIdEvictionPolicy
+    {
+        public static PersistentIdEvictionDecision DecideUnloaded(
+            bool registered, bool ownerSnapshotNull, bool ownerVesselNull, bool ownerIsIncomingVessel)
+        {
+            if (!registered) return PersistentIdEvictionDecision.NotRegistered;
+            if (ownerSnapshotNull || ownerVesselNull || ownerIsIncomingVessel) return PersistentIdEvictionDecision.EvictStaleOwner;
+            return PersistentIdEvictionDecision.KeepForeignOwner;
+        }
+
+        public static PersistentIdEvictionDecision DecideLoaded(
+            bool registered, bool ownerPartNull, bool ownerVesselNull, bool ownerIsIncomingVessel)
+        {
+            if (!registered) return PersistentIdEvictionDecision.NotRegistered;
+            if (ownerPartNull || ownerVesselNull || ownerIsIncomingVessel) return PersistentIdEvictionDecision.EvictStaleOwner;
+            return PersistentIdEvictionDecision.KeepForeignOwner;
+        }
+
+        public static bool ShouldRestoreLoadedOwner(bool ownerVesselStillPresent, bool idAlreadyRegistered)
+        {
+            return ownerVesselStillPresent && !idAlreadyRegistered;
+        }
+
+        public static bool IsDanglingVesselRegistration(object owner, Guid vesselId,
+            Func<object, Guid> ownerVesselId, Func<object, bool> ownerIsPresent)
+        {
+            if (owner == null) return false;
+            if (ownerVesselId(owner) != vesselId) return false;
+            return !ownerIsPresent(owner);
+        }
+    }
+}

--- a/LmpClient/VesselUtilities/SolarPanelActualOutputPolicy.cs
+++ b/LmpClient/VesselUtilities/SolarPanelActualOutputPolicy.cs
@@ -1,0 +1,25 @@
+namespace LmpClient.VesselUtilities
+{
+    public static class SolarPanelActualOutputPolicy
+    {
+        public static int? ComputeTarget(
+            bool moduleBehaviourEnabled,
+            bool hasSecondaryTransform,
+            bool hasTrackingBody,
+            bool timeWarpRateIsOne,
+            bool hasLineOfSight,
+            bool deployedOnGround,
+            bool isEnabled,
+            int potentialOutput)
+        {
+            if (moduleBehaviourEnabled && hasSecondaryTransform && hasTrackingBody && timeWarpRateIsOne)
+                return hasLineOfSight ? potentialOutput : 0;
+
+            //Stock freezes the last actual value while timewarping / no tracking body — don't overwrite.
+            if (deployedOnGround && isEnabled && moduleBehaviourEnabled)
+                return null;
+
+            return 0;
+        }
+    }
+}

--- a/LmpClient/VesselUtilities/StalePersistentIdEvictor.cs
+++ b/LmpClient/VesselUtilities/StalePersistentIdEvictor.cs
@@ -1,0 +1,389 @@
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using LmpClient.Utilities;
+
+namespace LmpClient.VesselUtilities
+{
+    public static class StalePersistentIdEvictor
+    {
+        private sealed class ClaimedPartIdentity
+        {
+            public uint Id;
+            public ProtoPartSnapshot PreviousUnloadedOwner;
+            public Part PreviousLoadedOwner;
+        }
+
+        private sealed class VesselEvictionRecord
+        {
+            public readonly List<ClaimedPartIdentity> Claims = new List<ClaimedPartIdentity>();
+
+            public ClaimedPartIdentity FindOrCreateClaim(uint id)
+            {
+                for (var i = 0; i < Claims.Count; i++)
+                    if (Claims[i].Id == id)
+                        return Claims[i];
+
+                var claim = new ClaimedPartIdentity { Id = id };
+                Claims.Add(claim);
+                return claim;
+            }
+        }
+
+        private static readonly ConcurrentDictionary<Guid, VesselEvictionRecord> EvictionsByVessel
+            = new ConcurrentDictionary<Guid, VesselEvictionRecord>();
+
+        private struct ForeignCollisionInfo
+        {
+            public int Count;
+            public string FirstOwnerDescription;
+        }
+
+        public static Dictionary<uint, uint> PreflightWireIdentityAndEvict(ConfigNode vesselNode, Guid vesselId)
+        {
+            var claimedIds = new Dictionary<uint, uint>();
+            try
+            {
+                var partNodes = vesselNode?.GetNodes("PART");
+                if (partNodes == null) return claimedIds;
+
+                var foreignInfo = new ForeignCollisionInfo();
+                foreach (var partNode in partNodes)
+                {
+                    var pidText = partNode?.GetValue("persistentId");
+                    if (string.IsNullOrEmpty(pidText) || !uint.TryParse(pidText, out var claimedId) || claimedId == 0)
+                        continue;
+
+                    uint flightId = 0;
+                    var uidText = partNode?.GetValue("uid");
+                    if (!string.IsNullOrEmpty(uidText)) uint.TryParse(uidText, out flightId);
+                    claimedIds[flightId] = claimedId;
+
+                    //Snapshot owners before evicting so rollback can restore them.
+                    var claim = GetRecord(vesselId).FindOrCreateClaim(claimedId);
+                    if (claim.PreviousUnloadedOwner == null
+                        && FlightGlobals.PersistentUnloadedPartIds.TryGetValue(claimedId, out var prevUnloaded))
+                        claim.PreviousUnloadedOwner = prevUnloaded;
+                    if (claim.PreviousLoadedOwner == null
+                        && FlightGlobals.PersistentLoadedPartIds.TryGetValue(claimedId, out var prevLoaded))
+                        claim.PreviousLoadedOwner = prevLoaded;
+
+                    ResolvePartIdCollision(claimedId, vesselId, ref foreignInfo);
+                }
+
+                if (foreignInfo.Count > 0)
+                    LunaLog.LogWarning($"[LMP]: PersistentId collisions: vessel {vesselId} has {foreignInfo.Count} part ID(s) owned by foreign vessel(s) ({foreignInfo.FirstOwnerDescription}); stock may rename");
+            }
+            catch (Exception e)
+            {
+                LunaLog.LogWarning($"[LMP]: Wire identity preflight failed for {vesselId} (falling back to stock collision handling): {e.Message}");
+            }
+            return claimedIds;
+        }
+
+        public static void LogWireConstructionResult(ProtoVessel constructed, Dictionary<uint, uint> claimedIds, Guid vesselId)
+        {
+            try
+            {
+                var snapshots = constructed?.protoPartSnapshots;
+                if (claimedIds == null || snapshots == null) return;
+
+                var renamed = 0;
+                foreach (var snapshot in snapshots)
+                {
+                    if (snapshot == null || !claimedIds.TryGetValue(snapshot.flightID, out var claimedId))
+                        continue;
+
+                    if (snapshot.persistentId != claimedId)
+                        renamed++;
+                }
+
+                if (renamed > 0)
+                    LunaLog.LogWarning($"[LMP]: PersistentId renamed: vessel {vesselId} {renamed} part persistentId(s) changed during construction");
+            }
+            catch (Exception e)
+            {
+                LunaLog.LogWarning($"[LMP]: Wire identity post-log failed for {vesselId}: {e.Message}");
+            }
+        }
+
+        public static int EvictStalePersistentIds(ProtoVessel vesselProto)
+        {
+            var evicted = 0;
+            try
+            {
+                var snapshots = vesselProto?.protoPartSnapshots;
+                if (snapshots == null) return 0;
+
+                var foreignInfo = new ForeignCollisionInfo();
+                for (var i = 0; i < snapshots.Count; i++)
+                {
+                    var snapshot = snapshots[i];
+                    if (snapshot == null || snapshot.persistentId == 0) continue;
+
+                    if (ResolvePartIdCollision(snapshot.persistentId, vesselProto.vesselID, ref foreignInfo)
+                        == PersistentIdEvictionDecision.EvictStaleOwner)
+                        evicted++;
+                }
+
+                if (foreignInfo.Count > 0)
+                    LunaLog.LogWarning($"[LMP]: PersistentId collisions: vessel {vesselProto.vesselID} has {foreignInfo.Count} part ID(s) owned by foreign vessel(s) ({foreignInfo.FirstOwnerDescription}); stock may rename");
+            }
+            catch (Exception e)
+            {
+                LunaLog.LogWarning($"[LMP]: PersistentId eviction failed for {SafeProtoVesselId(vesselProto)} (falling back to stock collision handling): {e.Message}");
+            }
+            return evicted;
+        }
+
+        public static void CommitEvictions(Guid vesselId)
+        {
+            EvictionsByVessel.TryRemove(vesselId, out _);
+        }
+
+        public static void ClearAll()
+        {
+            EvictionsByVessel.Clear();
+        }
+
+        public static void RollbackEvictions(Guid vesselId, ProtoVessel incomingCopy = null)
+        {
+            if (!EvictionsByVessel.TryRemove(vesselId, out var record))
+                return;
+            if (HighLogic.CurrentGame == null) return;
+
+            foreach (var claim in record.Claims)
+            {
+                try
+                {
+                    var unloaded = FlightGlobals.PersistentUnloadedPartIds;
+                    if (unloaded.TryGetValue(claim.Id, out var current)
+                        && !ReferenceEquals(current, claim.PreviousUnloadedOwner))
+                    {
+                        //Non-previous-owner entry is the incoming copy's registration — free the id.
+                        unloaded.Remove(claim.Id);
+                    }
+
+                    if (claim.PreviousUnloadedOwner != null)
+                    {
+                        var snapshot = claim.PreviousUnloadedOwner;
+                        //Restore only if the owning vessel is still in flightState — a re-placement
+                        //may have removed it since the eviction was recorded.
+                        if (OwnerStillPresent(snapshot) && !unloaded.ContainsKey(claim.Id))
+                            unloaded.Add(claim.Id, snapshot);
+                    }
+
+                    if (claim.PreviousLoadedOwner != null)
+                    {
+                        var part = claim.PreviousLoadedOwner;
+                        //Reference search, NOT part.vessel != null: Unity destruction is deferred,
+                        //so a doomed part keeps a non-null vessel until frame end.
+                        if (PersistentIdEvictionPolicy.ShouldRestoreLoadedOwner(
+                                ownerVesselStillPresent: LoadedOwnerVesselStillPresent(part, vesselId),
+                                idAlreadyRegistered: FlightGlobals.PersistentLoadedPartIds.ContainsKey(claim.Id)))
+                        {
+                            FlightGlobals.PersistentLoadedPartIds.Add(claim.Id, part);
+                        }
+                    }
+                }
+                catch (Exception e)
+                {
+                    LunaLog.LogWarning($"[LMP]: PersistentId rollback failed for vessel {vesselId} claimed id {claim.Id}: {e.Message}");
+                }
+            }
+
+            if (incomingCopy != null)
+                RemoveIncomingRenamedRegistrations(incomingCopy);
+            else
+                RemoveDanglingIncomingRegistrations(vesselId);
+        }
+
+        public static void ResolveSwapEvictions(Guid vesselId)
+        {
+            if (!EvictionsByVessel.TryRemove(vesselId, out var record))
+                return;
+            if (HighLogic.CurrentGame == null) return;
+
+            foreach (var claim in record.Claims)
+            {
+                try
+                {
+                    if (claim.PreviousLoadedOwner == null) continue;
+
+                    var part = claim.PreviousLoadedOwner;
+                    if (part != null && part.vessel != null && part.vessel.id == vesselId
+                        && !FlightGlobals.PersistentLoadedPartIds.ContainsKey(claim.Id))
+                    {
+                        FlightGlobals.PersistentLoadedPartIds.Add(claim.Id, part);
+                    }
+                }
+                catch (Exception e)
+                {
+                    LunaLog.LogWarning($"[LMP]: PersistentId swap-resolve failed for vessel {vesselId} claimed id {claim.Id}: {e.Message}");
+                }
+            }
+        }
+
+        private static bool OwnerStillPresent(ProtoPartSnapshot snapshot)
+        {
+            if (snapshot?.pVesselRef == null) return false;
+
+            var protoVessels = HighLogic.CurrentGame?.flightState?.protoVessels;
+            if (protoVessels == null) return false;
+
+            for (var i = 0; i < protoVessels.Count; i++)
+            {
+                if (ReferenceEquals(protoVessels[i], snapshot.pVesselRef))
+                    return true;
+            }
+            return false;
+        }
+
+        private static bool LoadedOwnerVesselStillPresent(Part part, Guid vesselId)
+        {
+            if (part == null || part.vessel == null || part.vessel.id != vesselId) return false;
+
+            var vessels = FlightGlobals.Vessels;
+            if (vessels == null) return false;
+
+            for (var i = 0; i < vessels.Count; i++)
+            {
+                if (ReferenceEquals(vessels[i], part.vessel))
+                    return true;
+            }
+            return false;
+        }
+
+        private static void RemoveDanglingIncomingRegistrations(Guid vesselId)
+        {
+            try
+            {
+                var unloaded = FlightGlobals.PersistentUnloadedPartIds;
+                if (unloaded == null || HighLogic.CurrentGame?.flightState?.protoVessels == null) return;
+
+                var idsToRemove = new List<uint>();
+                foreach (var id in unloaded.Keys)
+                {
+                    if (unloaded.TryGetValue(id, out var snapshot)
+                        && PersistentIdEvictionPolicy.IsDanglingVesselRegistration(
+                            snapshot,
+                            vesselId,
+                            owner => SafeProtoVesselId(((ProtoPartSnapshot)owner).pVesselRef),
+                            owner => OwnerStillPresent((ProtoPartSnapshot)owner)))
+                    {
+                        idsToRemove.Add(id);
+                    }
+                }
+                for (var i = 0; i < idsToRemove.Count; i++)
+                    unloaded.Remove(idsToRemove[i]);
+            }
+            catch (Exception e)
+            {
+                LunaLog.LogWarning($"[LMP]: PersistentId dangling-owner sweep failed: {e.Message}");
+            }
+        }
+
+        private static void RemoveIncomingRenamedRegistrations(ProtoVessel incomingCopy)
+        {
+            try
+            {
+                var unloaded = FlightGlobals.PersistentUnloadedPartIds;
+                var idsToRemove = new List<uint>();
+                foreach (var id in unloaded.Keys)
+                {
+                    if (unloaded.TryGetValue(id, out var snapshot)
+                        && ReferenceEquals(snapshot?.pVesselRef, incomingCopy))
+                    {
+                        idsToRemove.Add(id);
+                    }
+                }
+                for (var i = 0; i < idsToRemove.Count; i++)
+                    unloaded.Remove(idsToRemove[i]);
+            }
+            catch (Exception e)
+            {
+                LunaLog.LogWarning($"[LMP]: PersistentId renamed-id sweep failed: {e.Message}");
+            }
+        }
+
+        private static PersistentIdEvictionDecision ResolvePartIdCollision(uint id, Guid incomingVesselId, ref ForeignCollisionInfo foreignInfo)
+        {
+            var overall = PersistentIdEvictionDecision.NotRegistered;
+
+            if (FlightGlobals.PersistentUnloadedPartIds.TryGetValue(id, out var unloadedSnapshot))
+            {
+                var decision = PersistentIdEvictionPolicy.DecideUnloaded(
+                    registered: true,
+                    ownerSnapshotNull: unloadedSnapshot == null,
+                    ownerVesselNull: unloadedSnapshot != null && unloadedSnapshot.pVesselRef == null,
+                    ownerIsIncomingVessel: unloadedSnapshot != null && unloadedSnapshot.pVesselRef != null && unloadedSnapshot.pVesselRef.vesselID == incomingVesselId);
+
+                if (decision == PersistentIdEvictionDecision.EvictStaleOwner)
+                {
+                    FlightGlobals.PersistentUnloadedPartIds.Remove(id);
+                }
+                else if (decision == PersistentIdEvictionDecision.KeepForeignOwner)
+                {
+                    foreignInfo.Count++;
+                    if (foreignInfo.FirstOwnerDescription == null)
+                        foreignInfo.FirstOwnerDescription = $"proto {SafeProtoVesselId(unloadedSnapshot.pVesselRef)} '{SafeProtoVesselName(unloadedSnapshot.pVesselRef)}'";
+                }
+
+                if (decision > overall) overall = decision;
+            }
+
+            if (FlightGlobals.PersistentLoadedPartIds.TryGetValue(id, out var loadedPart))
+            {
+                var decision = PersistentIdEvictionPolicy.DecideLoaded(
+                    registered: true,
+                    ownerPartNull: loadedPart == null,
+                    ownerVesselNull: loadedPart != null && loadedPart.vessel == null,
+                    ownerIsIncomingVessel: loadedPart != null && loadedPart.vessel != null && loadedPart.vessel.id == incomingVesselId);
+
+                if (decision == PersistentIdEvictionDecision.EvictStaleOwner)
+                {
+                    FlightGlobals.PersistentLoadedPartIds.Remove(id);
+                }
+                else if (decision == PersistentIdEvictionDecision.KeepForeignOwner)
+                {
+                    foreignInfo.Count++;
+                    if (foreignInfo.FirstOwnerDescription == null)
+                        foreignInfo.FirstOwnerDescription = $"vessel {SafeVesselId(loadedPart.vessel)} '{SafeVesselName(loadedPart.vessel)}'";
+                }
+
+                if (decision > overall) overall = decision;
+            }
+
+            return overall;
+        }
+
+        private static VesselEvictionRecord GetRecord(Guid vesselId)
+        {
+            return EvictionsByVessel.GetOrAdd(vesselId, _ => new VesselEvictionRecord());
+        }
+
+        private static Guid SafeVesselId(Vessel vessel)
+        {
+            try { return vessel != null ? vessel.id : Guid.Empty; }
+            catch { return Guid.Empty; }
+        }
+
+        private static string SafeVesselName(Vessel vessel)
+        {
+            try { return vessel != null ? vessel.vesselName : "<null>"; }
+            catch { return "<error>"; }
+        }
+
+        private static Guid SafeProtoVesselId(ProtoVessel vessel)
+        {
+            try { return vessel != null ? vessel.vesselID : Guid.Empty; }
+            catch { return Guid.Empty; }
+        }
+
+        private static string SafeProtoVesselName(ProtoVessel vessel)
+        {
+            try { return vessel != null ? vessel.vesselName : "<null>"; }
+            catch { return "<error>"; }
+        }
+    }
+}

--- a/LmpClient/VesselUtilities/TransientDeployedStateDetector.cs
+++ b/LmpClient/VesselUtilities/TransientDeployedStateDetector.cs
@@ -1,0 +1,28 @@
+using System.Collections.Generic;
+
+namespace LmpClient.VesselUtilities
+{
+    public static class TransientDeployedStateDetector
+    {
+        private static readonly HashSet<string> GroundModuleNames = new HashSet<string>(System.StringComparer.Ordinal)
+        {
+            "ModuleGroundPart",
+            "ModuleGroundSciencePart",
+            "ModuleGroundCommsPart",
+            "ModuleGroundExperiment",
+            "ModuleGroundExpControl",
+        };
+
+        public static bool IsGroundModule(string moduleName)
+        {
+            return GroundModuleNames.Contains(moduleName);
+        }
+
+        public static bool IsTransientDeployedModule(string moduleName, bool? beingDeployed, bool? deployedOnGround, bool? isEnabled)
+        {
+            if (!GroundModuleNames.Contains(moduleName)) return false;
+            if (beingDeployed != true) return false;
+            return deployedOnGround == false || isEnabled == false;
+        }
+    }
+}

--- a/LmpClient/VesselUtilities/VesselLoadTransaction.cs
+++ b/LmpClient/VesselUtilities/VesselLoadTransaction.cs
@@ -1,0 +1,82 @@
+using System;
+
+namespace LmpClient.VesselUtilities
+{
+    public sealed class VesselLoadTransaction
+    {
+        public enum Phase
+        {
+            AwaitingLoad,
+            LoadSucceeded,
+            Committed,
+            Failed
+        }
+
+        public enum Trigger
+        {
+            UnchangedEarlyOut,
+            ValidationFailed,
+            LoadRefNull,
+            LoadSucceeded,
+            PostLoadFailure,
+            FinalSuccess,
+            ProtoSwapResolved
+        }
+
+        public enum Resolution
+        {
+            None,
+            Continue,
+            RollbackOnly,
+            RollbackAndCleanUp,
+            Commit,
+            SwapResolve
+        }
+
+        private Phase _phase = Phase.AwaitingLoad;
+
+        public Phase CurrentPhase => _phase;
+
+        public Resolution Resolve(Trigger trigger)
+        {
+            switch (trigger)
+            {
+                case Trigger.UnchangedEarlyOut:
+                case Trigger.ValidationFailed:
+                    if (_phase != Phase.AwaitingLoad) return Resolution.None;
+                    _phase = Phase.Failed;
+                    return Resolution.RollbackOnly;
+
+                case Trigger.LoadRefNull:
+                    if (_phase != Phase.AwaitingLoad) return Resolution.None;
+                    _phase = Phase.Failed;
+                    return Resolution.RollbackAndCleanUp;
+
+                case Trigger.LoadSucceeded:
+                    if (_phase != Phase.AwaitingLoad) return Resolution.None;
+                    _phase = Phase.LoadSucceeded;
+                    return Resolution.Continue;
+
+                case Trigger.PostLoadFailure:
+                    //Valid from before Load (exception inside Load) and after it (post-load failures).
+                    if (_phase != Phase.AwaitingLoad && _phase != Phase.LoadSucceeded) return Resolution.None;
+                    _phase = Phase.Failed;
+                    return Resolution.RollbackAndCleanUp;
+
+                case Trigger.FinalSuccess:
+                    //Commit only after Load produced a live vessel AND every post-load step completed.
+                    if (_phase != Phase.LoadSucceeded) return Resolution.None;
+                    _phase = Phase.Committed;
+                    return Resolution.Commit;
+
+                case Trigger.ProtoSwapResolved:
+                    if (_phase != Phase.AwaitingLoad) return Resolution.None;
+                    _phase = Phase.Committed;
+                    return Resolution.SwapResolve;
+
+                default:
+                    return Resolution.None;
+            }
+        }
+    }
+}

--- a/LmpClient/VesselUtilities/VesselLoader.cs
+++ b/LmpClient/VesselUtilities/VesselLoader.cs
@@ -43,14 +43,22 @@ namespace LmpClient.VesselUtilities
         /// </summary>
         public static VesselLoadOutcome LoadVessel(ProtoVessel vesselProto, bool forceReload)
         {
+            //One transaction per load attempt; commit only after the final success return,
+            //every failure routes through rollback/cleanup.
+            var transaction = new VesselLoadTransaction();
             try
             {
                 LogProtoVesselSummary(vesselProto, forceReload);
-                if (!vesselProto.Validate(true)) return VesselLoadOutcome.Failed;
-                return LoadVesselIntoGame(vesselProto, forceReload);
+                if (!vesselProto.Validate(true))
+                {
+                    ApplyTransactionResolution(transaction.Resolve(VesselLoadTransaction.Trigger.ValidationFailed), vesselProto);
+                    return VesselLoadOutcome.Failed;
+                }
+                return LoadVesselIntoGame(vesselProto, forceReload, transaction);
             }
             catch (Exception e)
             {
+                //Rollback first, before teardown, so owner-presence checks see the pre-teardown world.
                 LunaLog.LogError($"[LMP]: Error loading vessel: {e}");
                 SaveFailedProtoVesselToDisk(vesselProto, e);
                 CleanUpFailedVesselLoad(vesselProto);
@@ -109,6 +117,10 @@ namespace LmpClient.VesselUtilities
 
                 existingVessel.protoVessel = newProto;
                 newProto.vesselRef = existingVessel;
+
+                //Proto swap: unloaded registrations stay (new proto is authoritative), loaded ones go back.
+                var transaction = new VesselLoadTransaction();
+                ApplyTransactionResolution(transaction.Resolve(VesselLoadTransaction.Trigger.ProtoSwapResolved), existingVessel.id, newProto);
                 return true;
             }
             catch (Exception e)
@@ -275,6 +287,11 @@ namespace LmpClient.VesselUtilities
             var vesselId = vesselProto.vesselID;
             var vesselName = SafeGetVesselName(vesselProto);
 
+            //Roll the transaction back BEFORE teardown: the restore checks must observe the
+            //pre-teardown world or legitimate owners look gone.
+            try { StalePersistentIdEvictor.RollbackEvictions(vesselId, vesselProto); }
+            catch (Exception e) { LunaLog.LogWarning($"[LMP]: RollbackEvictions failed during cleanup for {vesselId}: {e.Message}"); }
+
             //Try every avenue we have to locate the partial Vessel — vesselProto.vesselRef
             //is set by stock ProtoVessel.Load early, but on certain failure paths it ends up
             //null while the GameObject still exists in the scene (and is later findable via
@@ -349,6 +366,30 @@ namespace LmpClient.VesselUtilities
                 }
             }
             catch (Exception e) { LunaLog.LogWarning($"[LMP]: flightState.protoVessels cleanup failed for {vesselId}: {e.Message}"); }
+        }
+
+        private static void ApplyTransactionResolution(VesselLoadTransaction.Resolution resolution, Guid vesselId, ProtoVessel incomingCopy)
+        {
+            switch (resolution)
+            {
+                case VesselLoadTransaction.Resolution.RollbackOnly:
+                    StalePersistentIdEvictor.RollbackEvictions(vesselId, incomingCopy);
+                    break;
+                case VesselLoadTransaction.Resolution.RollbackAndCleanUp:
+                    CleanUpFailedVesselLoad(incomingCopy);
+                    break;
+                case VesselLoadTransaction.Resolution.Commit:
+                    StalePersistentIdEvictor.CommitEvictions(vesselId);
+                    break;
+                case VesselLoadTransaction.Resolution.SwapResolve:
+                    StalePersistentIdEvictor.ResolveSwapEvictions(vesselId);
+                    break;
+            }
+        }
+
+        private static void ApplyTransactionResolution(VesselLoadTransaction.Resolution resolution, ProtoVessel vesselProto)
+        {
+            ApplyTransactionResolution(resolution, vesselProto.vesselID, vesselProto);
         }
 
         /// <summary>
@@ -700,7 +741,7 @@ namespace LmpClient.VesselUtilities
         /// caller can distinguish a real destructive reload from an unchanged early-out
         /// (the latter previously masqueraded as a successful reload in logs / events).
         /// </summary>
-        private static VesselLoadOutcome LoadVesselIntoGame(ProtoVessel vesselProto, bool forceReload)
+        private static VesselLoadOutcome LoadVesselIntoGame(ProtoVessel vesselProto, bool forceReload, VesselLoadTransaction transaction)
         {
             if (HighLogic.CurrentGame?.flightState == null)
                 return VesselLoadOutcome.Failed;
@@ -736,6 +777,8 @@ namespace LmpClient.VesselUtilities
                     //lets the caller skip the misleading "Vessel reloaded" log line and
                     //the VesselReloadEvent fire that previously ran on every wire-drift
                     //broadcast even when nothing actually changed.
+                    //Incoming copy discarded — registry rollback only, no teardown.
+                    ApplyTransactionResolution(transaction.Resolve(VesselLoadTransaction.Trigger.UnchangedEarlyOut), vesselProto);
                     return VesselLoadOutcome.UnchangedEarlyOut;
                 }
 
@@ -781,12 +824,21 @@ namespace LmpClient.VesselUtilities
             // vessel a tracking lifetime). Detailed rationale lives on EnsureSafeDiscoveryInfo.
             DiscoveryInfoSanitizer.EnsureSafeDiscoveryInfo(vesselProto);
 
+            //Defensive second eviction pass right before stock consults the registries inside ProtoVessel.Load.
+            StalePersistentIdEvictor.EvictStalePersistentIds(vesselProto);
+
             vesselProto.Load(HighLogic.CurrentGame.flightState);
             if (vesselProto.vesselRef == null)
             {
                 LunaLog.Log($"[LMP]: Protovessel {vesselProto.vesselID} failed to create a vessel!");
+                //A partial GameObject may exist even though vesselRef is null — full teardown, rollback first.
+                ApplyTransactionResolution(transaction.Resolve(VesselLoadTransaction.Trigger.LoadRefNull), vesselProto);
                 return VesselLoadOutcome.Failed;
             }
+
+            //The transaction stays open until every post-Load step below succeeds, so a later
+            //failure can still roll the registry back.
+            transaction.Resolve(VesselLoadTransaction.Trigger.LoadSucceeded);
 
             // Strip null entries from each ProtoPartSnapshot.protoModuleCrew that stock KSP just
             // appended when wire-side crew names failed to resolve through CrewRoster. Has to run
@@ -819,6 +871,8 @@ namespace LmpClient.VesselUtilities
             if (double.IsNaN(vesselProto.vesselRef.orbitDriver.pos.x))
             {
                 LunaLog.Log($"[LMP]: Protovessel {vesselProto.vesselID} has an invalid orbit");
+                //Vessel is live — full teardown, rollback first.
+                ApplyTransactionResolution(transaction.Resolve(VesselLoadTransaction.Trigger.PostLoadFailure), vesselProto);
                 return VesselLoadOutcome.Failed;
             }
 
@@ -843,6 +897,9 @@ namespace LmpClient.VesselUtilities
                     KerbalPortraitGallery.Instance.StartReset(FlightGlobals.ActiveVessel);
                 }
             }
+
+            //Every post-Load step succeeded — the incoming copy is the live vessel, so commit.
+            ApplyTransactionResolution(transaction.Resolve(VesselLoadTransaction.Trigger.FinalSuccess), vesselProto);
 
             //Only the destructive-reload branch and the brand-new-vessel branch reach
             //here; the structure-matches early-out returned UnchangedEarlyOut above.

--- a/LmpClient/VesselUtilities/VesselSerializer.cs
+++ b/LmpClient/VesselUtilities/VesselSerializer.cs
@@ -68,11 +68,21 @@ namespace LmpClient.VesselUtilities
                 //offending values itself.
                 DiscoveryInfoSanitizer.SanitizeVesselNode(inputNode, protoVesselId, "wire-input");
 
+                //Evict stale owners BEFORE the stock constructor deserialises the snapshots:
+                //it renames colliding persistentIds, and the VesselLoader pass is too late here.
+                var wireIdentities = StalePersistentIdEvictor.PreflightWireIdentityAndEvict(inputNode, protoVesselId);
+
                 //Cannot reuse the Protovessel to save memory garbage as it does not have any clear method :(
-                return new ProtoVessel(inputNode, HighLogic.CurrentGame);
+                var constructed = new ProtoVessel(inputNode, HighLogic.CurrentGame);
+
+                StalePersistentIdEvictor.LogWireConstructionResult(constructed, wireIdentities, protoVesselId);
+                return constructed;
             }
             catch (Exception e)
             {
+                //Constructor threw after the preflight evicted entries (possibly after a partial
+                //constructor registered some) — roll back so the previous copy stays registered.
+                StalePersistentIdEvictor.RollbackEvictions(protoVesselId);
                 LunaLog.LogError($"[LMP]: Damaged vessel {protoVesselId}, exception: {e}");
                 return null;
             }

--- a/ServerTest/DeployedScienceLiveRegistrationPolicyTest.cs
+++ b/ServerTest/DeployedScienceLiveRegistrationPolicyTest.cs
@@ -1,0 +1,66 @@
+using LmpClient.Systems.Scenario;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace ServerTest
+{
+    [TestClass]
+    public class DeployedScienceLiveRegistrationPolicyTest
+    {
+        [TestMethod]
+        public void SettledPartMissingFromClusterRegisters()
+        {
+            Assert.IsTrue(DeployedScienceLiveRegistrationPolicy.ShouldRegister(
+                deployedOnGround: true, beingDeployed: false, controlUnitIdAssigned: true,
+                clusterFound: true, clusterContainsPart: false,
+                isExperiment: false, clusterHasSameExperiment: false));
+        }
+
+        [TestMethod]
+        public void PartAlreadyInClusterIsSkipped()
+        {
+            Assert.IsFalse(DeployedScienceLiveRegistrationPolicy.ShouldRegister(
+                deployedOnGround: true, beingDeployed: false, controlUnitIdAssigned: true,
+                clusterFound: true, clusterContainsPart: true,
+                isExperiment: false, clusterHasSameExperiment: false));
+        }
+
+        [TestMethod]
+        public void TransientDeploymentStatesAreSkipped()
+        {
+            Assert.IsFalse(DeployedScienceLiveRegistrationPolicy.ShouldRegister(
+                deployedOnGround: false, beingDeployed: true, controlUnitIdAssigned: true,
+                clusterFound: true, clusterContainsPart: false,
+                isExperiment: false, clusterHasSameExperiment: false));
+            Assert.IsFalse(DeployedScienceLiveRegistrationPolicy.ShouldRegister(
+                deployedOnGround: true, beingDeployed: true, controlUnitIdAssigned: true,
+                clusterFound: true, clusterContainsPart: false,
+                isExperiment: false, clusterHasSameExperiment: false));
+        }
+
+        [TestMethod]
+        public void UnassignedOrClusterlessPartsAreLeftToStockScan()
+        {
+            Assert.IsFalse(DeployedScienceLiveRegistrationPolicy.ShouldRegister(
+                deployedOnGround: true, beingDeployed: false, controlUnitIdAssigned: false,
+                clusterFound: true, clusterContainsPart: false,
+                isExperiment: false, clusterHasSameExperiment: false));
+            Assert.IsFalse(DeployedScienceLiveRegistrationPolicy.ShouldRegister(
+                deployedOnGround: true, beingDeployed: false, controlUnitIdAssigned: true,
+                clusterFound: false, clusterContainsPart: false,
+                isExperiment: false, clusterHasSameExperiment: false));
+        }
+
+        [TestMethod]
+        public void DuplicateExperimentIsRefusedLikeStock()
+        {
+            Assert.IsFalse(DeployedScienceLiveRegistrationPolicy.ShouldRegister(
+                deployedOnGround: true, beingDeployed: false, controlUnitIdAssigned: true,
+                clusterFound: true, clusterContainsPart: false,
+                isExperiment: true, clusterHasSameExperiment: true));
+            Assert.IsTrue(DeployedScienceLiveRegistrationPolicy.ShouldRegister(
+                deployedOnGround: true, beingDeployed: false, controlUnitIdAssigned: true,
+                clusterFound: true, clusterContainsPart: false,
+                isExperiment: true, clusterHasSameExperiment: false));
+        }
+    }
+}

--- a/ServerTest/DeployedScienceSyncGateTest.cs
+++ b/ServerTest/DeployedScienceSyncGateTest.cs
@@ -1,0 +1,271 @@
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using LmpClient.Systems.Scenario;
+using System.Collections.Generic;
+
+namespace ServerTest
+{
+    [TestClass]
+    public class DeployedScienceSyncGateTest
+    {
+        private const double Grace = 5.0;
+
+        #region Send gate decisions
+
+        [TestMethod]
+        public void DeployedScienceSendBlockedUntilAuthoritativeApplySucceeded()
+        {
+            DeployedScienceSyncGate.DeployedScienceReady = false;
+            Assert.IsFalse(DeployedScienceSyncGate.ShouldSend(DeployedScienceSyncGate.ScenarioModuleName));
+        }
+
+        [TestMethod]
+        public void DeployedScienceSendAllowedAfterSuccessfulApply()
+        {
+            DeployedScienceSyncGate.DeployedScienceReady = true;
+            Assert.IsTrue(DeployedScienceSyncGate.ShouldSend(DeployedScienceSyncGate.ScenarioModuleName));
+        }
+
+        [TestMethod]
+        public void DeployedScienceSendRemainsBlockedWhileApplyFailedOrRetrying()
+        {
+            DeployedScienceSyncGate.DeployedScienceReady = false;
+            Assert.IsFalse(DeployedScienceSyncGate.ShouldSend(DeployedScienceSyncGate.ScenarioModuleName));
+        }
+
+        [TestMethod]
+        public void NonDeployedScienceScenariosAlwaysSendable()
+        {
+            DeployedScienceSyncGate.DeployedScienceReady = false;
+            Assert.IsTrue(DeployedScienceSyncGate.ShouldSend("ContractSystem"));
+            Assert.IsTrue(DeployedScienceSyncGate.ShouldSend("ProgressTracking"));
+            Assert.IsTrue(DeployedScienceSyncGate.ShouldSend(null));
+        }
+
+        #endregion
+
+        #region Fresh-server unblock
+
+        [TestMethod]
+        public void FreshServerUnblocksSendOnceVesselSyncCompletes()
+        {
+            Assert.IsTrue(DeployedScienceSyncGate.ShouldMarkFreshModuleAuthoritative(
+                receivedScenarioEntry: false, vesselSyncComplete: true, alreadyReady: false));
+        }
+
+        [TestMethod]
+        public void FreshServerUnblockNeverFiresAfterAuthoritativeEntryReceived()
+        {
+            Assert.IsFalse(DeployedScienceSyncGate.ShouldMarkFreshModuleAuthoritative(
+                receivedScenarioEntry: true, vesselSyncComplete: true, alreadyReady: false));
+        }
+
+        [TestMethod]
+        public void FreshServerUnblockWaitsForVesselSyncCompletion()
+        {
+            Assert.IsFalse(DeployedScienceSyncGate.ShouldMarkFreshModuleAuthoritative(
+                receivedScenarioEntry: false, vesselSyncComplete: false, alreadyReady: false));
+        }
+
+        [TestMethod]
+        public void FreshServerUnblockDoesNotReFireOnceReady()
+        {
+            Assert.IsFalse(DeployedScienceSyncGate.ShouldMarkFreshModuleAuthoritative(
+                receivedScenarioEntry: false, vesselSyncComplete: true, alreadyReady: true));
+        }
+
+        #endregion
+
+        #region Cluster membership apply check
+
+        private static DeployedScienceSyncGate.ClusterMembership Membership(uint controlId, uint[] partIds, string[] experimentIds = null)
+        {
+            var m = new DeployedScienceSyncGate.ClusterMembership();
+            foreach (var pid in partIds) m.PartIds.Add(pid);
+            if (experimentIds != null)
+                foreach (var eid in experimentIds) m.ExperimentIds.Add(eid);
+            return m;
+        }
+
+        [TestMethod]
+        public void MembershipEqualWhenClustersPartsAndExperimentsMatch()
+        {
+            var declared = new Dictionary<uint, DeployedScienceSyncGate.ClusterMembership>
+            {
+                { 1u, Membership(1u, new[] { 10u, 11u }, new[] { "expA" }) },
+                { 2u, Membership(2u, new[] { 20u }) },
+            };
+            var applied = new Dictionary<uint, DeployedScienceSyncGate.ClusterMembership>
+            {
+                { 1u, Membership(1u, new[] { 11u, 10u }, new[] { "expA" }) }, // order-independent
+                { 2u, Membership(2u, new[] { 20u }) },
+            };
+            Assert.IsTrue(DeployedScienceSyncGate.IsMembershipApplied(declared, applied));
+        }
+
+        [TestMethod]
+        public void EmptyMembershipsAreApplied()
+        {
+            var declared = new Dictionary<uint, DeployedScienceSyncGate.ClusterMembership>();
+            var applied = new Dictionary<uint, DeployedScienceSyncGate.ClusterMembership>();
+            Assert.IsTrue(DeployedScienceSyncGate.IsMembershipApplied(declared, applied));
+        }
+
+        [TestMethod]
+        public void MissingClusterFailsMembership()
+        {
+            var declared = new Dictionary<uint, DeployedScienceSyncGate.ClusterMembership>
+            {
+                { 1u, Membership(1u, new[] { 10u }) },
+                { 2u, Membership(2u, new[] { 20u }) },
+            };
+            var applied = new Dictionary<uint, DeployedScienceSyncGate.ClusterMembership>
+            {
+                { 1u, Membership(1u, new[] { 10u }) },
+            };
+            Assert.IsFalse(DeployedScienceSyncGate.IsMembershipApplied(declared, applied));
+        }
+
+        [TestMethod]
+        public void PrunedPartInsideClusterFailsMembership()
+        {
+            var declared = new Dictionary<uint, DeployedScienceSyncGate.ClusterMembership>
+            {
+                { 1u, Membership(1u, new[] { 10u, 11u, 12u }, new[] { "expA" }) },
+            };
+            var applied = new Dictionary<uint, DeployedScienceSyncGate.ClusterMembership>
+            {
+                { 1u, Membership(1u, new[] { 10u, 12u }, new[] { "expA" }) }, // 11u pruned
+            };
+            Assert.IsFalse(DeployedScienceSyncGate.IsMembershipApplied(declared, applied));
+        }
+
+        [TestMethod]
+        public void PrunedExperimentInsideClusterFailsMembership()
+        {
+            var declared = new Dictionary<uint, DeployedScienceSyncGate.ClusterMembership>
+            {
+                { 1u, Membership(1u, new[] { 10u, 11u }, new[] { "expA", "expB" }) },
+            };
+            var applied = new Dictionary<uint, DeployedScienceSyncGate.ClusterMembership>
+            {
+                { 1u, Membership(1u, new[] { 10u, 11u }, new[] { "expA" }) }, // expB pruned
+            };
+            Assert.IsFalse(DeployedScienceSyncGate.IsMembershipApplied(declared, applied));
+        }
+
+        [TestMethod]
+        public void ExtraPartInsideClusterFailsMembership()
+        {
+            var declared = new Dictionary<uint, DeployedScienceSyncGate.ClusterMembership>
+            {
+                { 1u, Membership(1u, new[] { 10u }) },
+            };
+            var applied = new Dictionary<uint, DeployedScienceSyncGate.ClusterMembership>
+            {
+                { 1u, Membership(1u, new[] { 10u, 99u }) },
+            };
+            Assert.IsFalse(DeployedScienceSyncGate.IsMembershipApplied(declared, applied));
+        }
+
+        #endregion
+
+        #region VesselSyncCompletionTracker
+
+        private static VesselSyncCompletionTracker CreateTracker() => new VesselSyncCompletionTracker(Grace);
+
+        [TestMethod]
+        public void TrackerDoesNothingWhileSceneNotReady()
+        {
+            var tracker = CreateTracker();
+            tracker.Update(10.0, protoSystemReady: false, anyProtoPending: true, vesselLoadedThisTick: false);
+            tracker.Update(11.0, protoSystemReady: false, anyProtoPending: false, vesselLoadedThisTick: false);
+            Assert.IsFalse(tracker.IsComplete);
+        }
+
+        [TestMethod]
+        public void EmptyServerCompletesOnlyAfterGraceWindow()
+        {
+            var tracker = CreateTracker();
+            tracker.Update(10.0, protoSystemReady: true, anyProtoPending: false, vesselLoadedThisTick: false);
+            Assert.IsFalse(tracker.IsComplete, "must not complete before the grace window elapses");
+
+            tracker.Update(10.0 + Grace - 0.1, protoSystemReady: true, anyProtoPending: false, vesselLoadedThisTick: false);
+            Assert.IsFalse(tracker.IsComplete);
+
+            tracker.Update(10.0 + Grace, protoSystemReady: true, anyProtoPending: false, vesselLoadedThisTick: false);
+            Assert.IsTrue(tracker.IsComplete);
+        }
+
+        [TestMethod]
+        public void ReadinessDropRestartsEmptyServerWindow()
+        {
+            var tracker = CreateTracker();
+            tracker.Update(10.0, protoSystemReady: true, anyProtoPending: false, vesselLoadedThisTick: false); // window starts at 10
+            tracker.Update(12.0, protoSystemReady: false, anyProtoPending: false, vesselLoadedThisTick: false); // readiness dropped
+            tracker.Update(20.0, protoSystemReady: true, anyProtoPending: false, vesselLoadedThisTick: false); // window restarts at 20
+            tracker.Update(20.0 + Grace - 0.1, protoSystemReady: true, anyProtoPending: false, vesselLoadedThisTick: false);
+            Assert.IsFalse(tracker.IsComplete, "window must restart after a readiness drop");
+            tracker.Update(20.0 + Grace, protoSystemReady: true, anyProtoPending: false, vesselLoadedThisTick: false);
+            Assert.IsTrue(tracker.IsComplete);
+        }
+
+        [TestMethod]
+        public void PendingProtosDelayCompletionAndRestartGrace()
+        {
+            var tracker = CreateTracker();
+            tracker.Update(10.0, protoSystemReady: true, anyProtoPending: true, vesselLoadedThisTick: false);
+            tracker.Update(10.0 + Grace - 0.1, protoSystemReady: true, anyProtoPending: false, vesselLoadedThisTick: false);
+            Assert.IsFalse(tracker.IsComplete, "grace must be measured from the last activity");
+
+            tracker.Update(10.0 + Grace + 1.0, protoSystemReady: true, anyProtoPending: true, vesselLoadedThisTick: false);
+            tracker.Update(10.0 + Grace + 1.0 + Grace - 0.1, protoSystemReady: true, anyProtoPending: false, vesselLoadedThisTick: false);
+            Assert.IsFalse(tracker.IsComplete);
+
+            tracker.Update(10.0 + Grace + 1.0 + Grace, protoSystemReady: true, anyProtoPending: false, vesselLoadedThisTick: false);
+            Assert.IsTrue(tracker.IsComplete);
+        }
+
+        [TestMethod]
+        public void VesselLoadCountsAsActivity()
+        {
+            var tracker = CreateTracker();
+            tracker.Update(10.0, protoSystemReady: true, anyProtoPending: false, vesselLoadedThisTick: true);
+            tracker.Update(10.0 + Grace - 0.1, protoSystemReady: true, anyProtoPending: false, vesselLoadedThisTick: false);
+            Assert.IsFalse(tracker.IsComplete);
+            tracker.Update(10.0 + Grace, protoSystemReady: true, anyProtoPending: false, vesselLoadedThisTick: false);
+            Assert.IsTrue(tracker.IsComplete);
+        }
+
+        [TestMethod]
+        public void TrackerLatchesOnceComplete()
+        {
+            var tracker = CreateTracker();
+            tracker.Update(10.0, protoSystemReady: true, anyProtoPending: false, vesselLoadedThisTick: false);
+            tracker.Update(10.0 + Grace, protoSystemReady: true, anyProtoPending: false, vesselLoadedThisTick: false);
+            Assert.IsTrue(tracker.IsComplete);
+
+            tracker.Update(50.0, protoSystemReady: true, anyProtoPending: true, vesselLoadedThisTick: true);
+            Assert.IsTrue(tracker.IsComplete);
+        }
+
+        [TestMethod]
+        public void ResetReArmsTracker()
+        {
+            var tracker = CreateTracker();
+            tracker.Update(10.0, protoSystemReady: true, anyProtoPending: false, vesselLoadedThisTick: false);
+            tracker.Update(10.0 + Grace, protoSystemReady: true, anyProtoPending: false, vesselLoadedThisTick: false);
+            Assert.IsTrue(tracker.IsComplete);
+
+            tracker.Reset();
+            Assert.IsFalse(tracker.IsComplete);
+
+            tracker.Update(20.0, protoSystemReady: true, anyProtoPending: false, vesselLoadedThisTick: false);
+            tracker.Update(20.0 + Grace - 0.1, protoSystemReady: true, anyProtoPending: false, vesselLoadedThisTick: false);
+            Assert.IsFalse(tracker.IsComplete);
+            tracker.Update(20.0 + Grace, protoSystemReady: true, anyProtoPending: false, vesselLoadedThisTick: false);
+            Assert.IsTrue(tracker.IsComplete);
+        }
+
+        #endregion
+    }
+}

--- a/ServerTest/PersistentIdEvictionPolicyTest.cs
+++ b/ServerTest/PersistentIdEvictionPolicyTest.cs
@@ -1,0 +1,98 @@
+using System.Collections.Generic;
+using LmpClient.VesselUtilities;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace ServerTest
+{
+    [TestClass]
+    public class PersistentIdEvictionPolicyTest
+    {
+        [TestMethod]
+        public void UnregisteredIdIsNotTouched()
+        {
+            Assert.AreEqual(PersistentIdEvictionDecision.NotRegistered,
+                PersistentIdEvictionPolicy.DecideUnloaded(registered: false, ownerSnapshotNull: false, ownerVesselNull: false, ownerIsIncomingVessel: false));
+            Assert.AreEqual(PersistentIdEvictionDecision.NotRegistered,
+                PersistentIdEvictionPolicy.DecideLoaded(registered: false, ownerPartNull: false, ownerVesselNull: false, ownerIsIncomingVessel: false));
+        }
+
+        [TestMethod]
+        public void NullRegistryEntriesAreStale()
+        {
+            Assert.AreEqual(PersistentIdEvictionDecision.EvictStaleOwner,
+                PersistentIdEvictionPolicy.DecideUnloaded(registered: true, ownerSnapshotNull: true, ownerVesselNull: false, ownerIsIncomingVessel: false));
+            Assert.AreEqual(PersistentIdEvictionDecision.EvictStaleOwner,
+                PersistentIdEvictionPolicy.DecideUnloaded(registered: true, ownerSnapshotNull: false, ownerVesselNull: true, ownerIsIncomingVessel: false));
+            Assert.AreEqual(PersistentIdEvictionDecision.EvictStaleOwner,
+                PersistentIdEvictionPolicy.DecideLoaded(registered: true, ownerPartNull: true, ownerVesselNull: false, ownerIsIncomingVessel: false));
+            Assert.AreEqual(PersistentIdEvictionDecision.EvictStaleOwner,
+                PersistentIdEvictionPolicy.DecideLoaded(registered: true, ownerPartNull: false, ownerVesselNull: true, ownerIsIncomingVessel: false));
+        }
+
+        [TestMethod]
+        public void OwnPreviousCopyIsEvictedOnReconnect()
+        {
+            Assert.AreEqual(PersistentIdEvictionDecision.EvictStaleOwner,
+                PersistentIdEvictionPolicy.DecideUnloaded(registered: true, ownerSnapshotNull: false, ownerVesselNull: false, ownerIsIncomingVessel: true));
+            Assert.AreEqual(PersistentIdEvictionDecision.EvictStaleOwner,
+                PersistentIdEvictionPolicy.DecideLoaded(registered: true, ownerPartNull: false, ownerVesselNull: false, ownerIsIncomingVessel: true));
+        }
+
+        [TestMethod]
+        public void LiveForeignOwnerIsKeptForStockRenaming()
+        {
+            Assert.AreEqual(PersistentIdEvictionDecision.KeepForeignOwner,
+                PersistentIdEvictionPolicy.DecideUnloaded(registered: true, ownerSnapshotNull: false, ownerVesselNull: false, ownerIsIncomingVessel: false));
+            Assert.AreEqual(PersistentIdEvictionDecision.KeepForeignOwner,
+                PersistentIdEvictionPolicy.DecideLoaded(registered: true, ownerPartNull: false, ownerVesselNull: false, ownerIsIncomingVessel: false));
+        }
+
+        [TestMethod]
+        public void LoadedOwnerRestoreRequiresVesselPresenceInFlightGlobals()
+        {
+            Assert.IsFalse(PersistentIdEvictionPolicy.ShouldRestoreLoadedOwner(
+                ownerVesselStillPresent: false, idAlreadyRegistered: false));
+
+            Assert.IsTrue(PersistentIdEvictionPolicy.ShouldRestoreLoadedOwner(
+                ownerVesselStillPresent: true, idAlreadyRegistered: false));
+
+            Assert.IsFalse(PersistentIdEvictionPolicy.ShouldRestoreLoadedOwner(
+                ownerVesselStillPresent: true, idAlreadyRegistered: true));
+        }
+
+        [TestMethod]
+        public void DanglingSweepSelectsOnlyAbsentOwnersOfThisVessel()
+        {
+            var vesselId = new System.Guid("10000000-0000-0000-0000-000000000001");
+            var otherVesselId = new System.Guid("20000000-0000-0000-0000-000000000002");
+
+            var previousCopy = new FakeOwner(vesselId, presentInGameState: true);
+            var partialFromThrowingCtor = new FakeOwner(vesselId, presentInGameState: false);
+            var foreignOwner = new FakeOwner(otherVesselId, presentInGameState: false);
+
+            var registry = new object[] { null, previousCopy, partialFromThrowingCtor, foreignOwner };
+
+            var selected = new List<object>();
+            foreach (var owner in registry)
+            {
+                if (PersistentIdEvictionPolicy.IsDanglingVesselRegistration(
+                        owner, vesselId, o => ((FakeOwner)o).VesselId, o => ((FakeOwner)o).PresentInGameState))
+                    selected.Add(owner);
+            }
+
+            CollectionAssert.AreEqual(new[] { partialFromThrowingCtor }, selected);
+        }
+
+        private sealed class FakeOwner
+        {
+            public readonly System.Guid VesselId;
+            public readonly bool PresentInGameState;
+
+            public FakeOwner(System.Guid vesselId, bool presentInGameState)
+            {
+                VesselId = vesselId;
+                PresentInGameState = presentInGameState;
+            }
+        }
+    }
+}

--- a/ServerTest/ServerTest.csproj
+++ b/ServerTest/ServerTest.csproj
@@ -21,6 +21,8 @@
   <ItemGroup>
     <!-- Pure (Unity/KSP-free) client code linked into the test assembly -->
     <Compile Include="..\LmpClient\VesselUtilities\TransientDeployedStateDetector.cs" Link="VesselUtilities\TransientDeployedStateDetector.cs" />
+    <Compile Include="..\LmpClient\VesselUtilities\PersistentIdEvictionPolicy.cs" Link="VesselUtilities\PersistentIdEvictionPolicy.cs" />
+    <Compile Include="..\LmpClient\VesselUtilities\VesselLoadTransaction.cs" Link="VesselUtilities\VesselLoadTransaction.cs" />
   </ItemGroup>
 
   <ItemGroup>

--- a/ServerTest/ServerTest.csproj
+++ b/ServerTest/ServerTest.csproj
@@ -25,6 +25,7 @@
     <Compile Include="..\LmpClient\VesselUtilities\VesselLoadTransaction.cs" Link="VesselUtilities\VesselLoadTransaction.cs" />
     <Compile Include="..\LmpClient\VesselUtilities\SolarPanelActualOutputPolicy.cs" Link="VesselUtilities\SolarPanelActualOutputPolicy.cs" />
     <Compile Include="..\LmpClient\Systems\Scenario\DeployedScienceSyncGate.cs" Link="Systems\Scenario\DeployedScienceSyncGate.cs" />
+    <Compile Include="..\LmpClient\Systems\Scenario\DeployedScienceLiveRegistrationPolicy.cs" Link="Systems\Scenario\DeployedScienceLiveRegistrationPolicy.cs" />
   </ItemGroup>
 
   <ItemGroup>

--- a/ServerTest/ServerTest.csproj
+++ b/ServerTest/ServerTest.csproj
@@ -23,6 +23,7 @@
     <Compile Include="..\LmpClient\VesselUtilities\TransientDeployedStateDetector.cs" Link="VesselUtilities\TransientDeployedStateDetector.cs" />
     <Compile Include="..\LmpClient\VesselUtilities\PersistentIdEvictionPolicy.cs" Link="VesselUtilities\PersistentIdEvictionPolicy.cs" />
     <Compile Include="..\LmpClient\VesselUtilities\VesselLoadTransaction.cs" Link="VesselUtilities\VesselLoadTransaction.cs" />
+    <Compile Include="..\LmpClient\Systems\Scenario\DeployedScienceSyncGate.cs" Link="Systems\Scenario\DeployedScienceSyncGate.cs" />
   </ItemGroup>
 
   <ItemGroup>

--- a/ServerTest/ServerTest.csproj
+++ b/ServerTest/ServerTest.csproj
@@ -19,6 +19,11 @@
   </ItemGroup>
 
   <ItemGroup>
+    <!-- Pure (Unity/KSP-free) client code linked into the test assembly -->
+    <Compile Include="..\LmpClient\VesselUtilities\TransientDeployedStateDetector.cs" Link="VesselUtilities\TransientDeployedStateDetector.cs" />
+  </ItemGroup>
+
+  <ItemGroup>
     <None Update="XmlExampleFiles\**\*">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>

--- a/ServerTest/ServerTest.csproj
+++ b/ServerTest/ServerTest.csproj
@@ -23,6 +23,7 @@
     <Compile Include="..\LmpClient\VesselUtilities\TransientDeployedStateDetector.cs" Link="VesselUtilities\TransientDeployedStateDetector.cs" />
     <Compile Include="..\LmpClient\VesselUtilities\PersistentIdEvictionPolicy.cs" Link="VesselUtilities\PersistentIdEvictionPolicy.cs" />
     <Compile Include="..\LmpClient\VesselUtilities\VesselLoadTransaction.cs" Link="VesselUtilities\VesselLoadTransaction.cs" />
+    <Compile Include="..\LmpClient\VesselUtilities\SolarPanelActualOutputPolicy.cs" Link="VesselUtilities\SolarPanelActualOutputPolicy.cs" />
     <Compile Include="..\LmpClient\Systems\Scenario\DeployedScienceSyncGate.cs" Link="Systems\Scenario\DeployedScienceSyncGate.cs" />
   </ItemGroup>
 

--- a/ServerTest/SolarPanelActualOutputPolicyTest.cs
+++ b/ServerTest/SolarPanelActualOutputPolicyTest.cs
@@ -1,0 +1,83 @@
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using LmpClient.VesselUtilities;
+
+namespace ServerTest
+{
+    [TestClass]
+    public class SolarPanelActualOutputPolicyTest
+    {
+        private const int Potential = 5;
+
+        [TestMethod]
+        public void DayWithLineOfSightProducesPotential()
+        {
+            Assert.AreEqual(Potential, SolarPanelActualOutputPolicy.ComputeTarget(
+                moduleBehaviourEnabled: true, hasSecondaryTransform: true, hasTrackingBody: true,
+                timeWarpRateIsOne: true, hasLineOfSight: true,
+                deployedOnGround: true, isEnabled: true, potentialOutput: Potential));
+        }
+
+        [TestMethod]
+        public void NightWithoutLineOfSightProducesZero()
+        {
+            Assert.AreEqual(0, SolarPanelActualOutputPolicy.ComputeTarget(
+                moduleBehaviourEnabled: true, hasSecondaryTransform: true, hasTrackingBody: true,
+                timeWarpRateIsOne: true, hasLineOfSight: false,
+                deployedOnGround: true, isEnabled: true, potentialOutput: Potential));
+        }
+
+        [TestMethod]
+        public void TimeWarpNotOneFreezesLastValue()
+        {
+            Assert.IsNull(SolarPanelActualOutputPolicy.ComputeTarget(
+                moduleBehaviourEnabled: true, hasSecondaryTransform: true, hasTrackingBody: true,
+                timeWarpRateIsOne: false, hasLineOfSight: true,
+                deployedOnGround: true, isEnabled: true, potentialOutput: Potential));
+        }
+
+        [TestMethod]
+        public void MissingTrackingBodyFreezesLastValue()
+        {
+            Assert.IsNull(SolarPanelActualOutputPolicy.ComputeTarget(
+                moduleBehaviourEnabled: true, hasSecondaryTransform: false, hasTrackingBody: false,
+                timeWarpRateIsOne: true, hasLineOfSight: false,
+                deployedOnGround: true, isEnabled: true, potentialOutput: Potential));
+        }
+
+        [TestMethod]
+        public void DisabledModuleProducesZero()
+        {
+            Assert.AreEqual(0, SolarPanelActualOutputPolicy.ComputeTarget(
+                moduleBehaviourEnabled: false, hasSecondaryTransform: true, hasTrackingBody: true,
+                timeWarpRateIsOne: true, hasLineOfSight: true,
+                deployedOnGround: true, isEnabled: true, potentialOutput: Potential));
+        }
+
+        [TestMethod]
+        public void NotYetDeployedWithoutTrackingProducesZero()
+        {
+            Assert.AreEqual(0, SolarPanelActualOutputPolicy.ComputeTarget(
+                moduleBehaviourEnabled: true, hasSecondaryTransform: false, hasTrackingBody: false,
+                timeWarpRateIsOne: false, hasLineOfSight: false,
+                deployedOnGround: false, isEnabled: false, potentialOutput: Potential));
+        }
+
+        [TestMethod]
+        public void DeployedButIsEnabledFalseProducesZero()
+        {
+            Assert.AreEqual(0, SolarPanelActualOutputPolicy.ComputeTarget(
+                moduleBehaviourEnabled: true, hasSecondaryTransform: false, hasTrackingBody: false,
+                timeWarpRateIsOne: false, hasLineOfSight: false,
+                deployedOnGround: true, isEnabled: false, potentialOutput: Potential));
+        }
+
+        [TestMethod]
+        public void ZeroPotentialDayStaysZero()
+        {
+            Assert.AreEqual(0, SolarPanelActualOutputPolicy.ComputeTarget(
+                moduleBehaviourEnabled: true, hasSecondaryTransform: true, hasTrackingBody: true,
+                timeWarpRateIsOne: true, hasLineOfSight: true,
+                deployedOnGround: true, isEnabled: true, potentialOutput: 0));
+        }
+    }
+}

--- a/ServerTest/TransientDeployedStateDetectorTest.cs
+++ b/ServerTest/TransientDeployedStateDetectorTest.cs
@@ -1,0 +1,63 @@
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using LmpClient.VesselUtilities;
+
+namespace ServerTest
+{
+    [TestClass]
+    public class TransientDeployedStateDetectorTest
+    {
+        [TestMethod]
+        public void GroundModuleFamilyIsRecognized()
+        {
+            Assert.IsTrue(TransientDeployedStateDetector.IsGroundModule("ModuleGroundPart"));
+            Assert.IsTrue(TransientDeployedStateDetector.IsGroundModule("ModuleGroundSciencePart"));
+            Assert.IsTrue(TransientDeployedStateDetector.IsGroundModule("ModuleGroundExperiment"));
+            Assert.IsTrue(TransientDeployedStateDetector.IsGroundModule("ModuleGroundExpControl"));
+            Assert.IsTrue(TransientDeployedStateDetector.IsGroundModule("ModuleGroundCommsPart"));
+
+            Assert.IsFalse(TransientDeployedStateDetector.IsGroundModule("ModuleCommand"));
+            Assert.IsFalse(TransientDeployedStateDetector.IsGroundModule("ModuleReactionWheel"));
+            Assert.IsFalse(TransientDeployedStateDetector.IsGroundModule(null));
+            Assert.IsFalse(TransientDeployedStateDetector.IsGroundModule(string.Empty));
+        }
+
+        [TestMethod]
+        public void TransientDeploymentIsDetected()
+        {
+            Assert.IsTrue(TransientDeployedStateDetector.IsTransientDeployedModule("ModuleGroundExperiment", true, false, false));
+            Assert.IsTrue(TransientDeployedStateDetector.IsTransientDeployedModule("ModuleGroundExperiment", true, false, true));
+            Assert.IsTrue(TransientDeployedStateDetector.IsTransientDeployedModule("ModuleGroundExperiment", true, true, false));
+        }
+
+        [TestMethod]
+        public void SettledModuleIsNotTransient()
+        {
+            Assert.IsFalse(TransientDeployedStateDetector.IsTransientDeployedModule("ModuleGroundExperiment", false, true, true));
+        }
+
+        [TestMethod]
+        public void BeingDeployedWithSettledEvidenceIsNotTransient()
+        {
+            Assert.IsFalse(TransientDeployedStateDetector.IsTransientDeployedModule("ModuleGroundExperiment", true, true, true));
+        }
+
+        [TestMethod]
+        public void MissingSettlementEvidenceIsNotTransient()
+        {
+            Assert.IsFalse(TransientDeployedStateDetector.IsTransientDeployedModule("ModuleGroundExperiment", true, null, null));
+        }
+
+        [TestMethod]
+        public void NonGroundModuleIsNotTransient()
+        {
+            Assert.IsFalse(TransientDeployedStateDetector.IsTransientDeployedModule("ModuleCommand", true, false, false));
+            Assert.IsFalse(TransientDeployedStateDetector.IsTransientDeployedModule(null, true, false, false));
+        }
+
+        [TestMethod]
+        public void NullBeingDeployedIsNotTransient()
+        {
+            Assert.IsFalse(TransientDeployedStateDetector.IsTransientDeployedModule("ModuleGroundExperiment", null, false, false));
+        }
+    }
+}

--- a/ServerTest/VesselLoadTransactionTest.cs
+++ b/ServerTest/VesselLoadTransactionTest.cs
@@ -1,0 +1,104 @@
+using LmpClient.VesselUtilities;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace ServerTest
+{
+    [TestClass]
+    public class VesselLoadTransactionTest
+    {
+        [TestMethod]
+        public void HappyPath_CommitOnlyImmediatelyBeforeFinalSuccess()
+        {
+            var tx = new VesselLoadTransaction();
+
+            Assert.AreEqual(VesselLoadTransaction.Resolution.None, tx.Resolve(VesselLoadTransaction.Trigger.FinalSuccess));
+            Assert.AreEqual(VesselLoadTransaction.Phase.AwaitingLoad, tx.CurrentPhase);
+
+            Assert.AreEqual(VesselLoadTransaction.Resolution.Continue, tx.Resolve(VesselLoadTransaction.Trigger.LoadSucceeded));
+
+            Assert.AreEqual(VesselLoadTransaction.Phase.LoadSucceeded, tx.CurrentPhase);
+
+            Assert.AreEqual(VesselLoadTransaction.Resolution.Commit, tx.Resolve(VesselLoadTransaction.Trigger.FinalSuccess));
+            Assert.AreEqual(VesselLoadTransaction.Phase.Committed, tx.CurrentPhase);
+
+            Assert.AreEqual(VesselLoadTransaction.Resolution.None, tx.Resolve(VesselLoadTransaction.Trigger.PostLoadFailure));
+        }
+
+        [TestMethod]
+        public void ExplicitFailureAfterLoad_RoutesThroughCleanupNotBareRollback()
+        {
+            var tx = new VesselLoadTransaction();
+            tx.Resolve(VesselLoadTransaction.Trigger.LoadSucceeded);
+
+            Assert.AreEqual(VesselLoadTransaction.Resolution.RollbackAndCleanUp,
+                tx.Resolve(VesselLoadTransaction.Trigger.PostLoadFailure));
+            Assert.AreEqual(VesselLoadTransaction.Phase.Failed, tx.CurrentPhase);
+        }
+
+        [TestMethod]
+        public void ExceptionDuringPostLoadProcessing_RoutesThroughCleanup()
+        {
+            var tx = new VesselLoadTransaction();
+            Assert.AreEqual(VesselLoadTransaction.Resolution.RollbackAndCleanUp,
+                tx.Resolve(VesselLoadTransaction.Trigger.PostLoadFailure));
+
+            var tx2 = new VesselLoadTransaction();
+            tx2.Resolve(VesselLoadTransaction.Trigger.LoadSucceeded);
+            Assert.AreEqual(VesselLoadTransaction.Resolution.RollbackAndCleanUp,
+                tx2.Resolve(VesselLoadTransaction.Trigger.PostLoadFailure));
+        }
+
+        [TestMethod]
+        public void LoadRefNull_RoutesThroughCleanup()
+        {
+            var tx = new VesselLoadTransaction();
+            Assert.AreEqual(VesselLoadTransaction.Resolution.RollbackAndCleanUp,
+                tx.Resolve(VesselLoadTransaction.Trigger.LoadRefNull));
+            Assert.AreEqual(VesselLoadTransaction.Phase.Failed, tx.CurrentPhase);
+
+            var tx2 = new VesselLoadTransaction();
+            tx2.Resolve(VesselLoadTransaction.Trigger.LoadSucceeded);
+            Assert.AreEqual(VesselLoadTransaction.Resolution.None, tx2.Resolve(VesselLoadTransaction.Trigger.LoadRefNull));
+        }
+
+        [TestMethod]
+        public void UnchangedEarlyOut_RollbackOnly_NoTeardown()
+        {
+            var tx = new VesselLoadTransaction();
+            Assert.AreEqual(VesselLoadTransaction.Resolution.RollbackOnly,
+                tx.Resolve(VesselLoadTransaction.Trigger.UnchangedEarlyOut));
+            Assert.AreEqual(VesselLoadTransaction.Phase.Failed, tx.CurrentPhase);
+        }
+
+        [TestMethod]
+        public void ValidationFailure_RollbackOnly_NoTeardown()
+        {
+            var tx = new VesselLoadTransaction();
+            Assert.AreEqual(VesselLoadTransaction.Resolution.RollbackOnly,
+                tx.Resolve(VesselLoadTransaction.Trigger.ValidationFailed));
+            Assert.AreEqual(VesselLoadTransaction.Phase.Failed, tx.CurrentPhase);
+        }
+
+        [TestMethod]
+        public void ProtoSwapResolution_SwapResolveAndTerminal()
+        {
+            var tx = new VesselLoadTransaction();
+            Assert.AreEqual(VesselLoadTransaction.Resolution.SwapResolve,
+                tx.Resolve(VesselLoadTransaction.Trigger.ProtoSwapResolved));
+            Assert.AreEqual(VesselLoadTransaction.Phase.Committed, tx.CurrentPhase);
+
+            Assert.AreEqual(VesselLoadTransaction.Resolution.None, tx.Resolve(VesselLoadTransaction.Trigger.PostLoadFailure));
+            Assert.AreEqual(VesselLoadTransaction.Resolution.None, tx.Resolve(VesselLoadTransaction.Trigger.FinalSuccess));
+        }
+
+        [TestMethod]
+        public void EarlyOutAfterLoadSucceeded_IsDriverBug_Refused()
+        {
+            var tx = new VesselLoadTransaction();
+            tx.Resolve(VesselLoadTransaction.Trigger.LoadSucceeded);
+            Assert.AreEqual(VesselLoadTransaction.Resolution.None,
+                tx.Resolve(VesselLoadTransaction.Trigger.UnchangedEarlyOut));
+            Assert.AreEqual(VesselLoadTransaction.Phase.LoadSucceeded, tx.CurrentPhase);
+        }
+    }
+}


### PR DESCRIPTION
> **AI-assisted contribution note**
>
> Most of the implementation in this PR was produced with AI assistance rather than written by me directly.
>
> I reproduced the original bug, worked through the investigation, reviewed the resulting diff, and iterated on it through multiple rounds of code review and testing. I also tested the final patch extensively in-game.
>
> I understand the problem being fixed and the intended behavior of the changes, but I do not claim to fully understand or be able to defend every implementation detail. Please review the implementation accordingly. I can provide reproduction steps, logs, save/server state, and test requested changes against the original bug.

# The annoying bug

I was running into a Breaking Ground deployed-science synchronization problem in LMP.

Deployed science worked correctly when initially placed, but its deployment-derived bonuses could be lost after synchronization or reconnect.

For example:

- an experiment deployed by a Scientist could initially have the expected deployment bonus, but later fall back to the base science rate;
- a solar panel deployed by an Engineer could initially produce its boosted power output, but later lose it;
- the ground-science controller could report stale or incomplete experiment/power state.

Picking up and redeploying an affected part fixed it temporarily, until the bad state was synchronized again.

## Reproduction

The original problem could be reproduced with a Breaking Ground deployed-science setup roughly like this:

1. Deploy a ground-science controller and experiment using a Scientist, so the experiment receives a deployment bonus.
2. Deploy the required power source using an Engineer.
3. Verify that the experiment and solar panel initially show the expected boosted values.
4. Let LMP synchronize the vessels/scenario.
5. Disconnect and reconnect to the server, or restart KSP and connect again.
6. Inspect the deployed experiment, power source and controller.

Before this patch, on the affected setup I could end up with the experiment falling back to its base deployment value and/or the deployed solar output being lost.

The incorrect state could then become part of the server-side `DeployedScience` state, making it persist across subsequent reconnects.

The investigation showed that this was not one isolated assignment but a combination of several lifecycle/order problems around deployed vessels, `persistentId` ownership and the `DeployedScience` scenario.

With the final patch applied, I can no longer reproduce the original deployed-science state loss using this flow.

# Fixes included in this PR

## 1. Defer transient deployed-part vessel snapshots

Breaking Ground parts pass through a transient deployment state where the proto snapshot is not yet suitable to become authoritative state.

If an outgoing vessel proto contains a ground module where `beingDeployed` is still true while `deployedOnGround` or `isEnabled` has not settled yet, LMP now defers that send.

Once deployment has settled, the vessel is serialized again from a fresh snapshot and synchronization continues normally.

This prevents a mid-deployment vessel definition from becoming canonical on the server.

## 2. Preserve `persistentId` ownership transactionally during vessel replacement

Incoming vessel replacement can interact badly with KSP's global persistent-part-ID registries.

The patch now treats temporary registry changes as a transaction:

- stale owners of the incoming wire `persistentId` values are evicted before construction/load;
- genuine foreign owners are preserved so stock collision handling can still do its job;
- removed registrations remain recoverable until the vessel replacement has completely succeeded;
- the transaction is committed only after final successful load/swap;
- validation, construction and post-load failures roll it back;
- rollback only restores owners that are still genuinely present in the live vessel set;
- registrations created for a failed incoming vessel are cleaned up.

This also avoids treating a replacement vessel with a reused vessel GUID as if it were the same object as the old owner.

## 3. Apply `DeployedScience` only after the initial vessel sync is complete

The stock `DeployedScience` scenario can be loaded before all corresponding deployed-science vessels exist locally.

When that happens, stock may interpret legitimate controller/experiment entries as missing.

The patch therefore defers authoritative `DeployedScience` scenario application until initial vessel synchronization is complete.

A readiness gate compares the membership declared by the incoming scenario with the deployed-science parts actually present in the live vessel set.

Outgoing `DeployedScience` synchronization remains blocked until the authoritative scenario has been successfully applied.

## 4. Relink already-loaded runtime modules after authoritative scenario load

By the time the deferred scenario is applied, some deployed-science `PartModule` instances already exist and may still contain stale/default runtime state.

After authoritative scenario application, the patch reconciles those live modules with the scenario:

- stale `scienceClusterData` caches are invalidated;
- stock cluster power/UI notifications are refreshed;
- `ScienceModifierRate`, `ScienceLimit` and `ScienceValue` are restored from the authoritative scenario into the corresponding live experiment modules;
- persisted solar power inputs are restored;
- `ActualPowerUnitsProduced` is recomputed using stock-equivalent line-of-sight and timewarp semantics.

The relinker does not overwrite accumulated science progress fields.

## 5. Recover deployed-science parts that missed live registration

There is also a lifecycle case where a deployed-science vessel exists correctly in the live game but never becomes registered in the stock deployed-science cluster dictionary.

A periodic 2-second sweep checks for these missing live registrations and replays the stock registration path.

The operation is idempotent.

The sweep reads stock's private `beingDeployed` field through reflection. If the field cannot be resolved, it fails closed and treats the part as still deploying rather than risking registration of transient state.

# Safety / scope

- No automatic deletion or migration of historical/stale clusters.
- Runtime relinking does not overwrite accumulated science progress fields.
- Genuine foreign `persistentId` owners are preserved.
- Failed vessel replacements restore only still-valid previous owners.
- Live deployed-science registration is idempotent.
- Uncertain deployment state fails closed rather than being synchronized.

# Validation

Automated validation:

- all five commits build independently;
- final Release build: **0 errors**;
- tests: **82/82 passed**;
- `git diff --check`: clean;
- replaying the five patches with `git am` onto a fresh `master` reproduces the expected final source tree;

In-game regression testing included:

- cold KSP start + server connect;
- warm LMP disconnect/reconnect;
- repeated reconnects;
- multiple scenario synchronization cycles;
- Scientist deployment bonus preservation;
- Engineer deployed-solar output preservation;
- server-side `DeployedScience` state preservation;
- normal vessel loading with no observed regression.