### PR TITLE
feat: add time offset display during warping

### DIFF
--- a/LmpClient/Systems/Warp/WarpMessageHandler.cs
+++ b/LmpClient/Systems/Warp/WarpMessageHandler.cs
@@ -64,6 +64,13 @@ namespace LmpClient.Systems.Warp
                         System.ClientSubspaceList[data.PlayerName] = data.Subspace;
                     }
                     break;
+                case WarpMessageType.WarpingTime:
+                    {
+                        var data = (WarpingTimeMsgData)msgData;
+                        if (data.PlayerName != SettingsSystem.CurrentSettings.PlayerName && !System.CurrentlyWarping)
+                            System.WarpingSubspaceTime = data.ServerTimeDifference;
+                    }
+                    break;
                 default:
                     {
                         LunaLog.LogError($"[LMP]: Unhandled WARP_MESSAGE type: {msgData.WarpMessageType}");

--- a/LmpClient/Systems/Warp/WarpMessageSender.cs
+++ b/LmpClient/Systems/Warp/WarpMessageSender.cs
@@ -45,5 +45,18 @@ namespace LmpClient.Systems.Warp
 
             SendMessage(msgData);
         }
+
+        /// <summary>
+        /// Sends our current time difference against the server clock so other players can see
+        /// how far ahead/behind we are while we are warping
+        /// </summary>
+        public void SendWarpingTimeMsg(double serverTimeDifference)
+        {
+            var msgData = NetworkMain.CliMsgFactory.CreateNewMessageData<WarpingTimeMsgData>();
+            msgData.PlayerName = SettingsSystem.CurrentSettings.PlayerName;
+            msgData.ServerTimeDifference = serverTimeDifference;
+
+            SendMessage(msgData);
+        }
     }
 }

--- a/LmpClient/Systems/Warp/WarpSystem.cs
+++ b/LmpClient/Systems/Warp/WarpSystem.cs
@@ -56,6 +56,7 @@ namespace LmpClient.Systems.Warp
 
         public ConcurrentDictionary<string, int> ClientSubspaceList { get; } = new ConcurrentDictionary<string, int>();
         public ConcurrentDictionary<int, double> Subspaces { get; } = new ConcurrentDictionary<int, double>();
+        public double WarpingSubspaceTime { get; set; }
         public int LatestSubspace => Subspaces.Any() ? Subspaces.OrderByDescending(s => s.Value).First().Key : 0;
         private ScreenMessage WarpMessage { get; set; }
         private WarpEvents WarpEvents { get; } = new WarpEvents();
@@ -80,6 +81,7 @@ namespace LmpClient.Systems.Warp
             GameEvents.onLevelWasLoadedGUIReady.Remove(WarpEvents.OnSceneChanged);
             ClientSubspaceList.Clear();
             Subspaces.Clear();
+            WarpingSubspaceTime = 0;
             SubspaceEntries.Clear();
             _currentSubspace = int.MinValue;
             SkipSubspaceProcess = false;
@@ -97,6 +99,7 @@ namespace LmpClient.Systems.Warp
                 SetupRoutine(new RoutineDefinition(100, RoutineExecution.Update, CheckWarpStopped));
                 SetupRoutine(new RoutineDefinition(1000, RoutineExecution.Update, WarpIfSpectatingToController));
                 SetupRoutine(new RoutineDefinition(5000, RoutineExecution.Update, CheckStuckAtWarp));
+                SetupRoutine(new RoutineDefinition(1000, RoutineExecution.Update, SendWarpingTime));
             }
         }
 
@@ -146,6 +149,18 @@ namespace LmpClient.Systems.Warp
                 WarpEvent.onTimeWarpStopped.Fire();
                 RequestNewSubspace();
             }
+        }
+
+        /// <summary>
+        /// While warping, keep the warping subspace time updated with our own time and broadcast it
+        /// so other players can see our relative time in the status window
+        /// </summary>
+        private void SendWarpingTime()
+        {
+            if (!CurrentlyWarping) return;
+
+            WarpingSubspaceTime = TimeSyncSystem.UniversalTime - TimeSyncSystem.ServerClockSec;
+            MessageSender.SendWarpingTimeMsg(WarpingSubspaceTime);
         }
 
         #endregion
