### PR TITLE
Rework command input system always show input at bottom

### DIFF
--- a/LmpCommon/BaseLogger.cs
+++ b/LmpCommon/BaseLogger.cs
@@ -8,6 +8,11 @@ namespace LmpCommon
         protected virtual LogLevels LogLevel => LogLevels.Debug;
         protected virtual bool UseUtcTime => false;
 
+        protected virtual void BeforePrint(string line)
+        {
+            //Implement your own before logging code
+        }
+
         protected virtual void AfterPrint(string line)
         {
             //Implement your own after logging code
@@ -20,6 +25,7 @@ namespace LmpCommon
             if (level <= LogLevel)
             {
                 var output = UseUtcTime ? $"[{DateTime.UtcNow:HH:mm:ss}][{type}]: {message}" : $"[{DateTime.Now:HH:mm:ss}][{type}]: {message}";
+                BeforePrint(output);
                 Console.WriteLine(output);
                 AfterPrint(output);
             }

--- a/Server/Command/CommandHandler.cs
+++ b/Server/Command/CommandHandler.cs
@@ -41,31 +41,60 @@ namespace Server.Command
         /// <summary>
         /// We receive the console inputs with a pipe
         /// </summary>
+        /// 
+        private static string InputCommand = "";
+
+        public static void NewLineifInput() {
+            if (InputCommand != "") {
+                Console.Write('\n');
+            }
+        }
+
+        public static void RedrawInput()
+        {
+            Console.ResetColor();
+            Console.Write(InputCommand);
+        }
+
         public static async Task ThreadMainAsync()
         {
             try
             {
                 while (ServerContext.ServerRunning)
                 {
-                    var input = Console.ReadLine();
-                    if (input == null)
+                    var input = Console.ReadKey();
+
+                    while (input.Key != ConsoleKey.Enter) {
+                        if (input.Key == ConsoleKey.Backspace)  {
+                            if (InputCommand.Length > 0) {
+                                InputCommand = InputCommand.Remove(InputCommand.Length - 1);
+                                Console.Write("\b \b"); // goes back one step, prints empty space, goes back to empty space, illusion of removing the letter
+                            }
+                        } else {
+                            InputCommand += input.KeyChar;
+                        }
+
+                        input = Console.ReadKey();
+                    }
+
+                    if (InputCommand == null)
                     {
                         LunaLog.Normal("End of stdin, stopping command listener");
                         break;
                     }
-                    if (!string.IsNullOrEmpty(input))
+                    if (!string.IsNullOrEmpty(InputCommand))
                     {
-                        LunaLog.Normal($"Command input: {input}");
-                        if (!string.IsNullOrEmpty(input))
+                        var InputCommandCopy = new string(InputCommand); // Copy the command and reset it to avoid CommandHandlers logs to reprint the InputCommand
+                        InputCommand = "";
+
+                        LunaLog.Normal($"Command input: {InputCommandCopy}");
+                        if (InputCommandCopy.StartsWith("/"))
                         {
-                            if (input.StartsWith("/"))
-                            {
-                                HandleServerInput(input.Substring(1));
-                            }
-                            else
-                            {
-                                Commands["say"].Func(input);
-                            }
+                            HandleServerInput(InputCommandCopy.Substring(1));
+                        }
+                        else
+                        {
+                            Commands["say"].Func(InputCommandCopy);
                         }
                     }
 

--- a/Server/Log/LunaLog.cs
+++ b/Server/Log/LunaLog.cs
@@ -6,6 +6,7 @@ using Server.Settings.Structures;
 using Server.System;
 using System;
 using System.IO;
+using Server.Command;
 
 namespace Server.Log
 {
@@ -69,9 +70,19 @@ namespace Server.Log
         protected override LogLevels LogLevel => LogSettings.SettingsStore.LogLevel;
         protected override bool UseUtcTime => true;
 
+        protected override void BeforePrint(string line)
+        {
+            base.BeforePrint(line);
+
+            CommandHandler.NewLineifInput();
+        }
+
+
         protected override void AfterPrint(string line)
         {
             base.AfterPrint(line);
+
+            CommandHandler.RedrawInput();
 
             lock (WriteLock)
             {


### PR DESCRIPTION
<!-- Thank you for contributing to LMP!

If you are adding a dedicated server, please read https://github.com/LunaMultiplayer/LunaMultiplayer/wiki/Dedicated-server first,
especially:
* Your server doesn't need to be listed as "dedicated server" to show up in the server browser.
* Dedicated servers should have either a static IP address or working DynDNS
* Port forwarding should be set up statically, or at least UPnP needs to work reliably
* Dedicated servers should not be password protected
* Dedicated servers need to be available 24/7

Please confirm that you have read and verified all of the above.
-->
### Fixes included in this PR:
Fixes #701 

### Changes proposed in this PR:
Rework input system to use a custom system that keeps track of input itself instead of waiting for full line.
Makes log function redraw input after writing log text.  

<img width="559" height="202" alt="image" src="https://github.com/user-attachments/assets/62b117d8-3851-4fb5-afa1-c37cc8ef6eea" />