@@ -247,6 +262,15 @@ namespace LmpClient.Systems.Warp
         /// </summary>
         public double GetSubspaceTime(int subspace)
         {
+            if (subspace == -1)
+            {
+                var warpingResult = TimeSyncSystem.ServerClockSec + WarpingSubspaceTime;
+                if (double.IsNaN(warpingResult) || double.IsInfinity(warpingResult) || warpingResult < 0)
+                    return 0d;
+
+                return warpingResult;
+            }
+
             if (!Subspaces.ContainsKey(subspace)) return 0d;
 
             var result = TimeSyncSystem.ServerClockSec + Subspaces[subspace];

--- a/LmpClient/Windows/Status/StatusDrawer.cs
+++ b/LmpClient/Windows/Status/StatusDrawer.cs
@@ -77,6 +77,8 @@ namespace LmpClient.Windows.Status
                 GUILayout.BeginHorizontal(GUILayout.ExpandWidth(true));
                 if (SubspaceDisplay[i].SubspaceId == -1)
                 {
+                    GUILayout.Label(StatusTexts.GetTimeLabel(SubspaceDisplay[i]));
+                    GUILayout.FlexibleSpace();
                     GUILayout.Label(StatusTexts.WarpingLabelTxt, BoldRedLabelStyle);
                 }
                 else

--- a/LmpCommon/Message/Client/WarpCliMsg.cs
+++ b/LmpCommon/Message/Client/WarpCliMsg.cs
@@ -21,7 +21,8 @@ namespace LmpCommon.Message.Client
         {
             [(ushort)WarpMessageType.SubspacesRequest] = typeof(WarpSubspacesRequestMsgData),
             [(ushort)WarpMessageType.NewSubspace] = typeof(WarpNewSubspaceMsgData),
-            [(ushort)WarpMessageType.ChangeSubspace] = typeof(WarpChangeSubspaceMsgData)
+            [(ushort)WarpMessageType.ChangeSubspace] = typeof(WarpChangeSubspaceMsgData),
+            [(ushort)WarpMessageType.WarpingTime] = typeof(WarpingTimeMsgData)
         };
 
         public override ClientMessageType MessageType => ClientMessageType.Warp;

--- a/LmpCommon/Message/Data/Warp/WarpingTimeMsgData.cs
+++ b/LmpCommon/Message/Data/Warp/WarpingTimeMsgData.cs
@@ -1,0 +1,39 @@
+using Lidgren.Network;
+using LmpCommon.Message.Base;
+using LmpCommon.Message.Types;
+
+namespace LmpCommon.Message.Data.Warp
+{
+    public class WarpingTimeMsgData : WarpBaseMsgData
+    {
+        /// <inheritdoc />
+        internal WarpingTimeMsgData() { }
+        public override WarpMessageType WarpMessageType => WarpMessageType.WarpingTime;
+
+        public string PlayerName;
+        public double ServerTimeDifference;
+
+        public override string ClassName { get; } = nameof(WarpingTimeMsgData);
+
+        internal override void InternalSerialize(NetOutgoingMessage lidgrenMsg)
+        {
+            base.InternalSerialize(lidgrenMsg);
+
+            lidgrenMsg.Write(PlayerName);
+            lidgrenMsg.Write(ServerTimeDifference);
+        }
+
+        internal override void InternalDeserialize(NetIncomingMessage lidgrenMsg)
+        {
+            base.InternalDeserialize(lidgrenMsg);
+
+            PlayerName = lidgrenMsg.ReadString();
+            ServerTimeDifference = lidgrenMsg.ReadDouble();
+        }
+
+        internal override int InternalGetMessageSize()
+        {
+            return base.InternalGetMessageSize() + PlayerName.GetByteCount() + sizeof(double);
+        }
+    }
+}

--- a/LmpCommon/Message/Server/WarpSrvMsg.cs
+++ b/LmpCommon/Message/Server/WarpSrvMsg.cs
@@ -21,7 +21,8 @@ namespace LmpCommon.Message.Server
         {
             [(ushort)WarpMessageType.SubspacesReply] = typeof(WarpSubspacesReplyMsgData),
             [(ushort)WarpMessageType.NewSubspace] = typeof(WarpNewSubspaceMsgData),
-            [(ushort)WarpMessageType.ChangeSubspace] = typeof(WarpChangeSubspaceMsgData)
+            [(ushort)WarpMessageType.ChangeSubspace] = typeof(WarpChangeSubspaceMsgData),
+            [(ushort)WarpMessageType.WarpingTime] = typeof(WarpingTimeMsgData)
         };
 
         public override ServerMessageType MessageType => ServerMessageType.Warp;

--- a/LmpCommon/Message/Types/WarpMessageType.cs
+++ b/LmpCommon/Message/Types/WarpMessageType.cs
@@ -5,6 +5,7 @@
         SubspacesRequest = 1,
         SubspacesReply = 2,
         NewSubspace = 3,
-        ChangeSubspace = 4
+        ChangeSubspace = 4,
+        WarpingTime = 5
     }
 }

--- a/Server/Message/WarpControlMsgReader.cs
+++ b/Server/Message/WarpControlMsgReader.cs
@@ -23,6 +23,9 @@ namespace Server.Message
                 case WarpMessageType.ChangeSubspace:
                     WarpReceiver.HandleChangeSubspace(client, (WarpChangeSubspaceMsgData)messageData);
                     break;
+                case WarpMessageType.WarpingTime:
+                    WarpReceiver.HandleWarpingTime(client, (WarpingTimeMsgData)messageData);
+                    break;
                 case WarpMessageType.SubspacesRequest:
                     WarpReceiver.HandleSubspaceRequest(client);
                     //We don't use this message anymore so we can recycle it

--- a/Server/System/WarpSystemReceiver.cs
+++ b/Server/System/WarpSystemReceiver.cs
@@ -73,6 +73,17 @@ namespace Server.System
             }
         }
 
+        public void HandleWarpingTime(ClientStructure client, WarpingTimeMsgData message)
+        {
+            if (message.PlayerName != client.PlayerName) return;
+
+            var msgData = ServerContext.ServerMessageFactory.CreateNewMessageData<WarpingTimeMsgData>();
+            msgData.PlayerName = message.PlayerName;
+            msgData.ServerTimeDifference = message.ServerTimeDifference;
+
+            MessageQueuer.RelayMessage<WarpSrvMsg>(client, msgData);
+        }
+
         public void HandleSubspaceRequest(ClientStructure client)
         {
             lock (CreateSubspaceLock)


### PR DESCRIPTION
<!-- Thank you for contributing to LMP!

If you are adding a dedicated server, please read https://github.com/LunaMultiplayer/LunaMultiplayer/wiki/Dedicated-server first,
especially:
* Your server doesn't need to be listed as "dedicated server" to show up in the server browser.
* Dedicated servers should have either a static IP address or working DynDNS
* Port forwarding should be set up statically, or at least UPnP needs to work reliably
* Dedicated servers should not be password protected
* Dedicated servers need to be available 24/7

Please confirm that you have read and verified all of the above.
-->
### Fixes included in this PR:

### Changes proposed in this PR:

When warping, players can still see how much time behind/ahead is given player, no need to stop warping to know that.